### PR TITLE
Update OWASP API Security references

### DIFF
--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/AddUserId.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/AddUserId.yaml
@@ -20,7 +20,7 @@ info:
   references:
     - "https://www.akto.io/blog/bola-exploitation-using-unauthorized-uuid-on-api-endpoint"
     - "https://www.akto.io/blog/what-is-broken-object-level-authorization-bola"
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa1-broken-object-level-authorization.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa1-broken-object-level-authorization.md"
     - "https://cwe.mitre.org/data/definitions/284.html"
     - "https://cwe.mitre.org/data/definitions/285.html"
     - "https://cwe.mitre.org/data/definitions/639.html"

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/BOLAByChangingAuthToken.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/BOLAByChangingAuthToken.yaml
@@ -24,7 +24,7 @@ info:
   references:
     - "https://www.akto.io/blog/bola-exploitation-using-unauthorized-uuid-on-api-endpoint"
     - "https://www.akto.io/blog/what-is-broken-object-level-authorization-bola"
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa1-broken-object-level-authorization.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa1-broken-object-level-authorization.md"
     - "https://cwe.mitre.org/data/definitions/284.html"
     - "https://cwe.mitre.org/data/definitions/285.html"
     - "https://cwe.mitre.org/data/definitions/639.html"

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/ContentTypeHeaderMissing.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/ContentTypeHeaderMissing.yaml
@@ -22,7 +22,7 @@ info:
   references:
     - "https://www.akto.io/blog/bola-exploitation-using-unauthorized-uuid-on-api-endpoint"
     - "https://www.akto.io/blog/what-is-broken-object-level-authorization-bola"
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa1-broken-object-level-authorization.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa1-broken-object-level-authorization.md"
     - "https://cwe.mitre.org/data/definitions/284.html"
     - "https://cwe.mitre.org/data/definitions/285.html"
     - "https://cwe.mitre.org/data/definitions/639.html"

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/FetchSensitiveFilesViaSSRF.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/FetchSensitiveFilesViaSSRF.yaml
@@ -21,7 +21,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2023/en/src/0xa6-server-side-request-forgery.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa7-server-side-request-forgery.md"
     - "https://www.akto.io/blog/how-to-prevent-server-side-request-forgery-ssrf-as-a-developer"
     - "https://www.cobalt.io/blog/from-ssrf-to-port-scanner"
   cwe:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/HeadMethodTest.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/HeadMethodTest.yaml
@@ -29,7 +29,7 @@ info:
   references:
     - "https://www.akto.io/blog/bola-exploitation-using-unauthorized-uuid-on-api-endpoint"
     - "https://www.akto.io/blog/what-is-broken-object-level-authorization-bola"
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa1-broken-object-level-authorization.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa1-broken-object-level-authorization.md"
     - "https://cwe.mitre.org/data/definitions/284.html"
     - "https://cwe.mitre.org/data/definitions/285.html"
     - "https://cwe.mitre.org/data/definitions/639.html"

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentChangeAccount.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentChangeAccount.yaml
@@ -23,7 +23,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa6-mass-assignment.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md"
   cwe:
     - CWE-915
   cve:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentChangeAdmin.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentChangeAdmin.yaml
@@ -23,7 +23,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa6-mass-assignment.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md"
   cwe:
     - CWE-915
   cve:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentChangeRole.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentChangeRole.yaml
@@ -23,7 +23,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa6-mass-assignment.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md"
   cwe:
     - CWE-915
   cve:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentCreateAdminUser.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/MassAssignmentCreateAdminUser.yaml
@@ -23,7 +23,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa6-mass-assignment.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md"
   cwe:
     - CWE-915
   cve:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/NoAuth.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/NoAuth.yaml
@@ -20,7 +20,7 @@ info:
     - HackerOne top 10
   references:
     - "https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/"
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa2-broken-user-authentication.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa2-broken-authentication.md"
     - "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html"
     - "https://cwe.mitre.org/data/definitions/798.html"
   cwe:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/OldApiVersion.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/OldApiVersion.yaml
@@ -22,10 +22,10 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa9-improper-assets-management.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa9-improper-assets-management.md"
     - "https://www.akto.io/blog/bola-exploitation-using-unauthorized-uuid-on-api-endpoint"
     - "https://www.akto.io/blog/what-is-broken-object-level-authorization-bola"
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa1-broken-object-level-authorization.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa1-broken-object-level-authorization.md"
     - "https://cwe.mitre.org/data/definitions/284.html"
     - "https://cwe.mitre.org/data/definitions/285.html"
     - "https://cwe.mitre.org/data/definitions/639.html"

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/PageDos.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/PageDos.yaml
@@ -15,7 +15,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa4-lack-of-resources-and-rate-limiting.md#scenario-2"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa4-lack-of-resources-and-rate-limiting.md#scenario-2"
   cwe:
     - CWE-400
   cve:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/ParameterPollution.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/ParameterPollution.yaml
@@ -21,7 +21,7 @@ info:
     - "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution"
     - "https://www.madlab.it/slides/BHEU2011/whitepaper-bhEU2011.pdf"
     - "https://www.akto.io/blog/what-is-broken-object-level-authorization-bola"
-    - "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa1-broken-object-level-authorization.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa1-broken-object-level-authorization.md"
     - "https://cwe.mitre.org/data/definitions/284.html"
   cwe:
     - CWE-88

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/PortScanningViaSSRF.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/PortScanningViaSSRF.yaml
@@ -21,7 +21,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2023/en/src/0xa6-server-side-request-forgery.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa7-server-side-request-forgery.md"
     - "https://www.akto.io/blog/how-to-prevent-server-side-request-forgery-ssrf-as-a-developer"
     - "https://www.cobalt.io/blog/from-ssrf-to-port-scanner"
   cwe:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnAWSMetaEndpointAbusingEnclosedAlphanumerics.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnAWSMetaEndpointAbusingEnclosedAlphanumerics.yaml
@@ -21,7 +21,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2023/en/src/0xa6-server-side-request-forgery.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa7-server-side-request-forgery.md"
     - "https://www.akto.io/blog/how-to-prevent-server-side-request-forgery-ssrf-as-a-developer"
     - "https://github.com/cujanovic/SSRF-Testing/tree/master#abusing-enclosed-alphanumerics"
   cwe:

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnAwsMetaEndpoint.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnAwsMetaEndpoint.yaml
@@ -21,7 +21,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2023/en/src/0xa6-server-side-request-forgery.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa7-server-side-request-forgery.md"
     - "https://www.akto.io/blog/how-to-prevent-server-side-request-forgery-ssrf-as-a-developer"
   cwe:
     - CWE-918

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnCSVUpload.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnCSVUpload.yaml
@@ -21,7 +21,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2023/en/src/0xa6-server-side-request-forgery.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa7-server-side-request-forgery.md"
     - "https://www.akto.io/blog/how-to-prevent-server-side-request-forgery-ssrf-as-a-developer"
   cwe:
     - CWE-918

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnFiles.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnFiles.yaml
@@ -21,7 +21,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2023/en/src/0xa6-server-side-request-forgery.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa7-server-side-request-forgery.md"
     - "https://www.akto.io/blog/how-to-prevent-server-side-request-forgery-ssrf-as-a-developer"
   cwe:
     - CWE-918

--- a/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnImageUpload.yaml
+++ b/apps/dashboard/src/main/resources/inbuilt_test_yaml_files/SSRFOnImageUpload.yaml
@@ -21,7 +21,7 @@ info:
     - OWASP top 10
     - HackerOne top 10
   references:
-    - "https://github.com/OWASP/API-Security/blob/master/2023/en/src/0xa6-server-side-request-forgery.md"
+    - "https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa7-server-side-request-forgery.md"
     - "https://www.akto.io/blog/how-to-prevent-server-side-request-forgery-ssrf-as-a-developer"
   cwe:
     - CWE-918

--- a/apps/dashboard/src/test/java/com/akto/action/testing/TestSaveTestEditorAction.java
+++ b/apps/dashboard/src/test/java/com/akto/action/testing/TestSaveTestEditorAction.java
@@ -73,7 +73,7 @@ public class TestSaveTestEditorAction extends MongoBasedTest {
             "    - HackerOne top 10\n" +
             "  references:\n" +
             "    - \"https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/\"\n" +
-            "    - \"https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa2-broken-user-authentication.md\"\n" +
+            "    - \"https://github.com/OWASP/API-Security/blob/master/editions/2023/en/0xa2-broken-authentication.md\"\n" +
             "    - \"https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html\"\n" +
             "    - \"https://cwe.mitre.org/data/definitions/798.html\"\n" +
             "\n" +


### PR DESCRIPTION
The OWASP API Security Github repository has changes in its structure. This PR changes the references of OWASP API Security Github into the correct references. 