### PR TITLE
Threat API Optimizations

### DIFF
--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -8240,6 +8240,7 @@
         <action name="api/getActorsCountPerCounty"
             class="com.akto.action.threat_detection.ThreatActorAction"
             method="getActorsCountPerCounty">
+            <interceptor-ref name="json" />
             <interceptor-ref name="defaultStack" />
             <interceptor-ref name="usageInterceptor">
                 <param name="featureLabel">THREAT_DETECTION</param>
@@ -8259,7 +8260,9 @@
                 <param
                     name="includeProperties">^actionErrors.*</param>
             </result>
-            <result name="SUCCESS" type="json"> </result>
+            <result name="SUCCESS" type="json"> 
+                <param name="includeProperties">^actorsCountPerCountry.*</param>
+            </result>
             <result name="ERROR" type="json">
                 <param name="statusCode">422</param>
                 <param name="ignoreHierarchy">false</param>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatActorPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatActorPage.jsx
@@ -18,7 +18,7 @@ import { ThreatSummary } from "./components/ThreatSummary";
 import ThreatActivityTimeline from "./components/ThreatActivityTimeline";
 import React from "react";
 
-const ChartComponent = ({ mapData, loading, onSubCategoryClick, currDateRange }) => {
+const ChartComponent = ({ onSubCategoryClick, currDateRange }) => {
     return (
         <VerticalStack gap={4} columns={2}>
             <HorizontalGrid gap={4} columns={2}>
@@ -28,12 +28,12 @@ const ChartComponent = ({ mapData, loading, onSubCategoryClick, currDateRange })
                     endTimestamp={parseInt(currDateRange.period.until.getTime()/1000)}
                 />
                 <ThreatWorldMap
-                    data={mapData}
+                    startTimestamp={parseInt(currDateRange.period.since.getTime()/1000)}
+                    endTimestamp={parseInt(currDateRange.period.until.getTime()/1000)}
                     style={{
                         width: "100%",
                         marginRight: "auto",
                     }}
-                    loading={loading}
                     key={"threat-actor-world-map"}
                 />
             </HorizontalGrid>
@@ -44,9 +44,6 @@ const ChartComponent = ({ mapData, loading, onSubCategoryClick, currDateRange })
 const MemoizedChartComponent = React.memo(ChartComponent);
 
 function ThreatActorPage() {
-  const [mapData, setMapData] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [subCategoryCount, setSubCategoryCount] = useState([]);
   const [actorDetails, setActorDetails] = useState(null);
   const [showActorDetails, setShowActorDetails] = useState(false);
 
@@ -57,32 +54,6 @@ function ThreatActorPage() {
   );
 
   useEffect(() => {
-    const fetchActorsPerCountry = async () => {
-      setLoading(true);
-      const res = await api.getActorsCountPerCounty();
-      if (res?.actorsCountPerCountry) {
-        setMapData(
-          res.actorsCountPerCountry.map((x) => {
-            return {
-              code: x.country,
-              z: 100,
-              count: x.count,
-            };
-          })
-        );
-      }
-      setLoading(false);
-    };
-    const fetchThreatCategoryCount = async () => {
-      setLoading(true);
-      const res = await api.fetchThreatCategoryCount();
-      const finalObj = threatDetectionFunc.getGraphsData(res);
-      // setCategoryCount(finalObj.categoryCountRes);
-      setSubCategoryCount(finalObj.subCategoryCount);
-      setLoading(false);
-    };
-    fetchActorsPerCountry();
-    fetchThreatCategoryCount();
   }, []);
 
   const onSubCategoryClick = (subCategory) => {
@@ -96,16 +67,14 @@ function ThreatActorPage() {
 
   const components = [
     <ThreatSummary startTimestamp={parseInt(currDateRange.period.since.getTime()/1000)} endTimestamp={parseInt(currDateRange.period.until.getTime()/1000)} />,
-    <MemoizedChartComponent 
-      mapData={mapData}
-      loading={loading}
+    <MemoizedChartComponent
+    key={"threat-actor-chart-component"}
       onSubCategoryClick={onSubCategoryClick}
       currDateRange={currDateRange}
     />,
     <ThreatActorTable
       key={"threat-actor-data-table"}
       currDateRange={currDateRange}
-      loading={loading}
       handleRowClick={onRowClick}
     />,
     ...(showActorDetails ? [<ActorDetails actorDetails={actorDetails} setShowActorDetails={setShowActorDetails} />] : [])

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/api.js
@@ -64,11 +64,11 @@ const threatDetectionRequests = {
             }
         })
     },
-    getActorsCountPerCounty() {
+    getActorsCountPerCounty(startTs, endTs) {
         return request({
             url: '/api/getActorsCountPerCounty',
-            method: 'get',
-            data: {}
+            method: 'post',
+            data: {startTs, endTs}
         })
     },
     fetchThreatConfiguration() {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ThreatActorsTable.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ThreatActorsTable.jsx
@@ -161,7 +161,7 @@ function ThreatActorTable({ data, currDateRange, handleRowClick }) {
           ...x,
           actor: x.id ? (
             <Text variant="bodyMd" fontWeight="medium">
-              {x.id}
+              {x.id?.length > 50 ? `${x.id.slice(0, 50)}...` : x.id}
             </Text>
           ) : "-",
           latestIp: x.latestApiIp || "-",

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ThreatWorldMap.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ThreatWorldMap.jsx
@@ -1,16 +1,39 @@
-import { useEffect } from "react";
+import { use, useEffect, useState } from "react";
 import Highcharts from "highcharts/highmaps";
 import Exporting from "highcharts/modules/exporting";
 import ExportData from "highcharts/modules/export-data";
 import FullScreen from "highcharts/modules/full-screen";
 import InfoCard from "../../dashboard/new_components/InfoCard";
+import { Spinner } from "@shopify/polaris";
+import api from "../api";
+
 // Initialize modules
 Exporting(Highcharts);
 ExportData(Highcharts);
 FullScreen(Highcharts);
 
-function ThreatWorldMap({ data, style, loading }) {
-  useEffect(() => {
+function ThreatWorldMap({ startTimestamp, endTimestamp,  style}) {
+
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState(false);
+
+    const fetchActorsPerCountry = async () => {
+      // setLoading(true);
+      const res = await api.getActorsCountPerCounty(startTimestamp, endTimestamp);
+      if (res?.actorsCountPerCountry) {
+        setData(
+          res.actorsCountPerCountry.map((x) => {
+            return {
+              code: x.country,
+              z: 100,
+              count: x.count,
+            };
+          })
+        );
+      }
+      setLoading(false);
+    };
+
     const fetchMapData = async () => {
       const topology = await fetch(
         "https://code.highcharts.com/mapdata/custom/world.topo.json"
@@ -104,14 +127,28 @@ function ThreatWorldMap({ data, style, loading }) {
       });
     };
 
-    fetchMapData();
+  useEffect(() => {
+    if (data) {
+      fetchMapData();
+    }
   }, [data]);
 
-  return <InfoCard
-    title={"Threat Actor Map"}
-    titleToolTip={"Threat Actor Map"}
-    component={<div id="threat-world-map-container" style={style}></div>}
-  />;
+  useEffect(() => {
+    fetchActorsPerCountry();
+    fetchMapData();
+  }, [startTimestamp, endTimestamp]);
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <InfoCard
+      title={"Threat Actor Map"}
+      titleToolTip={"Threat Actor Map"}
+      component={<div id="threat-world-map-container" style={style}></div>}
+    />
+  );
 }
 
 export default ThreatWorldMap;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ThreatWorldMap.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ThreatWorldMap.jsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Highcharts from "highcharts/highmaps";
 import Exporting from "highcharts/modules/exporting";
 import ExportData from "highcharts/modules/export-data";

--- a/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/router/DashboardRouter.java
+++ b/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/router/DashboardRouter.java
@@ -120,12 +120,25 @@ public class DashboardRouter implements ARouter {
             });
 
         router
-            .get("/get_actors_count_per_country")
+            .post("/get_actors_count_per_country")
             .blockingHandler(ctx -> {
+                RequestBody reqBody = ctx.body();
+                ThreatActorByCountryRequest req = ProtoMessageUtils.<
+                    ThreatActorByCountryRequest
+                >toProtoMessage(
+                    ThreatActorByCountryRequest.class,
+                    reqBody.asString()
+                ).orElse(null);
+
+                if (req == null) {
+                    ctx.response().setStatusCode(400).end("Invalid request");
+                    return;
+                }
+
                 ProtoMessageUtils.toString(
                     threatActorService.getThreatActorByCountry(
                         ctx.get("accountId"),
-                        ThreatActorByCountryRequest.newBuilder().build()
+                        req 
                     )
                 ).ifPresent(s -> ctx.response().setStatusCode(200).end(s));
             });

--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/ThreatConfigurationEvaluator.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/ThreatConfigurationEvaluator.java
@@ -95,12 +95,11 @@ public class ThreatConfigurationEvaluator {
 
     public String getActorId(HttpResponseParams responseParam) {
         getThreatConfiguration();
-        String actor;
-        String sourceIp = SourceIPActorGenerator.instance.generate(responseParam).orElse("");
-        responseParam.setSourceIP(sourceIp);
+        String actor = SourceIPActorGenerator.instance.generate(responseParam).orElse("");
+        responseParam.setSourceIP(actor);
+        logger.debugAndAddToDbCount("Actor ID generated: " + actor + " for response: " + responseParam.getOriginalMsg().get());
 
         if (threatConfiguration == null) {
-            actor = sourceIp;
             return actor;
         }
 
@@ -116,18 +115,16 @@ public class ThreatConfigurationEvaluator {
                             .get(actorId.getKey().toLowerCase());
                     if (header != null && !header.isEmpty()) {
                         actor = header.get(0);
+                        return actor;
                     } else {
                         logger.warn("Defaulting to source IP as actor id, header not found: "
                                 + actorId.getKey());
-                        actor = sourceIp;
+                        return actor;
                     }
-                    break;
                 default:
-                    actor = sourceIp;
                     break;
             }
-            return actor;
         }
-        return sourceIp;
+        return actor;
     }
 }

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -49,6 +49,7 @@ public class LoggerMaker  {
     private final Class<?> aClass;
 
     private static String slackWebhookUrl;
+    private static int counter = 0;
 
     public static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private static final DataActor dataActor = DataActorFactory.fetchInstance();
@@ -345,6 +346,14 @@ public class LoggerMaker  {
     }
 
     public void debugAndAddToDb(String message) {
+        debugAndAddToDb(message, this.db);
+    }
+
+    public void debugAndAddToDbCount(String message) {
+        if(counter > 500){
+            return;
+        }
+        counter++;
         debugAndAddToDb(message, this.db);
     }
 

--- a/protobuf/threat_detection/service/dashboard_service/v1/service.proto
+++ b/protobuf/threat_detection/service/dashboard_service/v1/service.proto
@@ -141,6 +141,8 @@ message ListThreatApiResponse {
 }
 
 message ThreatActorByCountryRequest {
+  uint32 start_ts = 1;
+  uint32 end_ts = 2;
 }
 
 message ThreatActorByCountryResponse {


### PR DESCRIPTION

#### Issue 1
Actor id too long , stretches the table

<img width="1184" alt="Screenshot 2025-06-01 at 10 46 22 AM" src="https://github.com/user-attachments/assets/0ef40ba9-6869-4505-b295-a3d61a306b89" />


#### Issue 2
- fetchThreatCategroyCount API called unnecssarily on Threat Actors Page

#### Issue 3
- API getThreatActorsCountPerCountry now uses the time-range to filter results.
- Optimized the query takes 1 sec on 2 months on local. ( Guild database dump)

#### Note
- Indexes evaluated detected_at, (detected_at, country ) , (country, detected_at)
- As per executionStats only detectedAt is used, tested for 7 days and 2 months data.