### PR TITLE
detect and change agg rule to false on new pod

### DIFF
--- a/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
@@ -194,6 +194,50 @@ public class DbLayer {
         );
     }
 
+    private static final int rebootThresholdSeconds = 2 * 60; // 2 minutes 
+    private static void updateModuleEnvAndReboot(ModuleInfo moduleInfo) {
+
+        try {
+            Map<String, Object> additionalData = moduleInfo.getAdditionalData();
+            if (additionalData == null || !(additionalData.get("env") instanceof Map)) {
+                return;
+            }
+            Map<?, ?> env = (Map<?, ?>) additionalData.get("env");
+            Object val = env.get("AGGREGATION_RULES_ENABLED");
+            if (!"true".equalsIgnoreCase(String.valueOf(val))) {
+                return;
+            }
+        } catch (Exception ignored) {
+            return;
+        }
+
+        try {
+            int deltaTimeForReboot = Context.now() - rebootThresholdSeconds;
+
+
+            Bson moduleFilter = Filters.and(
+                Filters.eq(ModuleInfo.NAME, moduleInfo.getName()),
+                Filters.gte(ModuleInfo.LAST_HEARTBEAT_RECEIVED, deltaTimeForReboot),
+                Filters.ne(ModuleInfo.ADDITIONAL_DATA, null),
+                Filters.eq(ModuleInfo.ADDITIONAL_DATA + ".env.AGGREGATION_RULES_ENABLED", "true")
+            );
+
+
+            List<Bson> updates = new ArrayList<>();
+            updates.add(Updates.set(ModuleInfo.ADDITIONAL_DATA + ".env.AGGREGATION_RULES_ENABLED", false));
+            updates.add(Updates.set(ModuleInfo._REBOOT, true));
+
+
+            ModuleInfoDao.instance.updateMany(moduleFilter, Updates.combine(updates));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> env = (Map<String, Object>) moduleInfo.getAdditionalData().get("env");
+            env.put("AGGREGATION_RULES_ENABLED", "false");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     public static ModuleInfo updateModuleInfo(ModuleInfo moduleInfo) {
         FindOneAndUpdateOptions updateOptions = new FindOneAndUpdateOptions();
         updateOptions.upsert(true);
@@ -206,6 +250,10 @@ public class DbLayer {
             moduleInfo.getAdditionalData().put("tokenExpired", true);
         }
 
+        if(Context.accountId.get() == 1758787662){
+           updateModuleEnvAndReboot(moduleInfo); 
+        }
+        
         return ModuleInfoDao.instance.getMCollection().findOneAndUpdate(Filters.eq(ModuleInfoDao.ID, moduleInfo.getId()),
                 Updates.combine(
                         //putting class name because findOneAndUpdate doesn't put class name by default


### PR DESCRIPTION
## Problem

When a new threat-detection pod spins up, its environment has `AGGREGATION_RULES_ENABLED=true` by default. The pod needs this set to `false` so it stops running aggregation rules and instead triggers an internal process restart — without a full pod restart.

## Flow

```
Pod starts up
     │
     ▼
Every 60s: heartbeat sent → updateModuleInfo() called
     │
     ├─► [First heartbeat] Doc doesn't exist yet
     │        │
     │        └─► findOneAndUpdate (upsert) creates doc with AGGREGATION_RULES_ENABLED="true"
     │
     └─► [Subsequent heartbeats] Doc exists
              │
              ▼
        updateModuleEnvAndReboot(moduleInfo)
              │
              ├─ Early return if additionalData/env missing
              ├─ Early return if AGGREGATION_RULES_ENABLED != "true" (in-memory check)
              │
              ▼
        DB update (only if DB value is still "true"):
          - SET additionalData.env.AGGREGATION_RULES_ENABLED = false
          - SET _reboot = true
          + mutate in-memory moduleInfo.env to "false"
              │
              ▼
        findOneAndUpdate persists additionalData with "false"
              │
              ▼
        Pod polls DB, sees _reboot=true → internal process restart
              │
              ▼
        Next heartbeat carries AGGREGATION_RULES_ENABLED="false"
        → early return, no more updates
```

## Why the DB filter matters

After the first DB write sets `AGGREGATION_RULES_ENABLED=false`, the pod continues sending heartbeats with `true` in its env (until it internally restarts, ~2 min). Without a DB-side filter, the update would fire on every heartbeat during this window.

The filter `Filters.eq("additionalData.env.AGGREGATION_RULES_ENABLED", "true")` makes subsequent writes a no-op once the DB value is already `false` — preventing redundant `_reboot=true` signals.

## Why the in-memory mutation matters

`updateModuleEnvAndReboot` runs before the main `findOneAndUpdate`. Without mutating the in-memory `moduleInfo` object, the main query would overwrite `additionalData` back to `true` (from the heartbeat payload), undoing the DB update.

## Changes

- `updateModuleEnvAndReboot()` — new method that detects `AGGREGATION_RULES_ENABLED=true` and sets it to `false` + triggers internal reboot signal
- Called only for account `1758787662` inside `updateModuleInfo()`
- DB filter prevents redundant writes during the ~2 min internal restart window
- In-memory mutation ensures the subsequent heartbeat upsert does not overwrite the change