### PR TITLE
Remove proto to string parsing from threat client

### DIFF
--- a/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/ThreatActorService.java
+++ b/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/ThreatActorService.java
@@ -1,5 +1,6 @@
 package com.akto.threat.backend.service;
 
+import com.akto.dto.HttpResponseParams;
 import com.akto.proto.generated.threat_detection.service.dashboard_service.v1.DailyActorsCountResponse;
 import com.akto.proto.generated.threat_detection.service.dashboard_service.v1.FetchMaliciousEventsRequest;
 import com.akto.proto.generated.threat_detection.service.dashboard_service.v1.FetchMaliciousEventsResponse;
@@ -322,7 +323,7 @@ public class ThreatActorService {
         for (Document doc: respList) {
             maliciousPayloadsResponse.add(
                 FetchMaliciousEventsResponse.MaliciousPayloadsResponse.newBuilder().
-                setOrig((doc.getString("latestApiOrig"))).
+                setOrig(HttpResponseParams.getSampleStringFromProtoString(doc.getString("latestApiOrig"))).
                 setTs(doc.getLong("detectedAt")).build());
         }
     } else {
@@ -331,7 +332,7 @@ public class ThreatActorService {
         for (Document doc: respList) {
             maliciousPayloadsResponse.add(
                 FetchMaliciousEventsResponse.MaliciousPayloadsResponse.newBuilder().
-                setOrig((doc.getString("orig"))).
+                setOrig(HttpResponseParams.getSampleStringFromProtoString(doc.getString("orig"))).
                 setTs(doc.getLong("requestTime")).build());
         }
     }

--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
@@ -17,7 +17,6 @@ import com.akto.dto.type.URLMethods;
 import com.akto.hybrid_parsers.HttpCallParser;
 import com.akto.kafka.KafkaConfig;
 import com.akto.log.LoggerMaker;
-import com.akto.log.LoggerMaker.LogDb;
 import com.akto.proto.generated.threat_detection.message.malicious_event.event_type.v1.EventType;
 import com.akto.proto.generated.threat_detection.message.malicious_event.v1.MaliciousEventKafkaEnvelope;
 import com.akto.proto.generated.threat_detection.message.malicious_event.v1.MaliciousEventMessage;
@@ -25,7 +24,6 @@ import com.akto.proto.generated.threat_detection.message.sample_request.v1.Metad
 import com.akto.proto.generated.threat_detection.message.sample_request.v1.SampleMaliciousRequest;
 import com.akto.proto.generated.threat_detection.message.sample_request.v1.SampleRequestKafkaEnvelope;
 import com.akto.proto.http_response_param.v1.HttpResponseParam;
-import com.akto.proto.http_response_param.v1.StringList;
 import com.akto.rules.TestPlugin;
 import com.akto.test_editor.execution.VariableResolver;
 import com.akto.test_editor.filter.data_operands_impl.ValidationResult;
@@ -36,7 +34,6 @@ import com.akto.threat.detection.kafka.KafkaProtoProducer;
 import com.akto.threat.detection.smart_event_detector.window_based.WindowBasedThresholdNotifier;
 import com.akto.util.HttpRequestResponseUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.BasicDBObject;
 import com.akto.IPLookupClient;
 import com.akto.RawApiMetadataFactory;
 
@@ -326,13 +323,6 @@ public class MaliciousTrafficDetectorTask implements Task {
 
     Map<String, List<String>> reqHeaders = (Map) httpResponseParamProto.getRequestHeadersMap();
 
-    Map<String, String> reqHeadersStr = new HashMap<>();
-
-    for (Map.Entry<String, StringList> entry :
-      httpResponseParamProto.getRequestHeadersMap().entrySet()) {
-          reqHeadersStr.put(entry.getKey(), entry.getValue().getValuesList().get(0));
-    }
-
     HttpRequestParams requestParams =
         new HttpRequestParams(
             httpResponseParamProto.getMethod(),
@@ -352,52 +342,6 @@ public class MaliciousTrafficDetectorTask implements Task {
 
     HttpResponseParams.Source source = HttpResponseParams.Source.valueOf(sourceStr);
     Map<String, List<String>> respHeaders = (Map) httpResponseParamProto.getResponseHeadersMap();
-    Map<String, String> respHeadersStr = new HashMap<>();
-
-    for (Map.Entry<String, StringList> entry :
-      httpResponseParamProto.getResponseHeadersMap().entrySet()) {
-        respHeadersStr.put(entry.getKey(), entry.getValue().getValuesList().get(0));
-    }
-
-    String reqHeaderStr2 = "";
-    try {
-      reqHeaderStr2 = objectMapper.writeValueAsString(reqHeadersStr); 
-    } catch (Exception e) {
-      // TODO: handle exception
-    }
-
-    String respHeaderStr2 = "";
-    try {
-      respHeaderStr2 = objectMapper.writeValueAsString(respHeadersStr); 
-    } catch (Exception e) {
-      // TODO: handle exception
-    }
-
-
-    BasicDBObject origObj = new BasicDBObject();
-    origObj.put("method", httpResponseParamProto.getMethod());
-    origObj.put("requestPayload", httpResponseParamProto.getRequestPayload());
-    origObj.put("responsePayload", httpResponseParamProto.getResponsePayload());
-    origObj.put("ip", httpResponseParamProto.getIp());
-    origObj.put("destIp", httpResponseParamProto.getDestIp());
-    origObj.put("source", sourceStr);
-    origObj.put("type", httpResponseParamProto.getType());
-    origObj.put("akto_vxlan_id", httpResponseParamProto.getAktoVxlanId());
-    origObj.put("path", httpResponseParamProto.getPath());
-    origObj.put("requestHeaders", reqHeaderStr2);
-    origObj.put("responseHeaders", respHeaderStr2);
-    origObj.put("time", httpResponseParamProto.getTime());
-    origObj.put("akto_account_id", httpResponseParamProto.getAktoAccountId());
-    origObj.put("statusCode", httpResponseParamProto.getStatusCode());
-    origObj.put("status", httpResponseParamProto.getStatus());
-
-    String origStr = "";
-    try {
-      origStr = objectMapper.writeValueAsString(origObj);
-    } catch (Exception e) {
-      System.out.println("error constructing orig obj");
-    }
-
 
     return new HttpResponseParams(
         httpResponseParamProto.getType(),
@@ -410,7 +354,7 @@ public class MaliciousTrafficDetectorTask implements Task {
         httpResponseParamProto.getAktoAccountId(),
         httpResponseParamProto.getIsPending(),
         source,
-        origStr,
+        httpResponseParamProto.toString(),
         httpResponseParamProto.getIp(),
         httpResponseParamProto.getDestIp(),
         httpResponseParamProto.getDirection());

--- a/libs/dao/pom.xml
+++ b/libs/dao/pom.xml
@@ -182,6 +182,12 @@
             <artifactId>fastjson2</artifactId>
             <version>2.0.51</version>
         </dependency>
+        <dependency>
+            <groupId>com.akto.libs.protobuf</groupId>
+            <artifactId>protobuf</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/libs/dao/src/main/java/com/akto/dto/HttpResponseParams.java
+++ b/libs/dao/src/main/java/com/akto/dto/HttpResponseParams.java
@@ -2,6 +2,10 @@ package com.akto.dto;
 
 
 import com.akto.dao.context.Context;
+import com.akto.proto.http_response_param.v1.HttpResponseParam;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import com.google.protobuf.TextFormat;
 
 import java.util.*;
 
@@ -190,5 +194,60 @@ public class HttpResponseParams {
 
     public void setRequestParams(HttpRequestParams requestParams) {
         this.requestParams = requestParams;
+    }
+
+    public static String getSampleStringFromProtoString(String httpResponseParamProtoString){
+
+        String origStr = "";
+        HttpResponseParam.Builder httpBuilder = HttpResponseParam.newBuilder();
+        try {
+          TextFormat.getParser().merge(httpResponseParamProtoString, httpBuilder);
+        } catch (Exception e) {
+          System.out.println("error parsing httpresponse param proto string");
+          return origStr;
+        }
+        HttpResponseParam httpResponseParamProto = httpBuilder.build();
+
+        BasicDBObject origObj = new BasicDBObject();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String sourceStr = httpResponseParamProto.getSource();
+        if (sourceStr == null || sourceStr.isEmpty()) {
+          sourceStr = HttpResponseParams.Source.OTHER.name();
+        }
+        Map<String, List<String>> reqHeaders = (Map) httpResponseParamProto.getRequestHeadersMap();
+        Map<String, List<String>> respHeaders = (Map) httpResponseParamProto.getResponseHeadersMap();
+        String reqHeaderStr2 = "";
+        String respHeaderStr2 = "";
+
+        try {
+            reqHeaderStr2 = objectMapper.writeValueAsString(reqHeaders);
+            respHeaderStr2 = objectMapper.writeValueAsString(respHeaders);
+        } catch (Exception e) {
+            // TODO: handle exception
+        }
+
+        origObj.put("method", httpResponseParamProto.getMethod());
+        origObj.put("requestPayload", httpResponseParamProto.getRequestPayload());
+        origObj.put("responsePayload", httpResponseParamProto.getResponsePayload());
+        origObj.put("ip", httpResponseParamProto.getIp());
+        origObj.put("destIp", httpResponseParamProto.getDestIp());
+        origObj.put("source", sourceStr);
+        origObj.put("type", httpResponseParamProto.getType());
+        origObj.put("akto_vxlan_id", httpResponseParamProto.getAktoVxlanId());
+        origObj.put("path", httpResponseParamProto.getPath());
+        origObj.put("requestHeaders", reqHeaderStr2);
+        origObj.put("responseHeaders", respHeaderStr2);
+        origObj.put("time", httpResponseParamProto.getTime());
+        origObj.put("akto_account_id", httpResponseParamProto.getAktoAccountId());
+        origObj.put("statusCode", httpResponseParamProto.getStatusCode());
+        origObj.put("status", httpResponseParamProto.getStatus());
+
+        try {
+          origStr = objectMapper.writeValueAsString(origObj);
+        } catch (Exception e) {
+        }
+
+        return origStr;
     }
 }


### PR DESCRIPTION
### Why
- Throughput optimization of threat client consumer before customer launch

#### What
- Remove the proto to string conversion from threat client for each record.

#### How
- httpParamsRecord is directly dumped as toString instead of doing parsing at the client.
- Threat backend will convert this string to protoObject and handle the format required to show in FE for sample malicious requests.

#### Breaking Change
- Sample values for all the previous malicious events will break.

#### Test cases
- [ ] New malicious events dumped as proto.toStrings().
- [ ] /fetchAggregateMaliciousRequests API sample values are shown correctly.
- [ ] 