### PR TITLE
Add inputs required for repo access from other platforms

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/agent_team/components/RepositoryInitializer.tsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/agent_team/components/RepositoryInitializer.tsx
@@ -200,7 +200,6 @@ function RepoSelector({ handleClickRepo, selectedConnection }) {
                 repoNameAzure: newRepoNameAzure,
                 privateToken: githubAccessToken
             }).then(async (res) => {
-                console.log("data from checkreporead: ", res);
                 if (res.success) {
                     setInvalidInput(false);
                     await handleClickRepo(newRepoName, project, null, githubAccessToken, newRepoNameAzure);
@@ -347,7 +346,6 @@ function RepositoryInitializer({ agentType }: { agentType: string }) {
                 }
                 : {};
         
-        console.log(data);
         if (Object.keys(data).length === 0) return;
         if(accessToken !== null) {
             data['accessToken'] = accessToken;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/agent_team/components/RepositoryInitializer.tsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/agent_team/components/RepositoryInitializer.tsx
@@ -23,27 +23,59 @@ const getProjectObj = (connection: string) => {
         case 'BIT_BUCKET':
             return {
                 "1": {
-                    label: "Team Name",
-                    placeholder: "Enter team name",
+                    label: "Workspace/Team Name",
+                    placeholder: "Enter WorkSpace/team name",
                 },
                 "2" : {
                     label: 'Repository Name',
                     placeholder: "Enter repository name",
                 }
             }
+        case 'AZURE_DEVOPS':
+            return {
+                "1": {
+                    label: "Organization Name",
+                    placeholder: "Enter organization name",
+                },
+                "2": {
+                    label: "Project name",
+                    placeholder: "Enter Project name",
+                },
+                "3": {
+                    label: "Repository name",
+                    placeholder: "Enter repository name",
+                }
+            }
+        case 'GITLAB':
+            return {
+                "1": {
+                    label: "Project ID",
+                    placeholder: "Enter project id",
+                }
+            }
     }   
 }
 
-async function checkRepoReadAccess({ platform, projectName, repoName, privateToken }): Promise<{ success: boolean; reason?: string }> {
+async function checkRepoReadAccess({ platform, projectName, repoName, repoNameAzure, privateToken }): Promise<{ success: boolean; reason?: string }> {
     try {
       let url = '';
       let headers = {};
   
       switch (platform.toLowerCase()) {
+        /**
+         * GitHub API
+         * URL Format: https://api.github.com/repos/{owner}/{repo}
+         * API Docs: https://docs.github.com/en/rest/repos/repos#get-a-repository
+        */
         case 'github':
           url = `https://api.github.com/repos/${projectName}/${repoName}`;
           headers = privateToken ? { Authorization: `Bearer ${privateToken}` } : {};
           break;
+        /**
+         * Bitbucket API
+         * URL Format: https://api.bitbucket.org/2.0/repositories/{workspace}/{repo_slug}
+         * API Docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-get
+        */
         case 'bit_bucket':
           url = `https://api.bitbucket.org/2.0/repositories/${projectName}/${repoName}`;
           headers = privateToken
@@ -52,7 +84,32 @@ async function checkRepoReadAccess({ platform, projectName, repoName, privateTok
               }
             : {};
           break;
-  
+        /**
+         * Azure DevOps API
+         * URL Format: https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repositoryName}?api-version=4.1
+         * API Docs: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/get?view=azure-devops-rest-4.1&tabs=HTTP
+        */
+        case 'azure_devops':
+            url = `https://dev.azure.com/${projectName}/${repoName}/_apis/git/repositories/${repoNameAzure}?api-version=4.1`;
+            headers = privateToken 
+              ? {
+                    Authorization: `Bearer ${privateToken}`,
+                }
+               : {}; 
+            break;
+        /**
+        * GitLab API
+       * URL Format: https://gitlab.com/api/v4/projects/{project_id}
+       * API Docs: https://docs.gitlab.com/api/projects/#get-a-single-project
+       */
+        case 'gitlab':
+            url = `https://gitlab.com/api/v4/projects/${projectName}`;
+            headers = privateToken
+              ? {
+                    'PRIVATE-TOKEN': `${privateToken}`,
+                }
+                : {};
+            break;
         default:
           throw new Error('Unsupported platform');
       }
@@ -61,6 +118,8 @@ async function checkRepoReadAccess({ platform, projectName, repoName, privateTok
   
       if (response.status === 200) {
         return { success: true };
+      } else if (response.status === 401 || response.status === 203) {
+        return { success: false, reason: `Pass correct Access Token`};
       } else if (response.status === 404 || response.status === 403) {
         return { success: false, reason: `Access denied or repository not found.` };
       } else {
@@ -74,8 +133,9 @@ async function checkRepoReadAccess({ platform, projectName, repoName, privateTok
   
 
 function RepoSelector({ handleClickRepo, selectedConnection }) {
-    const [newRepoName, setNewRepoName] = useState<string>('');
-    const [newProjectName, setNewProjectName] = useState<string>('');
+    const [newRepoName, setNewRepoName] = useState<string>('');   // organization_name, 
+    const [newProjectName, setNewProjectName] = useState<string>('');   // project_name,
+    const [newRepoNameAzure, setNewRepoNameAzure] = useState<string>('');   // repo_name
     const [githubAccessToken, setGithubAccessToken] = useState<string | null>(null);
     const [allRepos, setAllRepos] = useState<any[]>([]);
     const [manualType, setManualType] = useState<boolean>(selectedConnection !== 'GITHUB');
@@ -131,20 +191,24 @@ function RepoSelector({ handleClickRepo, selectedConnection }) {
 
     const handleAddRepository = async (projectName: string | null) => {
         const project = projectName || newProjectName;
-        if (newRepoName && project) {
+        if (newRepoName) {
             setLoading(true);
             await checkRepoReadAccess({
                 platform: selectedConnection.toLowerCase(),
                 projectName: newRepoName,
                 repoName: project,
+                repoNameAzure: newRepoNameAzure,
                 privateToken: githubAccessToken
             }).then(async (res) => {
+                console.log("data from checkreporead: ", res);
                 if (res.success) {
                     setInvalidInput(false);
-                    await handleClickRepo(newRepoName, project, null, githubAccessToken);
+                    await handleClickRepo(newRepoName, project, null, githubAccessToken, newRepoNameAzure);
                     setNewRepoName('');
                     setNewProjectName('');
+                    setNewRepoNameAzure('');
                     setGithubAccessToken('');
+                    func.setToast(true, false, "Repository added successfully");
                 } else {
                     setInvalidInput(true);
                     func.setToast(true, true, res.reason || "Error checking repository access");
@@ -158,6 +222,10 @@ function RepoSelector({ handleClickRepo, selectedConnection }) {
     };
 
     const projectObj = getProjectObj(selectedConnection);
+    
+
+    const isAzureDevops = (selectedConnection === 'AZURE_DEVOPS');
+    const isGitLab = (selectedConnection === 'GITLAB');
 
     return (
         <Box paddingInlineEnd={"2"} paddingInlineStart={"2"}>
@@ -185,7 +253,7 @@ function RepoSelector({ handleClickRepo, selectedConnection }) {
                                 error={invalidInput}
                             />
                         </Box>
-                        {manualType ? <Box width='200px'>
+                        {manualType && !isGitLab ? <Box width='200px'>
                             <TextField
                                 label={projectObj?.[2]?.label || "Repository Name"}
                                 autoComplete="off"
@@ -196,6 +264,19 @@ function RepoSelector({ handleClickRepo, selectedConnection }) {
                                 error={invalidInput}
                             />
                         </Box> : null}
+                        {isAzureDevops && (
+                            <Box width='200px'>
+                                <TextField
+                                    label={projectObj?.[3]?.label || "Azure Repository Name"}
+                                    autoComplete="off"
+                                    value={newRepoNameAzure}
+                                    onChange={(value) => setNewRepoNameAzure(value)}
+                                    placeholder={projectObj?.[3]?.placeholder || "Enter Azure Repository Name"}
+                                    requiredIndicator
+                                    error={invalidInput}
+                                />
+                            </Box>
+                        )}
                         <Box width='200px'>
                             <TextField
                                 label="Access Token"
@@ -203,12 +284,13 @@ function RepoSelector({ handleClickRepo, selectedConnection }) {
                                 value={githubAccessToken || ""}
                                 onChange={(value) => setGithubAccessToken(value)}
                                 placeholder="Enter access token in case of private repo"
+                                requiredIndicator={selectedConnection !== 'GITHUB'}
                                 error={invalidInput}
                             />
                         </Box>
                     </HorizontalStack>
                         <Box width='200px' paddingBlockStart={"6"} paddingInlineStart={"4"}>
-                            <Button loading={loading} onClick={() => manualType ? handleAddRepository(null) : getAllReposForProject(githubAccessToken, newRepoName)} disabled={manualType ? (!newRepoName || !newProjectName): (!newRepoName)} primary>
+                            <Button loading={loading} onClick={() => manualType ? handleAddRepository(null) : getAllReposForProject(githubAccessToken, newRepoName)} disabled={manualType ? (!newRepoName || (!isGitLab && !newProjectName) || (isAzureDevops && !newRepoNameAzure) || !githubAccessToken): (!newRepoName)} primary>
                                 {manualType ? "Add Repository" : "Add Project"}
                             </Button>
                         </Box>
@@ -250,20 +332,22 @@ function RepositoryInitializer({ agentType }: { agentType: string }) {
         }
     }
 
-    const handleClickRepo = async (repo: string, project: string, localString: string | null, accessToken: string|null) => {
+    const handleClickRepo = async (repo: string, project: string, localString: string | null, accessToken: string|null, repoNameAzure: string|null) => {
         setSelectedProject(project);
         setSelectedRepo(repo);
 
         const data = localString !== null
             ? { projectDir: localString }
-            : selectedConnection && repo && project
+            : selectedConnection && repo 
                 ? {
                     sourceCodeType: selectedConnection,
                     repository: repo,
-                    project: project
+                    ...(project && {project: project}),
+                    ...(repoNameAzure && { repositoryNameAzure: repoNameAzure})
                 }
                 : {};
-
+        
+        console.log(data);
         if (Object.keys(data).length === 0) return;
         if(accessToken !== null) {
             data['accessToken'] = accessToken;
@@ -290,6 +374,18 @@ function RepositoryInitializer({ agentType }: { agentType: string }) {
             logo: '/public/bitbucket.svg',
             text: 'Continue with BitBucket',
             onClickFunc: () => handleClick('BIT_BUCKET')
+        },
+        {
+            id: 'AZURE_DEVOPS',
+            logo: '/public/azure.svg',
+            text: 'Continue with AzureDevops',
+            onClickFunc: () => handleClick('AZURE_DEVOPS')
+        },
+        {
+            id: 'GITLAB',
+            logo: '/public/gitlab.svg',
+            text: 'Continue with GitLab',
+            onClickFunc: () => handleClick('GITLAB')
         }
     ]
 
@@ -314,7 +410,7 @@ function RepositoryInitializer({ agentType }: { agentType: string }) {
                                     value={temp}
                                     focused={true}
                                     onChange={(x: string) => setTemp(x)}
-                                    connectedRight={<Button onClick={() => handleClickRepo("", "", temp, null)}>Start</Button>}
+                                    connectedRight={<Button onClick={() => handleClickRepo("", "", temp, null, null)}>Start</Button>}
                                 /> : null}
                             </VerticalStack>
                         </VerticalStack>


### PR DESCRIPTION
#Implemented:

- Added 3 other buttons related to BIT_BUCKET, AZURE_DEVOPS, GITLAB platform.
- Skimmed API docs of each platform and understood the requirements need to fetch the specific response.
- Used required url to fetch the data from particular platform

# All Agents Page
<img width="944" height="742" alt="image" src="https://github.com/user-attachments/assets/6a4ab9b6-a52a-46d4-bf65-9d43550fefe3" />

 # Bitbucket
<img width="970" height="883" alt="image" src="https://github.com/user-attachments/assets/7cc1d0c4-c70d-4b14-bcb1-2673549eaa35" />

# Azure_devops
<img width="960" height="897" alt="image" src="https://github.com/user-attachments/assets/1d106d6b-3d8a-4153-ad1e-9ab6043f5545" />

# Gitlab
<img width="959" height="901" alt="image" src="https://github.com/user-attachments/assets/7a6cbf58-c171-4b79-b658-e0f618710f3a" />


