### PR TITLE
feat: show personal account badge on Endpoints page for agents and se…

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/Endpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/Endpoints.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo } from "react";
-import { IndexFiltersMode, Box, Badge } from "@shopify/polaris";
+import { IndexFiltersMode, Box, Badge, HorizontalStack, Text } from "@shopify/polaris";
 import { useNavigate } from "react-router-dom";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
 import GithubSimpleTable from "@/apps/dashboard/components/tables/GithubSimpleTable";
@@ -25,7 +25,7 @@ import {
     extractEndpointId,
     buildAgenticInventoryFilterForRow,
 } from "./constants";
-import { CLIENT_TYPES } from "./mcpClientHelper";
+import { CLIENT_TYPES, ROW_TYPES, hasPersonalAccountTag } from "./mcpClientHelper";
 
 const definedTableTabs = ['All', 'AI Agents', 'MCP Servers', 'LLMs', 'Skills'];
 
@@ -53,7 +53,11 @@ function Endpoints() {
         setSelected(selectedIndex);
     };
 
-    const headers = useMemo(() => getHeaders(), []);
+    const headers = useMemo(() => {
+        const h = getHeaders();
+        h[1] = { ...h[1], value: "groupNameDisplay" };
+        return h;
+    }, []);
 
     const getRiskScoreStatus = useCallback((riskScore) => {
         if (riskScore >= 4.5) return "critical";
@@ -66,6 +70,14 @@ function Endpoints() {
     const prettifyGroupData = useCallback((groups) => {
         return groups.map((group) => ({
             ...group,
+            groupNameDisplay: group.hasPersonalAccount && group.rowType !== ROW_TYPES.SKILL
+                ? (
+                    <HorizontalStack gap="2" align="start" wrap={false}>
+                        <Text>{group.groupName}</Text>
+                        <Badge size="small" status="warning">Contains personal account</Badge>
+                    </HorizontalStack>
+                )
+                : group.groupName,
             iconComp: (
                 <Box>
                     <CollectionIcon

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -9,7 +9,8 @@ import {
     getTypeFromTags,
     findAssetTag,
     findTypeTag,
-    getAgentTypeFromValue
+    getAgentTypeFromValue,
+    hasPersonalAccountTag,
 } from "./mcpClientHelper";
 import func from "@/util/func";
 import { getResolvedUsernameForCollection, DEFAULT_VALUE } from "../api_collections/endpointShieldHelper";
@@ -185,11 +186,13 @@ export const groupCollectionsByAgent = (collections, trafficMap = {}, sensitiveM
                 sensitiveTypes: new Set(),
                 maxTrafficTimestamp: 0,
                 maxRiskScore: 0,
+                hasPersonalAccount: false,
             };
         }
-        
+
         agents[key].collections.push(c);
         if (!agents[key].firstCollection) agents[key].firstCollection = c;
+        if (hasPersonalAccountTag(c.envType)) agents[key].hasPersonalAccount = true;
         
         // Track unique endpoint IDs
         if (endpointId) {
@@ -261,15 +264,16 @@ export const groupCollectionsByService = (collections, trafficMap = {}, sensitiv
                 sensitiveTypes: new Set(),
                 maxTrafficTimestamp: 0,
                 maxRiskScore: 0,
+                hasPersonalAccount: false,
             };
         }
-        
+
         services[key].collections.push(c);
-        // Track all hostnames for this service for filtering
         if (!services[key].hostNames.includes(hostName)) {
             services[key].hostNames.push(hostName);
         }
         if (!services[key].firstCollection) services[key].firstCollection = c;
+        if (hasPersonalAccountTag(c.envType)) services[key].hasPersonalAccount = true;
         
         // Track unique endpoint IDs
         if (endpointId) {
@@ -331,11 +335,13 @@ export const groupCollectionsBySkill = (collections, trafficMap = {}, sensitiveM
                     sensitiveTypes: new Set(),
                     maxTrafficTimestamp: 0,
                     maxRiskScore: 0,
+                    hasPersonalAccount: false,
                 };
             }
 
             skills[skillValue].collections.push(c);
             if (!skills[skillValue].firstCollection) skills[skillValue].firstCollection = c;
+            if (hasPersonalAccountTag(c.envType)) skills[skillValue].hasPersonalAccount = true;
             if (hostName && !skills[skillValue].hostNames.includes(hostName)) {
                 skills[skillValue].hostNames.push(hostName);
             }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/mcpClientHelper.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/mcpClientHelper.js
@@ -155,6 +155,19 @@ const getAgenticCategoryLabel = (collection) => {
     return getTypeFromTags(Array.isArray(raw) ? raw : []);
 };
 
+const PERSONAL_ACCOUNT_TAG_KEYS = ['browser-llm-account-type', 'login-user-email-type'];
+const PERSONAL_ACCOUNT_VALUE = 'personal';
+
+const hasPersonalAccountTag = (envType) => {
+    if (!Array.isArray(envType)) return false;
+    return envType.some((tag) => {
+        if (typeof tag === 'string') {
+            return PERSONAL_ACCOUNT_TAG_KEYS.some((key) => tag === `${key}=${PERSONAL_ACCOUNT_VALUE}`);
+        }
+        return PERSONAL_ACCOUNT_TAG_KEYS.includes(tag.keyName) && tag.value === PERSONAL_ACCOUNT_VALUE;
+    });
+};
+
 export {
     formatDisplayName,
     getDomainForFavicon,
@@ -165,6 +178,7 @@ export {
     findTypeTag,
     getAgentTypeFromValue,
     getAgenticCategoryLabel,
+    hasPersonalAccountTag,
     CLIENT_TYPES,
     TYPE_TAG_KEYS,
     ASSET_TAG_KEYS,


### PR DESCRIPTION
…rvices

- Add hasPersonalAccountTag helper in mcpClientHelper to detect personal account tags
- Track hasPersonalAccount flag in groupCollectionsByAgent, groupCollectionsByService, groupCollectionsBySkill
- In Endpoints.jsx, override header value to groupNameDisplay and show badge for non-skill rows
- UsersAndDevices.jsx and getHeaders are completely untouched