### PR TITLE
fix sorting in fetchThreatActors

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/threat_detection/ThreatActorAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/threat_detection/ThreatActorAction.java
@@ -554,4 +554,11 @@ public class ThreatActorAction extends AbstractThreatDetectionAction {
     this.eventType = eventType;
   }
 
+  public Map<String, Integer> getSort() {
+    return sort;
+  }
+
+  public void setSort(Map<String, Integer> sort) {
+    this.sort = sort;
+  }
 }


### PR DESCRIPTION
Struts getter and setter are used to get the values from request payload, without these sort will sent null to BE.