### PR TITLE
feat: block personal accounts via policy name in guardrails service

### DIFF
--- a/apps/guardrails-service/container/src/pkg/config/config.go
+++ b/apps/guardrails-service/container/src/pkg/config/config.go
@@ -30,6 +30,8 @@ type Config struct {
 
 	McpAllowedListRefreshIntervalMin int
 
+	CollectionRefreshIntervalMin int
+
 	// Supports comma-separated or "regex:" prefixed patterns.
 	FilterHost string
 	FilterPath string
@@ -90,7 +92,8 @@ func LoadConfig() *Config {
 		FilterPath:               getEnv("FILTER_PATH", ""),
 		SessionSyncIntervalMin:   getEnvAsInt("SESSION_SYNC_INTERVAL_MIN", 5),
 		SessionEnabled:           getEnvAsBool("SESSION_ENABLED", true),
-		McpAllowedListRefreshIntervalMin: getEnvAsInt("MCP_ALLOWLIST_REFRESH_INTERVAL_MIN", 1),
+		McpAllowedListRefreshIntervalMin:  getEnvAsInt("MCP_ALLOWLIST_REFRESH_INTERVAL_MIN", 1),
+		CollectionRefreshIntervalMin:   getEnvAsInt("COLLECTION_REFRESH_INTERVAL_MIN", 5),
 		File: FileConfig{
 			MaxFiles:         getEnvAsInt("FILE_VALIDATE_MAX_FILES", 5),
 			MaxTextFileBytes: getEnvAsInt("FILE_VALIDATE_MAX_TEXT_FILE_BYTES", 5*1024*1024),

--- a/apps/guardrails-service/container/src/pkg/dbabstractor/client.go
+++ b/apps/guardrails-service/container/src/pkg/dbabstractor/client.go
@@ -188,6 +188,46 @@ func (c *Client) FetchGuardrailEndpoints() ([]byte, error) {
 	return body, nil
 }
 
+// FetchApiCollections fetches all API collections (with their tags) from database-abstractor
+func (c *Client) FetchApiCollections() ([]byte, error) {
+	url := c.baseURL + "/fetchAllCollections"
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte("{}")))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	token := auth.GetDatabaseAbstractorServiceToken()
+	if token == "" {
+		return nil, fmt.Errorf("DATABASE_ABSTRACTOR_SERVICE_TOKEN not set")
+	}
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Content-Type", "application/json")
+
+	c.logger.Info("Fetching API collections", zap.String("url", url))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch API collections: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch API collections, status: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	c.logger.Info("Successfully fetched API collections",
+		zap.Int("responseSize", len(body)),
+		zap.String("responsePreview", string(body[:min(len(body), 500)])))
+
+	return body, nil
+}
+
 // SendRequest sends a generic request to database-abstractor service
 func (c *Client) SendRequest(method, endpoint string, body interface{}) ([]byte, error) {
 	url := c.baseURL + endpoint

--- a/apps/guardrails-service/container/src/pkg/dbabstractor/client.go
+++ b/apps/guardrails-service/container/src/pkg/dbabstractor/client.go
@@ -190,7 +190,7 @@ func (c *Client) FetchGuardrailEndpoints() ([]byte, error) {
 
 // FetchApiCollections fetches all API collections (with their tags) from database-abstractor
 func (c *Client) FetchApiCollections() ([]byte, error) {
-	url := c.baseURL + "/fetchAllCollections"
+	url := c.baseURL + "/fetchAllApiCollections"
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte("{}")))
 	if err != nil {

--- a/apps/guardrails-service/container/src/pkg/validator/service.go
+++ b/apps/guardrails-service/container/src/pkg/validator/service.go
@@ -415,6 +415,58 @@ func (s *Service) getLoginUserEmailType(params *models.ValidateRequestParams) st
 	return v
 }
 
+// TODO: move reportAndBlockPersonalAccount to mcp library so threat reporting
+// and validation live in one place alongside other policy enforcement.
+func (s *Service) reportAndBlockPersonalAccount(_ context.Context, params *models.ValidateRequestParams, payloadToValidate, sessionID, requestID string) *mcp.ValidationResult {
+	blockReason := "Blocked: personal accounts are not permitted by guardrail policy"
+
+	if s.sessionMgr != nil && sessionID != "" {
+		s.sessionMgr.TrackResponse(sessionID, requestID, blockReason, true)
+		s.sessionMgr.UpdateBlockedReason(sessionID, blockReason)
+	}
+
+	if !params.EffectiveSkipThreat() {
+		reqHeaders := make(map[string]string)
+		if params.RequestHeaders != "" {
+			json.Unmarshal([]byte(params.RequestHeaders), &reqHeaders)
+		}
+		statusCode := 0
+		if params.StatusCode != "" {
+			fmt.Sscanf(params.StatusCode, "%d", &statusCode)
+		}
+		go func() {
+			if err := mcp.ReportThreat(
+				context.Background(),
+				payloadToValidate,
+				"",
+				types.ThreatMetadata{
+					PolicyName:   "block_personal_account",
+					RuleViolated: "personal account type",
+					Severity:     "MEDIUM",
+					Reason:       blockReason,
+				},
+				params.IP,
+				params.Path,
+				params.Method,
+				reqHeaders,
+				nil,
+				statusCode,
+				types.ContextSource(params.ContextSource),
+				extractHostHeader(reqHeaders),
+				sessionID,
+			); err != nil {
+				s.logger.Warn("Failed to report threat for block_personal_account", zap.Error(err))
+			}
+		}()
+	}
+
+	return &mcp.ValidationResult{
+		Allowed:   false,
+		Reason:    blockReason,
+		Behaviour: "block",
+	}
+}
+
 // extractHostHeader extracts the host header value from request headers
 func extractHostHeader(headers map[string]string) string {
 	if host, ok := headers["Host"]; ok {
@@ -748,11 +800,7 @@ func (s *Service) ValidateRequest(ctx context.Context, params *models.ValidateRe
 				zap.String("account", params.AktoAccountID),
 				zap.String("accountType", accountType),
 				zap.String("sessionID", sessionID))
-			return &mcp.ValidationResult{
-				Allowed:   false,
-				Reason:    "Blocked: personal accounts are not permitted by guardrail policy",
-				Behaviour: "block",
-			}, nil
+			return s.reportAndBlockPersonalAccount(ctx, params, payloadToValidate, sessionID, requestID), nil
 		}
 	}
 

--- a/apps/guardrails-service/container/src/pkg/validator/service.go
+++ b/apps/guardrails-service/container/src/pkg/validator/service.go
@@ -24,7 +24,6 @@ type policyCache struct {
 	auditPolicies        map[string]*types.AuditPolicy
 	compiledRules        map[string]*regexp.Regexp
 	hasAuditRules        bool
-	blockPersonalAccount bool // true if any active policy has blockPersonalAccount=true
 	lastFetched          time.Time
 	mu                   sync.RWMutex
 }
@@ -35,10 +34,9 @@ type collectionTag struct {
 	Value   string `json:"value"`
 }
 
-// collectionTagsCache caches collection tags keyed by vxlan ID for fast per-request lookup
+// collectionTagsCache caches collection tags keyed by host name
 type collectionTagsCache struct {
-	// byVxlanId maps akto_vxlan_id (string) -> tagKey -> tagValue
-	byVxlanId   map[string]map[string]string
+	byHostName  map[string]map[string]string // hostName -> tagKey -> tagValue
 	lastFetched time.Time
 	mu          sync.RWMutex
 }
@@ -123,7 +121,7 @@ func NewService(cfg *config.Config, logger *zap.Logger) (*Service, error) {
 		logger:              logger,
 		cache:               &policyCache{},
 		mcpListCache:        &mcpListCache{},
-		collectionTagsCache: &collectionTagsCache{byVxlanId: make(map[string]map[string]string)},
+		collectionTagsCache: &collectionTagsCache{byHostName: make(map[string]map[string]string)},
 		sessionMgr:          sessionManager,
 		schemaFetcher:       schemaFetcher,
 	}, nil
@@ -292,7 +290,7 @@ func (s *Service) refreshPolicies() ([]types.Policy, map[string]*types.AuditPoli
 
 	s.logger.Info("Refreshing policies cache - fetching ALL policies")
 
-	policies, auditPolicies, compiledRules, hasAuditRules, hasBlockPersonalAccount, err := s.fetchAndParsePolicies()
+	policies, auditPolicies, compiledRules, hasAuditRules, err := s.fetchAndParsePolicies()
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -302,24 +300,24 @@ func (s *Service) refreshPolicies() ([]types.Policy, map[string]*types.AuditPoli
 	s.cache.auditPolicies = auditPolicies
 	s.cache.compiledRules = compiledRules
 	s.cache.hasAuditRules = hasAuditRules
-	s.cache.blockPersonalAccount = hasBlockPersonalAccount
 	s.cache.lastFetched = time.Now()
 
 	s.logger.Info("Policy cache refreshed with ALL policies",
 		zap.Int("policiesCount", len(policies)),
 		zap.Int("auditPoliciesCount", len(auditPolicies)),
-		zap.Bool("blockPersonalAccount", hasBlockPersonalAccount),
 		zap.Time("lastFetched", s.cache.lastFetched),
 		zap.Any("policies", policies))
 
 	return policies, auditPolicies, compiledRules, hasAuditRules, nil
 }
 
-// blockPersonalAccountEnabled reads the cached flag under a read lock.
-func (s *Service) blockPersonalAccountEnabled() bool {
-	s.cache.mu.RLock()
-	defer s.cache.mu.RUnlock()
-	return s.cache.blockPersonalAccount
+func hasBlockPersonalAccountPolicy(policies []types.Policy) bool {
+	for _, p := range policies {
+		if p.Info.Name == "block_personal_account" {
+			return true
+		}
+	}
+	return false
 }
 
 // refreshCollectionTagsIfNeeded fetches all collections from the database abstractor and
@@ -345,12 +343,13 @@ func (s *Service) refreshCollectionTagsIfNeeded() {
 	raw, err := s.dbClient.FetchApiCollections()
 	if err != nil {
 		s.logger.Warn("Failed to fetch API collections for tag cache", zap.Error(err))
+		s.collectionTagsCache.lastFetched = time.Now()
 		return
 	}
 
 	var response struct {
 		ApiCollections []struct {
-			VxlanId  int             `json:"vxlanId"`
+			HostName string          `json:"hostName"`
 			TagsList []collectionTag `json:"tagsList"`
 		} `json:"apiCollections"`
 	}
@@ -359,59 +358,60 @@ func (s *Service) refreshCollectionTagsIfNeeded() {
 		return
 	}
 
-	byVxlanId := make(map[string]map[string]string, len(response.ApiCollections))
+	byHostName := make(map[string]map[string]string, len(response.ApiCollections))
 	for _, c := range response.ApiCollections {
-		if c.VxlanId == 0 {
+		if c.HostName == "" {
 			continue
 		}
-		key := fmt.Sprintf("%d", c.VxlanId)
 		tags := make(map[string]string, len(c.TagsList))
 		for _, t := range c.TagsList {
 			if t.KeyName != "" {
 				tags[t.KeyName] = t.Value
 			}
 		}
-		byVxlanId[key] = tags
+		byHostName[c.HostName] = tags
 	}
 
-	s.collectionTagsCache.byVxlanId = byVxlanId
+	s.collectionTagsCache.byHostName = byHostName
 	s.collectionTagsCache.lastFetched = time.Now()
-	s.logger.Info("Collection tag cache refreshed", zap.Int("collectionsCount", len(byVxlanId)))
+	s.logger.Info("Collection tag cache refreshed", zap.Int("collectionsCount", len(byHostName)))
 }
 
-// getLoginUserEmailType returns the value of the "login-user-email-type" tag for the
-// incoming request. It first checks the request's own tag JSON, then falls back to the
-// collection tag cache keyed by akto_vxlan_id.
-// It also returns "personal" if the "browser-llm-account-type" tag equals "personal".
+// getLoginUserEmailType looks up the host from request headers in the collection tag cache
+// and returns login-user-email-type, falling back to browser-llm-account-type.
 func (s *Service) getLoginUserEmailType(params *models.ValidateRequestParams) string {
-	const tagKey = "login-user-email-type"
-	const browserLlmTagKey = "browser-llm-account-type"
-
-	if params.Tag != "" {
-		var tagMap map[string]interface{}
-		if err := json.Unmarshal([]byte(params.Tag), &tagMap); err == nil {
-			if v, ok := tagMap[browserLlmTagKey].(string); ok && v == "personal" {
-				return "personal"
-			}
-			if v, ok := tagMap[tagKey].(string); ok && v != "" {
-				return v
-			}
-		}
+	var reqHeaders map[string]string
+	if params.RequestHeaders != "" {
+		json.Unmarshal([]byte(params.RequestHeaders), &reqHeaders)
+	}
+	host := extractHostHeader(reqHeaders)
+	s.logger.Info("getLoginUserEmailType - host extracted", zap.String("host", host))
+	if host == "" {
+		return ""
 	}
 
-	if params.AktoVxlanID != "" {
-		s.collectionTagsCache.mu.RLock()
-		tags, ok := s.collectionTagsCache.byVxlanId[params.AktoVxlanID]
-		s.collectionTagsCache.mu.RUnlock()
-		if ok {
-			if tags[browserLlmTagKey] == "personal" {
-				return "personal"
-			}
-			return tags[tagKey]
-		}
+	s.collectionTagsCache.mu.RLock()
+	tags, ok := s.collectionTagsCache.byHostName[host]
+	cacheSize := len(s.collectionTagsCache.byHostName)
+	s.collectionTagsCache.mu.RUnlock()
+
+	s.logger.Info("getLoginUserEmailType - cache lookup",
+		zap.String("host", host),
+		zap.Bool("found", ok),
+		zap.Int("cacheSize", cacheSize),
+		zap.Any("tags", tags))
+
+	if !ok {
+		return ""
 	}
 
-	return ""
+	if v := tags["login-user-email-type"]; v != "" {
+		s.logger.Info("getLoginUserEmailType - returning login-user-email-type", zap.String("value", v))
+		return v
+	}
+	v := tags["browser-llm-account-type"]
+	s.logger.Info("getLoginUserEmailType - returning browser-llm-account-type", zap.String("value", v))
+	return v
 }
 
 // extractHostHeader extracts the host header value from request headers
@@ -426,10 +426,10 @@ func extractHostHeader(headers map[string]string) string {
 }
 
 // fetchAndParsePolicies fetches policies from database abstractor and parses them
-func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.AuditPolicy, map[string]*regexp.Regexp, bool, bool, error) {
+func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.AuditPolicy, map[string]*regexp.Regexp, bool, error) {
 	rawGuardrailPolicies, err := s.dbClient.FetchGuardrailPolicies()
 	if err != nil {
-		return nil, nil, nil, false, false, fmt.Errorf("failed to fetch guardrail policies: %w", err)
+		return nil, nil, nil, false, fmt.Errorf("failed to fetch guardrail policies: %w", err)
 	}
 
 	s.logger.Debug("Raw guardrail policies response",
@@ -444,7 +444,7 @@ func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.Aud
 		s.logger.Error("Failed to parse guardrail policies",
 			zap.Error(err),
 			zap.String("rawResponse", string(rawGuardrailPolicies)))
-		return nil, nil, nil, false, false, fmt.Errorf("failed to parse guardrail policies: %w", err)
+		return nil, nil, nil, false, fmt.Errorf("failed to parse guardrail policies: %w", err)
 	}
 
 	s.logger.Info("Parsed guardrail policies",
@@ -458,15 +458,6 @@ func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.Aud
 			policies = append(policies, policy)
 		}
 	}
-
-	hasBlockPersonalAccount := false
-	for _, p := range policies {
-		if p.Info.Name == "block_personal_account" {
-			hasBlockPersonalAccount = true
-			break
-		}
-	}
-	s.logger.Info("Parsed blockPersonalAccount flag", zap.Bool("hasBlockPersonalAccount", hasBlockPersonalAccount))
 
 	// Fetch MCP audit info from database abstractor
 	rawAuditPolicies, err := s.dbClient.FetchMcpAuditInfo()
@@ -538,10 +529,9 @@ func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.Aud
 	s.logger.Info("Successfully fetched and parsed policies",
 		zap.Int("guardrailPolicies", len(policies)),
 		zap.Int("auditPolicies", len(auditPolicies)),
-		zap.Int("compiledRules", len(compiledRules)),
-		zap.Bool("hasBlockPersonalAccount", hasBlockPersonalAccount))
+		zap.Int("compiledRules", len(compiledRules)))
 
-	return policies, auditPolicies, compiledRules, hasAuditRules, hasBlockPersonalAccount, nil
+	return policies, auditPolicies, compiledRules, hasAuditRules, nil
 }
 
 // validationContextFromParams builds mcp.ValidationContext from traffic params and explicit payload strings for the context.
@@ -742,15 +732,15 @@ func (s *Service) ValidateRequest(ctx context.Context, params *models.ValidateRe
 		zap.Any("policies", policies),
 		zap.Int64("latencyMs", time.Since(policiesStart).Milliseconds()))
 
-	// Check account-type guardrail after policies are loaded (cache is warm)
-	s.refreshCollectionTagsIfNeeded()
-	if s.blockPersonalAccountEnabled() {
+	// Check account-type guardrail: block if any active policy is named block_personal_account
+	if hasBlockPersonalAccountPolicy(policies) {
+		s.refreshCollectionTagsIfNeeded()
 		accountType := s.getLoginUserEmailType(params)
 		s.logger.Info("ValidateRequest - account type check",
 			zap.String("path", params.Path),
 			zap.String("sessionID", sessionID),
 			zap.String("accountType", accountType))
-		if accountType != "enterprise" {
+		if accountType != "" && accountType != "enterprise" {
 			s.logger.Warn("ValidateRequest - blocking non-enterprise account",
 				zap.String("path", params.Path),
 				zap.String("method", params.Method),

--- a/apps/guardrails-service/container/src/pkg/validator/service.go
+++ b/apps/guardrails-service/container/src/pkg/validator/service.go
@@ -20,12 +20,27 @@ import (
 
 // policyCache holds cached policies and their metadata
 type policyCache struct {
-	policies      []types.Policy
-	auditPolicies map[string]*types.AuditPolicy
-	compiledRules map[string]*regexp.Regexp
-	hasAuditRules bool
-	lastFetched   time.Time
-	mu            sync.RWMutex
+	policies             []types.Policy
+	auditPolicies        map[string]*types.AuditPolicy
+	compiledRules        map[string]*regexp.Regexp
+	hasAuditRules        bool
+	blockPersonalAccount bool // true if any active policy has blockPersonalAccount=true
+	lastFetched          time.Time
+	mu                   sync.RWMutex
+}
+
+// collectionTag represents a single key-value tag on a collection
+type collectionTag struct {
+	KeyName string `json:"keyName"`
+	Value   string `json:"value"`
+}
+
+// collectionTagsCache caches collection tags keyed by vxlan ID for fast per-request lookup
+type collectionTagsCache struct {
+	// byVxlanId maps akto_vxlan_id (string) -> tagKey -> tagValue
+	byVxlanId   map[string]map[string]string
+	lastFetched time.Time
+	mu          sync.RWMutex
 }
 
 type mcpListCache struct {
@@ -36,14 +51,15 @@ type mcpListCache struct {
 
 // Service handles payload validation using akto-gateway library
 type Service struct {
-	config        *config.Config
-	dbClient      *dbabstractor.Client
-	processor     mcp.RequestProcessor // Default processor (skipThreat=false)
-	logger        *zap.Logger
-	cache         *policyCache
-	mcpListCache  *mcpListCache
-	sessionMgr    *session.SessionManager // Our session manager implementation for session tracking
-	schemaFetcher *SchemaFetcher
+	config             *config.Config
+	dbClient           *dbabstractor.Client
+	processor          mcp.RequestProcessor // Default processor (skipThreat=false)
+	logger             *zap.Logger
+	cache              *policyCache
+	mcpListCache       *mcpListCache
+	collectionTagsCache *collectionTagsCache
+	sessionMgr         *session.SessionManager // Our session manager implementation for session tracking
+	schemaFetcher      *SchemaFetcher
 }
 
 // NewService creates a new validator service
@@ -101,14 +117,15 @@ func NewService(cfg *config.Config, logger *zap.Logger) (*Service, error) {
 	schemaFetcher := NewSchemaFetcher(dbClient, time.Duration(cfg.PolicyRefreshIntervalMin)*time.Minute, logger)
 
 	return &Service{
-		config:        cfg,
-		dbClient:      dbClient,
-		processor:     defaultProcessor,
-		logger:        logger,
-		cache:         &policyCache{},
-		mcpListCache:  &mcpListCache{},
-		sessionMgr:    sessionManager,
-		schemaFetcher: schemaFetcher,
+		config:              cfg,
+		dbClient:            dbClient,
+		processor:           defaultProcessor,
+		logger:              logger,
+		cache:               &policyCache{},
+		mcpListCache:        &mcpListCache{},
+		collectionTagsCache: &collectionTagsCache{byVxlanId: make(map[string]map[string]string)},
+		sessionMgr:          sessionManager,
+		schemaFetcher:       schemaFetcher,
 	}, nil
 }
 
@@ -275,7 +292,7 @@ func (s *Service) refreshPolicies() ([]types.Policy, map[string]*types.AuditPoli
 
 	s.logger.Info("Refreshing policies cache - fetching ALL policies")
 
-	policies, auditPolicies, compiledRules, hasAuditRules, err := s.fetchAndParsePolicies()
+	policies, auditPolicies, compiledRules, hasAuditRules, hasBlockPersonalAccount, err := s.fetchAndParsePolicies()
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -285,15 +302,116 @@ func (s *Service) refreshPolicies() ([]types.Policy, map[string]*types.AuditPoli
 	s.cache.auditPolicies = auditPolicies
 	s.cache.compiledRules = compiledRules
 	s.cache.hasAuditRules = hasAuditRules
+	s.cache.blockPersonalAccount = hasBlockPersonalAccount
 	s.cache.lastFetched = time.Now()
 
 	s.logger.Info("Policy cache refreshed with ALL policies",
 		zap.Int("policiesCount", len(policies)),
 		zap.Int("auditPoliciesCount", len(auditPolicies)),
+		zap.Bool("blockPersonalAccount", hasBlockPersonalAccount),
 		zap.Time("lastFetched", s.cache.lastFetched),
 		zap.Any("policies", policies))
 
 	return policies, auditPolicies, compiledRules, hasAuditRules, nil
+}
+
+// blockPersonalAccountEnabled reads the cached flag under a read lock.
+func (s *Service) blockPersonalAccountEnabled() bool {
+	s.cache.mu.RLock()
+	defer s.cache.mu.RUnlock()
+	return s.cache.blockPersonalAccount
+}
+
+// refreshCollectionTagsIfNeeded fetches all collections from the database abstractor and
+// rebuilds the in-memory map of vxlan_id → tag key → tag value.
+func (s *Service) refreshCollectionTagsIfNeeded() {
+	refreshInterval := time.Duration(s.config.CollectionRefreshIntervalMin) * time.Minute
+
+	s.collectionTagsCache.mu.RLock()
+	fresh := !s.collectionTagsCache.lastFetched.IsZero() && time.Since(s.collectionTagsCache.lastFetched) < refreshInterval
+	s.collectionTagsCache.mu.RUnlock()
+	if fresh {
+		return
+	}
+
+	s.collectionTagsCache.mu.Lock()
+	defer s.collectionTagsCache.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if !s.collectionTagsCache.lastFetched.IsZero() && time.Since(s.collectionTagsCache.lastFetched) < refreshInterval {
+		return
+	}
+
+	raw, err := s.dbClient.FetchApiCollections()
+	if err != nil {
+		s.logger.Warn("Failed to fetch API collections for tag cache", zap.Error(err))
+		return
+	}
+
+	var response struct {
+		ApiCollections []struct {
+			VxlanId  int             `json:"vxlanId"`
+			TagsList []collectionTag `json:"tagsList"`
+		} `json:"apiCollections"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		s.logger.Warn("Failed to parse API collections response", zap.Error(err))
+		return
+	}
+
+	byVxlanId := make(map[string]map[string]string, len(response.ApiCollections))
+	for _, c := range response.ApiCollections {
+		if c.VxlanId == 0 {
+			continue
+		}
+		key := fmt.Sprintf("%d", c.VxlanId)
+		tags := make(map[string]string, len(c.TagsList))
+		for _, t := range c.TagsList {
+			if t.KeyName != "" {
+				tags[t.KeyName] = t.Value
+			}
+		}
+		byVxlanId[key] = tags
+	}
+
+	s.collectionTagsCache.byVxlanId = byVxlanId
+	s.collectionTagsCache.lastFetched = time.Now()
+	s.logger.Info("Collection tag cache refreshed", zap.Int("collectionsCount", len(byVxlanId)))
+}
+
+// getLoginUserEmailType returns the value of the "login-user-email-type" tag for the
+// incoming request. It first checks the request's own tag JSON, then falls back to the
+// collection tag cache keyed by akto_vxlan_id.
+// It also returns "personal" if the "browser-llm-account-type" tag equals "personal".
+func (s *Service) getLoginUserEmailType(params *models.ValidateRequestParams) string {
+	const tagKey = "login-user-email-type"
+	const browserLlmTagKey = "browser-llm-account-type"
+
+	if params.Tag != "" {
+		var tagMap map[string]interface{}
+		if err := json.Unmarshal([]byte(params.Tag), &tagMap); err == nil {
+			if v, ok := tagMap[browserLlmTagKey].(string); ok && v == "personal" {
+				return "personal"
+			}
+			if v, ok := tagMap[tagKey].(string); ok && v != "" {
+				return v
+			}
+		}
+	}
+
+	if params.AktoVxlanID != "" {
+		s.collectionTagsCache.mu.RLock()
+		tags, ok := s.collectionTagsCache.byVxlanId[params.AktoVxlanID]
+		s.collectionTagsCache.mu.RUnlock()
+		if ok {
+			if tags[browserLlmTagKey] == "personal" {
+				return "personal"
+			}
+			return tags[tagKey]
+		}
+	}
+
+	return ""
 }
 
 // extractHostHeader extracts the host header value from request headers
@@ -308,10 +426,10 @@ func extractHostHeader(headers map[string]string) string {
 }
 
 // fetchAndParsePolicies fetches policies from database abstractor and parses them
-func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.AuditPolicy, map[string]*regexp.Regexp, bool, error) {
+func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.AuditPolicy, map[string]*regexp.Regexp, bool, bool, error) {
 	rawGuardrailPolicies, err := s.dbClient.FetchGuardrailPolicies()
 	if err != nil {
-		return nil, nil, nil, false, fmt.Errorf("failed to fetch guardrail policies: %w", err)
+		return nil, nil, nil, false, false, fmt.Errorf("failed to fetch guardrail policies: %w", err)
 	}
 
 	s.logger.Debug("Raw guardrail policies response",
@@ -326,7 +444,7 @@ func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.Aud
 		s.logger.Error("Failed to parse guardrail policies",
 			zap.Error(err),
 			zap.String("rawResponse", string(rawGuardrailPolicies)))
-		return nil, nil, nil, false, fmt.Errorf("failed to parse guardrail policies: %w", err)
+		return nil, nil, nil, false, false, fmt.Errorf("failed to parse guardrail policies: %w", err)
 	}
 
 	s.logger.Info("Parsed guardrail policies",
@@ -340,6 +458,15 @@ func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.Aud
 			policies = append(policies, policy)
 		}
 	}
+
+	hasBlockPersonalAccount := false
+	for _, p := range policies {
+		if p.Info.Name == "block_personal_account" {
+			hasBlockPersonalAccount = true
+			break
+		}
+	}
+	s.logger.Info("Parsed blockPersonalAccount flag", zap.Bool("hasBlockPersonalAccount", hasBlockPersonalAccount))
 
 	// Fetch MCP audit info from database abstractor
 	rawAuditPolicies, err := s.dbClient.FetchMcpAuditInfo()
@@ -411,9 +538,10 @@ func (s *Service) fetchAndParsePolicies() ([]types.Policy, map[string]*types.Aud
 	s.logger.Info("Successfully fetched and parsed policies",
 		zap.Int("guardrailPolicies", len(policies)),
 		zap.Int("auditPolicies", len(auditPolicies)),
-		zap.Int("compiledRules", len(compiledRules)))
+		zap.Int("compiledRules", len(compiledRules)),
+		zap.Bool("hasBlockPersonalAccount", hasBlockPersonalAccount))
 
-	return policies, auditPolicies, compiledRules, hasAuditRules, nil
+	return policies, auditPolicies, compiledRules, hasAuditRules, hasBlockPersonalAccount, nil
 }
 
 // validationContextFromParams builds mcp.ValidationContext from traffic params and explicit payload strings for the context.
@@ -613,6 +741,29 @@ func (s *Service) ValidateRequest(ctx context.Context, params *models.ValidateRe
 		zap.Strings("policyNames", policyNames(policies)),
 		zap.Any("policies", policies),
 		zap.Int64("latencyMs", time.Since(policiesStart).Milliseconds()))
+
+	// Check account-type guardrail after policies are loaded (cache is warm)
+	s.refreshCollectionTagsIfNeeded()
+	if s.blockPersonalAccountEnabled() {
+		accountType := s.getLoginUserEmailType(params)
+		s.logger.Info("ValidateRequest - account type check",
+			zap.String("path", params.Path),
+			zap.String("sessionID", sessionID),
+			zap.String("accountType", accountType))
+		if accountType != "enterprise" {
+			s.logger.Warn("ValidateRequest - blocking non-enterprise account",
+				zap.String("path", params.Path),
+				zap.String("method", params.Method),
+				zap.String("account", params.AktoAccountID),
+				zap.String("accountType", accountType),
+				zap.String("sessionID", sessionID))
+			return &mcp.ValidationResult{
+				Allowed:   false,
+				Reason:    "Blocked: personal accounts are not permitted by guardrail policy",
+				Behaviour: "block",
+			}, nil
+		}
+	}
 
 	// Create validation context with full request metadata (matching batch flow)
 	valCtx := s.validationContextFromParams(params, sessionID, payloadToValidate, params.ResponsePayload, "ValidateRequest", mcpAllowedHostList)

--- a/apps/guardrails-service/container/src/pkg/validator/service.go
+++ b/apps/guardrails-service/container/src/pkg/validator/service.go
@@ -355,6 +355,7 @@ func (s *Service) refreshCollectionTagsIfNeeded() {
 	}
 	if err := json.Unmarshal(raw, &response); err != nil {
 		s.logger.Warn("Failed to parse API collections response", zap.Error(err))
+		s.collectionTagsCache.lastFetched = time.Now()
 		return
 	}
 


### PR DESCRIPTION
- Detect block_personal_account guardrail by policy name instead of a boolean field, using the already-parsed policies slice (removes rawGuardrailsPolicy struct and second JSON unmarshal)
- Add browser-llm-account-type=personal as a blocking signal alongside login-user-email-type
- Move personal account check after getCachedPolicies so the flag is populated on the first request
- Add FetchApiCollections to db abstractor client for collection tag cache
- Rename CollectionTagRefreshIntervalMin -> CollectionRefreshIntervalMin (env: COLLECTION_REFRESH_INTERVAL_MIN)