### PR TITLE
Passed githubAccessToken on click of startAgain 

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/agent_team/components/agentResponses/Subprocess.tsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/agent_team/components/agentResponses/Subprocess.tsx
@@ -206,6 +206,7 @@ export const Subprocess = ({ agentId, processId, subProcessFromProp, triggerCall
             let data = await api.createAgentRun({
                 agent: previousAgentRun.agent,
                 data: previousAgentRun.agentInitDocument,
+                githubAccessToken: previousAgentRun.privateData?.githubAccessToken,
                 modelName: selectedModel?.id
             })
             if(data.agentRun){


### PR DESCRIPTION
githubAccessToken wasn't getting passed in akto createAgentRun API invoked on clicking start again option from code analysis subprocess

Fixed that now
<img width="1242" height="590" alt="Screenshot 2025-07-26 at 2 48 48 PM" src="https://github.com/user-attachments/assets/e90bd552-c072-4cd4-aea0-5cbe5095af48" />
<img width="1244" height="534" alt="Screenshot 2025-07-26 at 2 49 15 PM" src="https://github.com/user-attachments/assets/81eb2371-be8b-4f26-8589-ba0fbfd45d2f" />
