### PR TITLE
feat: add skills set support to createCollectionForHostAndVpc

### DIFF
--- a/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
@@ -357,6 +357,9 @@ public class DbAction extends ActionSupport {
     @lombok.Setter
     List<CollectionTags> tagsList;
 
+    @lombok.Getter
+    @lombok.Setter
+    List<String> skills;
 
     @lombok.Getter
     @lombok.Setter
@@ -3043,7 +3046,7 @@ public class DbAction extends ActionSupport {
 
     public String createCollectionForHostAndVpc() {
         try {
-            DbLayer.createCollectionForHostAndVpc(host, colId, vpcId, checkTagsNeedUpdates(tagsList, colId), accessType);
+            DbLayer.createCollectionForHostAndVpc(host, colId, vpcId, checkTagsNeedUpdates(tagsList, colId), accessType, skills);
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "Error in createCollectionForHostAndVpc " + e.toString());
             return Action.ERROR.toUpperCase();

--- a/libs/dao/src/main/java/com/akto/dto/ApiCollection.java
+++ b/libs/dao/src/main/java/com/akto/dto/ApiCollection.java
@@ -111,6 +111,9 @@ public class ApiCollection {
     List<CollectionTags> tagsList;
     public static final String TAGS_STRING = "tagsList";
 
+    Set<String> skills;
+    public static final String SKILLS = "skills";
+
     List<String> hostNames;
     public static final String HOST_NAMES = "hostNames";
 
@@ -461,6 +464,14 @@ public class ApiCollection {
 
     public void setTagsList(List<CollectionTags> tagsList) {
         this.tagsList = tagsList;
+    }
+
+    public Set<String> getSkills() {
+        return skills;
+    }
+
+    public void setSkills(Set<String> skills) {
+        this.skills = skills;
     }
 
     public String getSseCallbackUrl() {

--- a/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
@@ -1145,6 +1145,10 @@ public class ClientActor extends DataActor {
     }
 
     public void createCollectionForHostAndVpc(String host, int colId, String vpcId, List<CollectionTags> tags, String accessType) {
+        createCollectionForHostAndVpc(host, colId, vpcId, tags, accessType, null);
+    }
+
+    public void createCollectionForHostAndVpc(String host, int colId, String vpcId, List<CollectionTags> tags, String accessType, List<String> skills) {
         Map<String, List<String>> headers = buildHeaders();
         BasicDBObject obj = new BasicDBObject();
         obj.put("colId", colId);
@@ -1152,6 +1156,7 @@ public class ClientActor extends DataActor {
         obj.put("vpcId", vpcId);
         obj.put("tagsList", tags);
         obj.put("accessType", accessType);
+        obj.put("skills", skills);
         OriginalHttpRequest request = new OriginalHttpRequest(url + "/createCollectionForHostAndVpc", "", "POST", obj.toString(), headers, "");
         try {
             OriginalHttpResponse response = ApiExecutor.sendRequest(request, true, null, false, null);

--- a/libs/utils/src/main/java/com/akto/data_actor/DataActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DataActor.java
@@ -282,6 +282,8 @@ public abstract class DataActor {
 
     public abstract void createCollectionForHostAndVpc(String host, int colId, String vpcId, List<CollectionTags> tags, String accessType);
 
+    public abstract void createCollectionForHostAndVpc(String host, int colId, String vpcId, List<CollectionTags> tags, String accessType, List<String> skills);
+
     public abstract List<BasicDBObject> fetchEndpointsInCollectionUsingHost(int apiCollectionId, int skip, int deltaPeriodValue);
 
     public abstract OtpTestData fetchOtpTestData(String uuid, int curTime);

--- a/libs/utils/src/main/java/com/akto/data_actor/DbActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DbActor.java
@@ -606,6 +606,10 @@ public class DbActor extends DataActor {
         DbLayer.createCollectionForHostAndVpc(host, colId, vpcId, tags, accessType);
     }
 
+    public void createCollectionForHostAndVpc(String host, int colId, String vpcId, List<CollectionTags> tags, String accessType, List<String> skills) {
+        DbLayer.createCollectionForHostAndVpc(host, colId, vpcId, tags, accessType, skills);
+    }
+
     public List<BasicDBObject> fetchEndpointsInCollectionUsingHost(int apiCollectionId, int skip, int deltaPeriodValue) {
         return DbLayer.fetchEndpointsInCollectionUsingHost(apiCollectionId, skip, deltaPeriodValue);
     }

--- a/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
@@ -1043,6 +1043,10 @@ public class DbLayer {
     }
 
     public static void createCollectionForHostAndVpc(String host, int id, String vpcId, List<CollectionTags> tags, String accessType) {
+        createCollectionForHostAndVpc(host, id, vpcId, tags, accessType, null);
+    }
+
+    public static void createCollectionForHostAndVpc(String host, int id, String vpcId, List<CollectionTags> tags, String accessType, List<String> skills) {
 
         FindOneAndUpdateOptions updateOptions = new FindOneAndUpdateOptions();
         updateOptions.upsert(true);
@@ -1067,9 +1071,14 @@ public class DbLayer {
             }
         }
 
-        // Skip update for existing apiCollection if vpc and tags are same.
-        if ( apiCollection != null && (vpcId == null || vpcIdAlreadyExists) && (tags == null || tags.isEmpty()) && !accessTypeChanged) {
-            loggerMaker.info("No new tags or vpcId or accessType, Updates skipped for collectionId: " + id);
+        if (skills != null) {
+            skills.removeIf(s -> s == null || s.trim().isEmpty());
+        }
+        boolean hasSkills = skills != null && !skills.isEmpty();
+
+        // Skip update for existing apiCollection if vpc, tags, skills, and accessType are same.
+        if (apiCollection != null && (vpcId == null || vpcIdAlreadyExists) && (tags == null || tags.isEmpty()) && !accessTypeChanged && !hasSkills) {
+            loggerMaker.info("No new tags or vpcId or accessType or skills, Updates skipped for collectionId: " + id);
             return;
         }
 
@@ -1090,6 +1099,10 @@ public class DbLayer {
 
         if(accessType != null && !accessType.isEmpty()) {
             updates = Updates.combine(updates, Updates.set(ApiCollection.ACCESS_TYPE, accessType));
+        }
+
+        if (hasSkills) {
+            updates = Updates.combine(updates, Updates.addEachToSet(ApiCollection.SKILLS, skills));
         }
 
         ApiCollectionsDao.instance.getMCollection().findOneAndUpdate(Filters.eq(ApiCollection.HOST_NAME, host), updates, updateOptions);


### PR DESCRIPTION
## Summary
- Adds `Set<String> skills` field to `ApiCollection` (persisted in `api_collections` MongoDB collection)
- Skills are populated exclusively via `createCollectionForHostAndVpc` — no other collection creation path touches this field
- Uses MongoDB `$addToSet` with `$each` for atomic set semantics: first call stores all skills, subsequent calls add only new ones

## Behaviour
| Scenario | Result |
|---|---|
| First call with `["skill-a", "skill-b"]` | Collection created, skills = `["skill-a", "skill-b"]` |
| Second call with `["skill-a", "skill-c"]` | Only `"skill-c"` added → skills = `["skill-a", "skill-b", "skill-c"]` |
| Call with `null` or empty list | Skills field untouched |

## Changes
- `ApiCollection` — new `skills` field + getter/setter
- `DbLayer` — new 6-param overload; null/blank values stripped before write; old 5-param overload delegates to it
- `DataActor` / `DbActor` / `ClientActor` — new overload wired through the actor chain
- `DbAction` — new `skills` field (Struts2 auto-binds from request JSON), passed to `DbLayer`

## Test plan
- [ ] Create a collection via `createCollectionForHostAndVpc` with skills — verify `skills` array stored in `api_collections`
- [ ] Call again with overlapping + new skills — verify only new ones added, no duplicates
- [ ] Call with no skills — verify existing skills field untouched
- [ ] Existing callers without skills param — verify no regression (backward-compatible overload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)