### PR TITLE
Use find for regex validation

### DIFF
--- a/libs/utils/src/main/java/com/akto/test_editor/Utils.java
+++ b/libs/utils/src/main/java/com/akto/test_editor/Utils.java
@@ -60,7 +60,7 @@ public class Utils {
 
     public static Boolean checkIfContainsMatch(String text, String keyword) {
         Pattern pattern = Pattern.compile(keyword);
-        return pattern.matcher(text).matches();
+        return pattern.matcher(text).find();
     }
 
     public static boolean deleteKeyFromPayload(Object obj, String parentKey, String queryKey) {


### PR DESCRIPTION
### Why
Regex validation needs to run on request params like header, body represented as a single string.
Using match requires that the entier request param string needs to fit the regex. 
