### PR TITLE
Update scheduling logic for test runs to handle 'Now' option and adju…

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/transform.js
@@ -1227,7 +1227,7 @@ getMissingConfigs(testResults){
       sendMsTeamsAlert:testRun.sendMsTeamsAlert,
       recurringDaily: testRun.recurringDaily,
       continuousTesting: testRun.continuousTesting,
-      scheduleTimestamp: testRun.startTimestamp,
+      scheduleTimestamp: testRun?.hourlyLabel === 'Now' && ((testRun.startTimestamp - func.getStartOfTodayEpoch()) < 86400) ? 0 : testRun.startTimestamp,
       recurringWeekly: testRun.recurringWeekly,
       recurringMonthly: testRun.recurringMonthly
     }


### PR DESCRIPTION
…st timestamps accordingly