### PR TITLE
feat: add fetchApiSequences endpoint to database-abstractor

### DIFF
--- a/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
@@ -774,7 +774,7 @@ public class DbAction extends ActionSupport {
 
     public String fetchApiSequences() {
         try {
-            apiSequencesList = ApiSequencesDao.instance.findAll(new BasicDBObject());
+            apiSequencesList = ApiSequencesDao.instance.findAll(new BasicDBObject(), skip, 1000, null);
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "error in fetchApiSequences: " + e.getMessage());
             return Action.ERROR.toUpperCase();

--- a/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
@@ -772,6 +772,16 @@ public class DbAction extends ActionSupport {
         return Action.SUCCESS.toUpperCase();
     }
 
+    public String fetchApiSequences() {
+        try {
+            apiSequencesList = ApiSequencesDao.instance.findAll(new BasicDBObject());
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb(e, "error in fetchApiSequences: " + e.getMessage());
+            return Action.ERROR.toUpperCase();
+        }
+        return Action.SUCCESS.toUpperCase();
+    }
+
     public String bulkWriteSti() {
         loggerMaker.infoAndAddToDb("bulkWriteSti called");
         int accId = Context.accountId.get();

--- a/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
@@ -774,7 +774,7 @@ public class DbAction extends ActionSupport {
 
     public String fetchApiSequences() {
         try {
-            apiSequencesList = ApiSequencesDao.instance.findAll(new BasicDBObject(), skip, 1000, null);
+            apiSequencesList = ApiSequencesDao.instance.findAll(new BasicDBObject(), skip, 5000, null);
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "error in fetchApiSequences: " + e.getMessage());
             return Action.ERROR.toUpperCase();

--- a/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
@@ -774,7 +774,7 @@ public class DbAction extends ActionSupport {
 
     public String fetchApiSequences() {
         try {
-            apiSequencesList = ApiSequencesDao.instance.findAll(new BasicDBObject(), skip, 5000, null);
+            apiSequencesList = ApiSequencesDao.instance.findAll(new BasicDBObject(), skip, 1000, null);
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "error in fetchApiSequences: " + e.getMessage());
             return Action.ERROR.toUpperCase();

--- a/apps/database-abstractor/src/main/resources/struts.xml
+++ b/apps/database-abstractor/src/main/resources/struts.xml
@@ -273,6 +273,17 @@
             </result>
         </action>
 
+        <action name="api/fetchApiSequences" class="com.akto.action.DbAction" method="fetchApiSequences">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <result name="SUCCESS" type="json"/>
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/bulkWriteSti" class="com.akto.action.DbAction" method="bulkWriteSti">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />


### PR DESCRIPTION
## Summary
- Adds `fetchApiSequences()` action to `DbAction` — fetches all `api_sequences` documents for the account
- Registers `api/fetchApiSequences` GET endpoint in `struts.xml`
- Response field: `apiSequencesList` (matches existing getter/setter on `DbAction`)

This endpoint is consumed by `ClientActor.fetchApiSequences()` in threat-detection's `SequenceCache` for sequence-based anomaly detection.

## Test plan
- [ ] GET `/api/fetchApiSequences` returns 200 with `apiSequencesList` array
- [ ] Returns empty list when no sequences exist (not an error)
- [ ] Returns 422 on DB exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)