### PR TITLE
Add Severity Filter in run tests configuration

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/RunTestSuites.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/RunTestSuites.jsx
@@ -22,7 +22,7 @@ const owaspTop10List = {
 
 function RunTestSuites({ testRun, setTestRun, apiCollectionName, checkRemoveAll, handleRemoveAll, handleModifyConfig, activeFromTesting }) {
 
-    const [data, setData] = useState({ owaspTop10List: {}, testingMethods:{}, custom : {} });
+    const [data, setData] = useState({ owaspTop10List: {}, testingMethods:{}, custom : {}, severity: {} });
 
 
     async function fetchData() {
@@ -51,6 +51,19 @@ function RunTestSuites({ testRun, setTestRun, apiCollectionName, checkRemoveAll,
             return { name: val, tests };
         });
 
+        // Fetch Severity Test Suites
+        const severityTestSuites = ["Critical", "High", "Medium", "Low"].map((val) => {
+            const tests = [];
+            Object.keys(testRun?.tests || {}).forEach((category) => {
+                testRun.tests[category]?.forEach((test) => {
+                    if (test.severity === val.toUpperCase()) {
+                        tests.push(test.value);
+                    }
+                });
+            });
+            return { name: val, tests };
+        });
+
         // Fetch Custom Test Suite
         const fetchedTestSuite = await testingApi.fetchAllTestSuites();
         const fetchedData = fetchedTestSuite.map((testSuiteItem) => {
@@ -61,13 +74,15 @@ function RunTestSuites({ testRun, setTestRun, apiCollectionName, checkRemoveAll,
             if (
                 !func.deepArrayComparison(prev?.owaspTop10List?.testSuite||[],newOwaspTop10TestSuites) ||
                 !func.deepArrayComparison(prev?.testingMethods?.testSuite||[], newTestingMethodsTestSuites) ||
-                !func.deepArrayComparison(prev?.custom?.testSuite||[], fetchedData)
+                !func.deepArrayComparison(prev?.custom?.testSuite||[], fetchedData) ||
+                !func.deepArrayComparison(prev?.severity?.testSuite||[], severityTestSuites)
             ) {
                 return {
                     ...prev,
                     owaspTop10List: { rowName: "OWASP top 10", testSuite: newOwaspTop10TestSuites },
                     testingMethods: { rowName: "Testing Methods", testSuite: newTestingMethodsTestSuites },
-                    custom: { rowName: "Custom", testSuite: fetchedData }
+                    custom: { rowName: "Custom", testSuite: fetchedData },
+                    severity: { rowName: "Severity", testSuite: severityTestSuites }
                 };
             }
             return prev;


### PR DESCRIPTION
### Why
Users want to run tests based on severity only.

### What
Add severity filter in test configuration.

