### PR TITLE
[Jul 30] feature/add tags to groups

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -784,9 +784,7 @@ function ApiCollections(props) {
             )
         }
         const bulkActionsOptions = [...actions];
-        if(selectedTab !== 'groups') {
-            bulkActionsOptions.push(toggleEnvType)
-        }
+        bulkActionsOptions.push(toggleEnvType)
         return bulkActionsOptions
     }
     const updateData = (dataMap) => {

--- a/libs/dao/src/main/java/com/akto/dto/ApiCollection.java
+++ b/libs/dao/src/main/java/com/akto/dto/ApiCollection.java
@@ -157,8 +157,6 @@ public class ApiCollection {
     }
 
     public List<CollectionTags> getEnvType(){
-        if(this.type != null && this.type == Type.API_GROUP) return null;
-        
         if(this.tagsList == null || this.tagsList.isEmpty()){
             CollectionTags envTypeTag = new CollectionTags();
             envTypeTag.setKeyName("envType");


### PR DESCRIPTION
Removed checks to allow addition of tags for `Groups` type API Collection

Before
(For non-group collections, envType getting populated)
<img width="1151" height="439" alt="Screenshot 2025-08-04 at 4 08 02 PM" src="https://github.com/user-attachments/assets/0f1acb57-f09c-46c9-b086-fd36e4fc3019" />

After
able to see tags for groups
<img width="1680" height="567" alt="Screenshot 2025-08-04 at 4 50 39 PM" src="https://github.com/user-attachments/assets/8c78f67d-a421-4286-b30f-f481d132b0ea" />

