### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/beamer.yml
+++ b/.github/workflows/beamer.yml
@@ -53,8 +53,8 @@ jobs:
           release_notes = release_notes+release_notes2
       
           
-          print(f"::set-output name=tag_name::{tag_name}")
-          print(f"::set-output name=release_notes::{release_notes}")
+          print(f"tag_name={tag_name}" >> $GITHUB_OUTPUT)
+          print(f"release_notes={release_notes}" >> $GITHUB_OUTPUT)
           EOF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beamerAndDiscord.yml
+++ b/.github/workflows/beamerAndDiscord.yml
@@ -52,8 +52,8 @@ jobs:
           release_notes = release_notes+release_notes2
       
           
-          print(f"::set-output name=tag_name::{tag_name}")
-          print(f"::set-output name=release_notes::{release_notes}")
+          print(f"tag_name={tag_name}" >> $GITHUB_OUTPUT)
+          print(f"release_notes={release_notes}" >> $GITHUB_OUTPUT)
           EOF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -115,8 +115,8 @@ jobs:
               # Remove the last line from the description
               description_lines = description_lines[:-1]
               description = '\n'.join(description_lines) 
-          print(f"::set-output name=tag::{tag}")
-          print(f"::set-output name=description::{json.dumps(description)}")
+          print(f"tag={tag}" >> $GITHUB_OUTPUT)
+          print(f"description={json.dumps(description)}" >> $GITHUB_OUTPUT)
           EOF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -171,8 +171,8 @@ jobs:
 
           print("slack_message_body", slack_message_body)
           
-          print(f"::set-output name=tag_name::{tag_name}")
-          print(f"::set-output name=slack_message_body::{slack_message_body}")
+          print(f"tag_name={tag_name}" >> $GITHUB_OUTPUT)
+          print(f"slack_message_body={slack_message_body}" >> $GITHUB_OUTPUT)
           EOF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -68,19 +68,19 @@ jobs:
           # Build a docker container and push it to DockerHub 
           cd apps/dashboard
           docker buildx build --platform linux/arm64/v8,linux/amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY-dashboard:$IMAGE_TAG_1 -t $ECR_REGISTRY/$ECR_REPOSITORY-dashboard:$IMAGE_TAG_2 . --push
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY-dashboard:$IMAGE_TAG"   
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY-dashboard:$IMAGE_TAG" >> $GITHUB_OUTPUT   
           cd ../testing
           docker buildx build --platform linux/arm64/v8,linux/amd64 -t $ECR_REGISTRY/akto-api-testing:$IMAGE_TAG_1 -t $ECR_REGISTRY/akto-api-testing:$IMAGE_TAG_2 . --push
-          echo "::set-output name=image::$ECR_REGISTRY/akto-api-testing:$IMAGE_TAG"       
+          echo "image=$ECR_REGISTRY/akto-api-testing:$IMAGE_TAG" >> $GITHUB_OUTPUT       
           cd ../testing-cli
           docker buildx build --platform linux/arm64/v8,linux/amd64 -t $ECR_REGISTRY/akto-api-testing-cli:$IMAGE_TAG_1 -t $ECR_REGISTRY/akto-api-testing-cli:$IMAGE_TAG_2 . --push
-          echo "::set-output name=image::$ECR_REGISTRY/akto-api-testing-cli:$IMAGE_TAG"
+          echo "image=$ECR_REGISTRY/akto-api-testing-cli:$IMAGE_TAG" >> $GITHUB_OUTPUT
           cd ../billing
           docker buildx build --platform linux/arm64/v8,linux/amd64 -t $ECR_REGISTRY/akto-billing:$IMAGE_TAG_1 -t $ECR_REGISTRY/akto-billing:$IMAGE_TAG_2 . --push
-          echo "::set-output name=image::$ECR_REGISTRY/akto-billing:$IMAGE_TAG"
+          echo "image=$ECR_REGISTRY/akto-billing:$IMAGE_TAG" >> $GITHUB_OUTPUT
           cd ../internal
           docker buildx build --platform linux/arm64/v8,linux/amd64 -t $ECR_REGISTRY/akto-internal:$IMAGE_TAG_1 -t $ECR_REGISTRY/akto-internal:$IMAGE_TAG_2 . --push
-          echo "::set-output name=image::$ECR_REGISTRY/akto-internal:$IMAGE_TAG"
+          echo "image=$ECR_REGISTRY/akto-internal:$IMAGE_TAG" >> $GITHUB_OUTPUT
       - name: Push git tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


