### PR TITLE
fix: rename mcp security title (#2622)

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/HomeDashboard.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/HomeDashboard.jsx
@@ -1217,7 +1217,7 @@ function HomeDashboard() {
                         <Text variant='headingMd'>-</Text>
                     </VerticalStack>
                     <VerticalStack gap={1}>
-                        <Box style={{ minHeight: '36px' }}><Text color="subdued">MCP security</Text></Box>
+                        <Box style={{ minHeight: '36px' }}><Text color="subdued">MCP protection</Text></Box>
                         <Text variant='headingMd'>-</Text>
                     </VerticalStack>
                     <VerticalStack gap={1}>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/mcp-security/McpSecurityPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/mcp-security/McpSecurityPage.jsx
@@ -102,7 +102,7 @@ function McpSecurityPage() {
     <PageWithMultipleCards
       title={
         <HorizontalStack gap="2">
-          <Text as="h1" variant="headingLg">MCP Security</Text>
+          <Text as="h1" variant="headingLg">MCP Protection</Text>
           <Badge>Beta</Badge>
         </HorizontalStack>
       }
@@ -123,8 +123,8 @@ function McpSecurityPage() {
             <Box width="100%" key="beta-card">
               <EmptyScreensLayout
                 iconSrc={"/public/mcp.svg"}
-                headingText={"MCP Security is in beta"}
-                description={"MCP Security is currently in beta. Contact our sales team to learn more about this feature and get access."}
+                headingText={"MCP Protection is in beta"}
+                description={"MCP Protection is currently in beta. Contact our sales team to learn more about this feature and get access."}
                 bodyComponent={<Button url="https://www.akto.io/api-security-demo" target="_blank" primary>Contact sales</Button>}
               />
             </Box>

--- a/apps/dashboard/web/polaris_web/web/src/apps/main/labelHelperMap.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/main/labelHelperMap.js
@@ -165,7 +165,7 @@ export const labelMap = {
     "Untracked APIs": "Untracked tools",
     "Total endpoints": "Total tools",
     "Test your APIs": "Scan your MCPs",
-    "API Security": "MCP Security",
+    "API Security": "MCP Protection",
     "API endpoint": "MCP component",
     "API endpoints": "MCP components",
     "API Endpoints Discovered": "MCP Components Discovered",


### PR DESCRIPTION
## Summary
This PR renames the user-facing MCP title from `MCP Security` to `MCP Protection` in the Polaris dashboard UI. It keeps the internal category key unchanged so existing routing and category checks continue to work.

## Related issue
Closes #2622

## Changes made
- Updated the MCP label mapping to display `MCP Protection`
- Updated the MCP page heading from `MCP Security` to `MCP Protection`
- Updated the MCP beta banner copy to use `MCP Protection`
- Updated the MCP label shown on the home dashboard card

## How to test
1. Check out this branch
2. Open the Polaris dashboard UI
3. Navigate to the MCP section
4. Confirm the visible title now says `MCP Protection`
5. Confirm the MCP page heading and beta copy also use `MCP Protection`

## Screenshots / logs (if applicable)
Not applicable

Checklist:
- [x] Code follows the project's style guidelines
- [ ] Tests have been added/updated and all pass
- [x] PR is scoped to a single issue
- [x] PR description clearly explains the change
