### PR TITLE
Read skills directly from api_collection.skills field

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/Endpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/Endpoints.jsx
@@ -125,7 +125,7 @@ function Endpoints() {
             const agentGroupKeys = new Set(prettifiedAgents.map((a) => a.groupKey));
             const servicesToShow = prettifiedServices.filter((s) => !agentGroupKeys.has(s.groupKey));
 
-            const allData = [...prettifiedAgents, ...servicesToShow];
+            const allData = [...prettifiedAgents, ...servicesToShow, ...prettifiedSkills];
 
             // Calculate unique endpoint IDs across all collections
             const uniqueEndpointIds = new Set();

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -1,16 +1,15 @@
 import { CellType } from "@/apps/dashboard/components/tables/rows/GithubRow";
 import { 
-    ASSET_TAG_KEYS, 
+    ASSET_TAG_KEYS,
     ROW_TYPES,
     TYPE_TAG_KEYS,
     SKILL_TAG_KEY,
     CLIENT_TYPES,
-    formatDisplayName, 
-    getTypeFromTags, 
+    formatDisplayName,
+    getTypeFromTags,
     findAssetTag,
     findTypeTag,
-    findSkillTags,
-    getAgentTypeFromValue 
+    getAgentTypeFromValue
 } from "./mcpClientHelper";
 import func from "@/util/func";
 import { getResolvedUsernameForCollection, DEFAULT_VALUE } from "../api_collections/endpointShieldHelper";
@@ -282,7 +281,7 @@ export const groupCollectionsBySkill = (collections, trafficMap = {}, sensitiveM
 
     collections.forEach((c) => {
         if (c.deactivated) return;
-        const skillValues = findSkillTags(c.envType);
+        const skillValues = c.skills || [];
         if (!skillValues || skillValues.length === 0) return;
 
         const hostName = c.hostName || c.displayName || c.name;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/mcpClientHelper.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/mcpClientHelper.js
@@ -120,11 +120,6 @@ const findTypeTag = (envType) => {
     return null;
 };
 
-const findSkillTags = (envType) => {
-    if (!Array.isArray(envType)) return [];
-    return envType.filter(tag => tag.keyName === SKILL_TAG_KEY).map(tag => tag.value).filter(Boolean);
-};
-
 // Get agent type from tag value using KNOWN_CLIENTS map (for agent rows)
 const getAgentTypeFromValue = (tagValue) => {
     const info = findClientInfo(tagValue);
@@ -139,17 +134,14 @@ const getAgenticCategoryLabel = (collection) => {
     const raw = collection?.envTypeOriginal;
     if (Array.isArray(raw) && raw.length > 0) {
         if (typeof raw[0] === 'object' && raw[0]?.keyName) {
-            if (findSkillTags(raw).length > 0) {
-                return CLIENT_TYPES.SKILL;
-            }
             return getTypeFromTags(raw);
         }
     }
+    if (Array.isArray(collection?.skills) && collection.skills.length > 0) {
+        return CLIENT_TYPES.SKILL;
+    }
     const envArr = collection?.envType;
     if (Array.isArray(envArr) && envArr.length > 0 && typeof envArr[0] === 'string') {
-        if (envArr.some((t) => typeof t === 'string' && t.startsWith('skill='))) {
-            return CLIENT_TYPES.SKILL;
-        }
         if (envArr.some((t) => typeof t === 'string' && t.startsWith('mcp-server='))) {
             return TYPE_TAG_TO_DISPLAY[TYPE_TAG_KEYS.MCP_SERVER];
         }
@@ -171,7 +163,6 @@ export {
     getTypeFromTags,
     findAssetTag,
     findTypeTag,
-    findSkillTags,
     getAgentTypeFromValue,
     getAgenticCategoryLabel,
     CLIENT_TYPES,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -319,6 +319,7 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
             nextUrl: "/dashboard/observe/inventory/"+ c.id,
             envTypeOriginal: c?.envType,
             envType: c?.envType?.map(func.formatCollectionType),
+            skills: c?.skills,
             displayNameComp: (
                 <HorizontalStack gap="2" align="start">
                     <Box maxWidth="30vw"><Text truncate fontWeight="medium">{displayText}</Text></Box>
@@ -418,6 +419,7 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
         urlsCount: rawCollection.urlsCount,
         startTs: rawCollection.startTs,
         tagsList: rawCollection.tagsList,
+        skills: rawCollection.skills,
         registryStatus: rawCollection.registryStatus,
         description: rawCollection.description,
         isOutOfTestingScope: rawCollection.isOutOfTestingScope,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/useAgenticFilter.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/useAgenticFilter.js
@@ -182,14 +182,21 @@ const useAgenticFilter = (normalData) => {
                 const eq = filterValues[0].indexOf('=');
                 const filterKey = eq >= 0 ? filterValues[0].slice(0, eq) : '';
                 const filterTagValue = eq >= 0 ? filterValues[0].slice(eq + 1) : '';
-                const matchBothAgentTags = AGENT_TAG_KEYS_FOR_FILTER.includes(filterKey);
-                const matchingTags = matchBothAgentTags && filterTagValue
-                    ? AGENT_TAG_KEYS_FOR_FILTER.map(k => `${k}=${filterTagValue}`)
-                    : [filterValues[0]];
-                filteredCollections = normalData.filter(collection => {
-                    const envTypeArr = getFormattedEnvType(collection);
-                    return envTypeArr.some(tag => tag === filterValues[0] || matchingTags.includes(tag));
-                });
+
+                if (filterType === FILTER_TYPES.SKILL) {
+                    filteredCollections = normalData.filter(collection =>
+                        Array.isArray(collection.skills) && collection.skills.includes(filterTagValue)
+                    );
+                } else {
+                    const matchBothAgentTags = AGENT_TAG_KEYS_FOR_FILTER.includes(filterKey);
+                    const matchingTags = matchBothAgentTags && filterTagValue
+                        ? AGENT_TAG_KEYS_FOR_FILTER.map(k => `${k}=${filterTagValue}`)
+                        : [filterValues[0]];
+                    filteredCollections = normalData.filter(collection => {
+                        const envTypeArr = getFormattedEnvType(collection);
+                        return envTypeArr.some(tag => tag === filterValues[0] || matchingTags.includes(tag));
+                    });
+                }
             }
         }
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/main/PersistStore.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/main/PersistStore.js
@@ -107,7 +107,7 @@ let persistStore = (set, get) => ({
     },
     setAllCollections: (allCollections) => {
         try {
-            const optimizedCollections = allCollections.map(({ id, displayName, urlsCount, deactivated, type, automated, startTs, hostName, name, description, envType, isOutOfTestingScope, urls}) => ({
+            const optimizedCollections = allCollections.map(({ id, displayName, urlsCount, deactivated, type, automated, startTs, hostName, name, description, envType, isOutOfTestingScope, urls, skills}) => ({
                 id,
                 displayName,
                 urlsCount,
@@ -121,6 +121,7 @@ let persistStore = (set, get) => ({
                 envType,
                 isOutOfTestingScope,
                 urls,
+                skills,
             }));
             set({ allCollections: optimizedCollections });
         } catch (error) {

--- a/libs/dao/src/main/java/com/akto/dto/ApiCollection.java
+++ b/libs/dao/src/main/java/com/akto/dto/ApiCollection.java
@@ -161,6 +161,9 @@ public class ApiCollection {
     List<CollectionTags> tagsList;
     public static final String TAGS_STRING = "tagsList";
 
+    List<String> skills;
+    public static final String SKILLS = "skills";
+
     public static final String DEFAULT_TAG_KEY = "userSetEnvType";
 
     // Service tag for service-tag based collections
@@ -534,6 +537,14 @@ public class ApiCollection {
         }
 
         this.tagsList.addAll(tagsList);
+    }
+
+    public List<String> getSkills() {
+        return skills;
+    }
+
+    public void setSkills(List<String> skills) {
+        this.skills = skills;
     }
 
     public boolean isMcpCollection() {


### PR DESCRIPTION
## Summary
- Add `skills: List<String>` field to `ApiCollection` DTO (backend) so skills are stored as a top-level array instead of being derived from `tagsList` collection tags
- Frontend reads `c.skills` directly across all display, grouping, and filtering logic — removes the old `findSkillTags` tag-based approach entirely
- Skills filter on the inventory page now matches against `collection.skills` instead of `envType` tag strings

## Changes
- **`ApiCollection.java`** — new `skills` field + `SKILLS` constant + getter/setter
- **`mcpClientHelper.js`** — remove `findSkillTags`, `getAgenticCategoryLabel` checks `collection.skills`
- **`constants.js`** — `groupCollectionsBySkill` uses `c.skills` directly
- **`useAgenticFilter.js`** — skill filter branch checks `collection.skills.includes(filterTagValue)`
- **`ApiCollections.jsx`** — `convertToNewData` and `transformRawCollectionData` carry `skills` field through
- **`PersistStore.js`** — `setAllCollections` preserves `skills` field
- **`Endpoints.jsx`** — include `prettifiedSkills` in `allData` (was computed but never rendered)

## Test plan
- [ ] Navigate to Agentic Assets — skill rows appear in the table
- [ ] Click a skill row — inventory page filters to collections with that skill
- [ ] Collections with `skills: null` do not appear as skill rows
- [ ] Other filters (agent, service, MCP server) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)