### PR TITLE
feat: strip hash suffix from AI agent display names

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
@@ -55,17 +55,19 @@ function UsersAndDevices() {
         setSelected(selectedIndex);
     };
 
-    const headers = useMemo(
-        () =>
-            getHeaders({
-                primaryColumnTitle: selectedTab === "users" ? "User" : "Device",
-                primaryColumnText: selectedTab === "users" ? "User" : "Device",
-                includeIconColumn: false,
-                includeUserColumns: selectedTab === "users",
-                ...usersAndDevicesCountColumnOpts,
-            }),
-        [selectedTab],
-    );
+    const headers = useMemo(() => {
+        const h = getHeaders({
+            primaryColumnTitle: selectedTab === "users" ? "User" : "Device",
+            primaryColumnText: selectedTab === "users" ? "User" : "Device",
+            includeIconColumn: false,
+            includeUserColumns: selectedTab === "users",
+            ...usersAndDevicesCountColumnOpts,
+        });
+        if (selectedTab === "devices") {
+            h[0] = { ...h[0], value: "groupNameDisplay", textValue: "groupNameDisplay", filterKey: "groupNameDisplay" };
+        }
+        return h;
+    }, [selectedTab]);
 
     const sortOptionsNoIcon = useMemo(
         () => getSortOptionsWithoutIconColumn(usersAndDevicesCountColumnOpts),

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
@@ -55,17 +55,20 @@ function UsersAndDevices() {
         setSelected(selectedIndex);
     };
 
-    const headers = useMemo(
-        () =>
-            getHeaders({
-                primaryColumnTitle: selectedTab === "users" ? "User" : "Device",
-                primaryColumnText: selectedTab === "users" ? "User" : "Device",
-                includeIconColumn: false,
-                includeUserColumns: selectedTab === "users",
-                ...usersAndDevicesCountColumnOpts,
-            }),
-        [selectedTab],
-    );
+    const headers = useMemo(() => {
+        const h = getHeaders({
+            primaryColumnTitle: selectedTab === "users" ? "User" : "Device",
+            primaryColumnText: selectedTab === "users" ? "User" : "Device",
+            includeIconColumn: false,
+            includeUserColumns: selectedTab === "users",
+            ...usersAndDevicesCountColumnOpts,
+        });
+        // For devices tab only: show stripped display name in column and filter
+        if (selectedTab === "devices") {
+            h[0] = { ...h[0], value: "groupNameDisplay", textValue: "groupNameDisplay", filterKey: "groupNameDisplay" };
+        }
+        return h;
+    }, [selectedTab]);
 
     const sortOptionsNoIcon = useMemo(
         () => getSortOptionsWithoutIconColumn(usersAndDevicesCountColumnOpts),

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
@@ -55,20 +55,17 @@ function UsersAndDevices() {
         setSelected(selectedIndex);
     };
 
-    const headers = useMemo(() => {
-        const h = getHeaders({
-            primaryColumnTitle: selectedTab === "users" ? "User" : "Device",
-            primaryColumnText: selectedTab === "users" ? "User" : "Device",
-            includeIconColumn: false,
-            includeUserColumns: selectedTab === "users",
-            ...usersAndDevicesCountColumnOpts,
-        });
-        // For devices tab only: show stripped display name in column and filter
-        if (selectedTab === "devices") {
-            h[0] = { ...h[0], value: "groupNameDisplay", textValue: "groupNameDisplay", filterKey: "groupNameDisplay" };
-        }
-        return h;
-    }, [selectedTab]);
+    const headers = useMemo(
+        () =>
+            getHeaders({
+                primaryColumnTitle: selectedTab === "users" ? "User" : "Device",
+                primaryColumnText: selectedTab === "users" ? "User" : "Device",
+                includeIconColumn: false,
+                includeUserColumns: selectedTab === "users",
+                ...usersAndDevicesCountColumnOpts,
+            }),
+        [selectedTab],
+    );
 
     const sortOptionsNoIcon = useMemo(
         () => getSortOptionsWithoutIconColumn(usersAndDevicesCountColumnOpts),

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -438,7 +438,7 @@ export const groupCollectionsByDevice = (collections, trafficMap = {}, sensitive
             devices[deviceId] = {
                 rowType: ROW_TYPES.SERVICE,
                 groupName: deviceId,
-                groupNameDisplay: deviceId.replace(/--[0-9a-f]{8}(?=\.|$)/i, ''),
+                groupNameDisplay: func.stripAgentHashSuffix(deviceId),
                 groupKey: deviceId,
                 hostNames: [],
                 clientTypes: new Set(),

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -404,10 +404,9 @@ const finalizeHostGroupedRow = (g, idSegment) => {
     return {
         rowType: g.rowType,
         groupName: g.groupName,
-        groupNameDisplay: g.groupNameDisplay ?? g.groupName,
         groupKey: g.groupKey,
         hostNames: g.hostNames,
-        inventoryScopeLabel: g.groupNameDisplay ?? g.groupName,
+        inventoryScopeLabel: g.groupName,
         collections: g.collections,
         firstCollection: g.firstCollection,
         id: `${ROW_ID_PREFIX.SERVICE}-${idSegment}-${String(g.groupKey).replace(/[^a-zA-Z0-9_.-]/g, "_")}`,
@@ -438,7 +437,6 @@ export const groupCollectionsByDevice = (collections, trafficMap = {}, sensitive
             devices[deviceId] = {
                 rowType: ROW_TYPES.SERVICE,
                 groupName: deviceId,
-                groupNameDisplay: func.stripAgentHashSuffix(deviceId),
                 groupKey: deviceId,
                 hostNames: [],
                 clientTypes: new Set(),

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -404,9 +404,10 @@ const finalizeHostGroupedRow = (g, idSegment) => {
     return {
         rowType: g.rowType,
         groupName: g.groupName,
+        groupNameDisplay: g.groupNameDisplay ?? g.groupName,
         groupKey: g.groupKey,
         hostNames: g.hostNames,
-        inventoryScopeLabel: g.groupName,
+        inventoryScopeLabel: g.groupNameDisplay ?? g.groupName,
         collections: g.collections,
         firstCollection: g.firstCollection,
         id: `${ROW_ID_PREFIX.SERVICE}-${idSegment}-${String(g.groupKey).replace(/[^a-zA-Z0-9_.-]/g, "_")}`,
@@ -437,6 +438,7 @@ export const groupCollectionsByDevice = (collections, trafficMap = {}, sensitive
             devices[deviceId] = {
                 rowType: ROW_TYPES.SERVICE,
                 groupName: deviceId,
+                groupNameDisplay: deviceId.replace(/--[0-9a-f]{8}(?=\.|$)/i, ''),
                 groupKey: deviceId,
                 hostNames: [],
                 clientTypes: new Set(),

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -404,9 +404,10 @@ const finalizeHostGroupedRow = (g, idSegment) => {
     return {
         rowType: g.rowType,
         groupName: g.groupName,
+        groupNameDisplay: g.groupNameDisplay ?? g.groupName,
         groupKey: g.groupKey,
         hostNames: g.hostNames,
-        inventoryScopeLabel: g.groupName,
+        inventoryScopeLabel: g.groupNameDisplay ?? g.groupName,
         collections: g.collections,
         firstCollection: g.firstCollection,
         id: `${ROW_ID_PREFIX.SERVICE}-${idSegment}-${String(g.groupKey).replace(/[^a-zA-Z0-9_.-]/g, "_")}`,
@@ -437,6 +438,7 @@ export const groupCollectionsByDevice = (collections, trafficMap = {}, sensitive
             devices[deviceId] = {
                 rowType: ROW_TYPES.SERVICE,
                 groupName: deviceId,
+                groupNameDisplay: func.stripDeviceIdSuffix(deviceId),
                 groupKey: deviceId,
                 hostNames: [],
                 clientTypes: new Set(),

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/AgentEndpointTreeTable.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/AgentEndpointTreeTable.jsx
@@ -27,8 +27,8 @@ const parentHeadersBase = [
         title: "Endpoint ID",
         text: "Endpoint ID",
         value: "displayNameComp",
-        filterKey: "endpointIdDisplay",
-        textValue: 'endpointIdDisplay',
+        filterKey: "endpointId",
+        textValue: 'endpointId',
         showFilter: true,
     },
     {
@@ -176,7 +176,6 @@ const groupByEndpointId = (collections) => {
         if (!groups[endpointId]) {
             groups[endpointId] = {
                 endpointId,
-                endpointIdDisplay: collection.endpointIdDisplay || endpointId,
                 children: [],
                 riskScore: 0,
                 sensitiveInRespTypes: [],
@@ -235,11 +234,11 @@ const prettifyGroupedData = (groupedData, filterType, showCategoryColumn, expand
             id: group.apiCollectionIds[0] || `endpoint-${group.endpointId}`,
             allIds: group.apiCollectionIds, // Keep array for bulk actions
             name: `endpoint-${group.endpointId}`,
-            displayName: group.endpointIdDisplay || group.endpointId,
+            displayName: group.endpointId,
             displayNameComp: (
                 <HorizontalStack gap="1" align="start" wrap={false}>
                     <Box maxWidth="200px">
-                        <TooltipText tooltip={group.endpointIdDisplay || group.endpointId} text={group.endpointIdDisplay || group.endpointId} textProps={{variant: 'headingSm'}} />
+                        <TooltipText tooltip={group.endpointId} text={group.endpointId} textProps={{variant: 'headingSm'}} />
                     </Box>
                     <Badge size="small" status="new">{childCount}</Badge>
                     {group.hasPersonalAccount && <Badge size="small" status="warning">Contains personal account</Badge>}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/AgentEndpointTreeTable.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/AgentEndpointTreeTable.jsx
@@ -27,8 +27,8 @@ const parentHeadersBase = [
         title: "Endpoint ID",
         text: "Endpoint ID",
         value: "displayNameComp",
-        filterKey: "endpointId",
-        textValue: 'endpointId',
+        filterKey: "endpointIdDisplay",
+        textValue: 'endpointIdDisplay',
         showFilter: true,
     },
     {
@@ -176,6 +176,7 @@ const groupByEndpointId = (collections) => {
         if (!groups[endpointId]) {
             groups[endpointId] = {
                 endpointId,
+                endpointIdDisplay: collection.endpointIdDisplay || endpointId,
                 children: [],
                 riskScore: 0,
                 sensitiveInRespTypes: [],
@@ -234,11 +235,11 @@ const prettifyGroupedData = (groupedData, filterType, showCategoryColumn, expand
             id: group.apiCollectionIds[0] || `endpoint-${group.endpointId}`,
             allIds: group.apiCollectionIds, // Keep array for bulk actions
             name: `endpoint-${group.endpointId}`,
-            displayName: group.endpointId,
+            displayName: group.endpointIdDisplay || group.endpointId,
             displayNameComp: (
                 <HorizontalStack gap="1" align="start" wrap={false}>
                     <Box maxWidth="200px">
-                        <TooltipText tooltip={group.endpointId} text={group.endpointId} textProps={{variant: 'headingSm'}} />
+                        <TooltipText tooltip={group.endpointIdDisplay || group.endpointId} text={group.endpointIdDisplay || group.endpointId} textProps={{variant: 'headingSm'}} />
                     </Box>
                     <Badge size="small" status="new">{childCount}</Badge>
                     {group.hasPersonalAccount && <Badge size="small" status="warning">Contains personal account</Badge>}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -76,9 +76,9 @@ const headers = [
         {
             title: "Endpoint ID",
             text: "Endpoint ID",
-            value: "endpointIdDisplay",
-            filterKey: "endpointIdDisplay",
-            textValue: 'endpointIdDisplay',
+            value: "endpointId",
+            filterKey: "endpointId",
+            textValue: 'endpointId',
             showFilter: true,
             isText: CellType.TEXT,
             boxWidth: '100px'
@@ -294,11 +294,6 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
         if (isEndpointSecurityCategory()) {
             displayText = splitResult.apiCollectionName;
         }
-        // Strip hash suffix (e.g. --be4f9b91) from display only for Atlas/Argus categories
-        // endpointId is kept raw (with hash) for grouping/filtering logic
-        if (isAtlasArgus) {
-            displayText = func.stripAgentHashSuffix(displayText);
-        }
 
         // Build result object directly without spread operator for better memory efficiency
         return {
@@ -306,7 +301,6 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
             displayName: c.displayName,
             splitApiCollectionName: displayText,
             endpointId: endpointId,
-            endpointIdDisplay: isAtlasArgus ? func.stripAgentHashSuffix(endpointId) : endpointId,
             sourceId: sourceId,
             serviceName: serviceName,
             hostName: c.hostName,
@@ -409,11 +403,6 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
     if (isEndpointSecurityCategory()) {
         splitApiCollectionName = splitResult.apiCollectionName;
     }
-    // Strip hash suffix (e.g. --be4f9b91) from display only for Atlas/Argus categories
-    // endpointId is kept raw (with hash) for grouping/filtering logic
-    if (isAtlasArgus) {
-        splitApiCollectionName = func.stripAgentHashSuffix(splitApiCollectionName);
-    }
 
     // Return minimal object - only fields needed for filtering, sorting, and categorization
     // JSX components will be created on-demand by prettifyPageData
@@ -422,7 +411,6 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
         displayName: rawCollection.displayName,
         splitApiCollectionName: splitApiCollectionName,
         endpointId: endpointId,
-        endpointIdDisplay: isAtlasArgus ? func.stripAgentHashSuffix(endpointId) : endpointId,
         sourceId: sourceId,
         serviceName: serviceName,
         hostName: rawCollection.hostName,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -297,7 +297,7 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
         // Strip hash suffix (e.g. --be4f9b91) from display only for Atlas/Argus categories
         // endpointId is kept raw (with hash) for grouping/filtering logic
         if (isAtlasArgus) {
-            displayText = displayText.replace(/--[0-9a-f]{8}(?=\.|$)/i, '');
+            displayText = func.stripAgentHashSuffix(displayText);
         }
 
         // Build result object directly without spread operator for better memory efficiency
@@ -306,7 +306,7 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
             displayName: c.displayName,
             splitApiCollectionName: displayText,
             endpointId: endpointId,
-            endpointIdDisplay: isAtlasArgus ? endpointId.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : endpointId,
+            endpointIdDisplay: isAtlasArgus ? func.stripAgentHashSuffix(endpointId) : endpointId,
             sourceId: sourceId,
             serviceName: serviceName,
             hostName: c.hostName,
@@ -412,7 +412,7 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
     // Strip hash suffix (e.g. --be4f9b91) from display only for Atlas/Argus categories
     // endpointId is kept raw (with hash) for grouping/filtering logic
     if (isAtlasArgus) {
-        splitApiCollectionName = splitApiCollectionName.replace(/--[0-9a-f]{8}(?=\.|$)/i, '');
+        splitApiCollectionName = func.stripAgentHashSuffix(splitApiCollectionName);
     }
 
     // Return minimal object - only fields needed for filtering, sorting, and categorization
@@ -422,7 +422,7 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
         displayName: rawCollection.displayName,
         splitApiCollectionName: splitApiCollectionName,
         endpointId: endpointId,
-        endpointIdDisplay: isAtlasArgus ? endpointId.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : endpointId,
+        endpointIdDisplay: isAtlasArgus ? func.stripAgentHashSuffix(endpointId) : endpointId,
         sourceId: sourceId,
         serviceName: serviceName,
         hostName: rawCollection.hostName,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -76,9 +76,9 @@ const headers = [
         {
             title: "Endpoint ID",
             text: "Endpoint ID",
-            value: "endpointId",
-            filterKey: "endpointId",
-            textValue: 'endpointId',
+            value: "endpointIdDisplay",
+            filterKey: "endpointIdDisplay",
+            textValue: 'endpointIdDisplay',
             showFilter: true,
             isText: CellType.TEXT,
             boxWidth: '100px'
@@ -294,6 +294,11 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
         if (isEndpointSecurityCategory()) {
             displayText = splitResult.apiCollectionName;
         }
+        // Strip hash suffix (e.g. --be4f9b91) from display only for Atlas/Argus categories
+        // endpointId is kept raw (with hash) for grouping/filtering logic
+        if (isAtlasArgus) {
+            displayText = displayText.replace(/--[0-9a-f]{8}(?=\.|$)/i, '');
+        }
 
         // Build result object directly without spread operator for better memory efficiency
         return {
@@ -301,6 +306,7 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
             displayName: c.displayName,
             splitApiCollectionName: displayText,
             endpointId: endpointId,
+            endpointIdDisplay: isAtlasArgus ? endpointId.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : endpointId,
             sourceId: sourceId,
             serviceName: serviceName,
             hostName: c.hostName,
@@ -403,6 +409,11 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
     if (isEndpointSecurityCategory()) {
         splitApiCollectionName = splitResult.apiCollectionName;
     }
+    // Strip hash suffix (e.g. --be4f9b91) from display only for Atlas/Argus categories
+    // endpointId is kept raw (with hash) for grouping/filtering logic
+    if (isAtlasArgus) {
+        splitApiCollectionName = splitApiCollectionName.replace(/--[0-9a-f]{8}(?=\.|$)/i, '');
+    }
 
     // Return minimal object - only fields needed for filtering, sorting, and categorization
     // JSX components will be created on-demand by prettifyPageData
@@ -411,6 +422,7 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
         displayName: rawCollection.displayName,
         splitApiCollectionName: splitApiCollectionName,
         endpointId: endpointId,
+        endpointIdDisplay: isAtlasArgus ? endpointId.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : endpointId,
         sourceId: sourceId,
         serviceName: serviceName,
         hostName: rawCollection.hostName,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -76,9 +76,9 @@ const headers = [
         {
             title: "Endpoint ID",
             text: "Endpoint ID",
-            value: "endpointId",
-            filterKey: "endpointId",
-            textValue: 'endpointId',
+            value: "endpointIdDisplay",
+            filterKey: "endpointIdDisplay",
+            textValue: 'endpointIdDisplay',
             showFilter: true,
             isText: CellType.TEXT,
             boxWidth: '100px'
@@ -294,6 +294,9 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
         if (isEndpointSecurityCategory()) {
             displayText = splitResult.apiCollectionName;
         }
+        if (isAtlasArgus) {
+            displayText = func.stripDeviceIdSuffix(displayText);
+        }
 
         // Build result object directly without spread operator for better memory efficiency
         return {
@@ -301,6 +304,7 @@ const convertToNewData = (collectionsArr, sensitiveInfoMap, severityInfoMap, cov
             displayName: c.displayName,
             splitApiCollectionName: displayText,
             endpointId: endpointId,
+            endpointIdDisplay: isAtlasArgus ? func.stripDeviceIdSuffix(endpointId) : endpointId,
             sourceId: sourceId,
             serviceName: serviceName,
             hostName: c.hostName,
@@ -403,6 +407,9 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
     if (isEndpointSecurityCategory()) {
         splitApiCollectionName = splitResult.apiCollectionName;
     }
+    if (isAtlasArgus) {
+        splitApiCollectionName = func.stripDeviceIdSuffix(splitApiCollectionName);
+    }
 
     // Return minimal object - only fields needed for filtering, sorting, and categorization
     // JSX components will be created on-demand by prettifyPageData
@@ -411,6 +418,7 @@ const transformRawCollectionData = (rawCollection, transformMaps) => {
         displayName: rawCollection.displayName,
         splitApiCollectionName: splitApiCollectionName,
         endpointId: endpointId,
+        endpointIdDisplay: isAtlasArgus ? func.stripDeviceIdSuffix(endpointId) : endpointId,
         sourceId: sourceId,
         serviceName: serviceName,
         hostName: rawCollection.hostName,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
@@ -256,7 +256,8 @@ function ApiEndpoints(props) {
     const setCollectionsMap = PersistStore(state => state.setCollectionsMap)
     const setAllCollections = PersistStore(state => state.setAllCollections)
 
-    const [ pageTitle, setPageTitle] = useState(collectionsMap[apiCollectionId] !== undefined ? collectionsMap[apiCollectionId] : "")
+    const stripCollectionHashSuffix = (name) => (isAgenticSecurityCategory() || isEndpointSecurityCategory()) ? func.stripDeviceIdSuffix(name || '') : (name || '');
+    const [ pageTitle, setPageTitle] = useState(stripCollectionHashSuffix(collectionsMap[apiCollectionId] !== undefined ? collectionsMap[apiCollectionId] : ""))
     const [apiEndpoints, setApiEndpoints] = useState([])
     const [apiInfoList, setApiInfoList] = useState([])
     const [unusedEndpoints, setUnusedEndpoints] = useState([])
@@ -790,8 +791,8 @@ function ApiEndpoints(props) {
     }, [apiCollectionId, endpointListFromConditions])
 
     useEffect(() => {
-        if (pageTitle !== collectionsMap[apiCollectionId]) { 
-            setPageTitle(collectionsMap[apiCollectionId])
+        if (pageTitle !== stripCollectionHashSuffix(collectionsMap[apiCollectionId])) {
+            setPageTitle(stripCollectionHashSuffix(collectionsMap[apiCollectionId]))
         }
 
         setDescription(collectionsObj?.description || "")

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
@@ -256,7 +256,8 @@ function ApiEndpoints(props) {
     const setCollectionsMap = PersistStore(state => state.setCollectionsMap)
     const setAllCollections = PersistStore(state => state.setAllCollections)
 
-    const [ pageTitle, setPageTitle] = useState(collectionsMap[apiCollectionId] !== undefined ? collectionsMap[apiCollectionId] : "")
+    const stripCollectionHashSuffix = (name) => (isAgenticSecurityCategory() || isEndpointSecurityCategory()) ? (name || '').replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : (name || '');
+    const [ pageTitle, setPageTitle] = useState(stripCollectionHashSuffix(collectionsMap[apiCollectionId] !== undefined ? collectionsMap[apiCollectionId] : ""))
     const [apiEndpoints, setApiEndpoints] = useState([])
     const [apiInfoList, setApiInfoList] = useState([])
     const [unusedEndpoints, setUnusedEndpoints] = useState([])
@@ -790,8 +791,8 @@ function ApiEndpoints(props) {
     }, [apiCollectionId, endpointListFromConditions])
 
     useEffect(() => {
-        if (pageTitle !== collectionsMap[apiCollectionId]) { 
-            setPageTitle(collectionsMap[apiCollectionId])
+        if (pageTitle !== stripCollectionHashSuffix(collectionsMap[apiCollectionId])) {
+            setPageTitle(stripCollectionHashSuffix(collectionsMap[apiCollectionId]))
         }
 
         setDescription(collectionsObj?.description || "")

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
@@ -256,7 +256,7 @@ function ApiEndpoints(props) {
     const setCollectionsMap = PersistStore(state => state.setCollectionsMap)
     const setAllCollections = PersistStore(state => state.setAllCollections)
 
-    const stripCollectionHashSuffix = (name) => (isAgenticSecurityCategory() || isEndpointSecurityCategory()) ? (name || '').replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : (name || '');
+    const stripCollectionHashSuffix = (name) => (isAgenticSecurityCategory() || isEndpointSecurityCategory()) ? func.stripAgentHashSuffix(name || '') : (name || '');
     const [ pageTitle, setPageTitle] = useState(stripCollectionHashSuffix(collectionsMap[apiCollectionId] !== undefined ? collectionsMap[apiCollectionId] : ""))
     const [apiEndpoints, setApiEndpoints] = useState([])
     const [apiInfoList, setApiInfoList] = useState([])

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
@@ -256,8 +256,7 @@ function ApiEndpoints(props) {
     const setCollectionsMap = PersistStore(state => state.setCollectionsMap)
     const setAllCollections = PersistStore(state => state.setAllCollections)
 
-    const stripCollectionHashSuffix = (name) => (isAgenticSecurityCategory() || isEndpointSecurityCategory()) ? func.stripAgentHashSuffix(name || '') : (name || '');
-    const [ pageTitle, setPageTitle] = useState(stripCollectionHashSuffix(collectionsMap[apiCollectionId] !== undefined ? collectionsMap[apiCollectionId] : ""))
+    const [ pageTitle, setPageTitle] = useState(collectionsMap[apiCollectionId] !== undefined ? collectionsMap[apiCollectionId] : "")
     const [apiEndpoints, setApiEndpoints] = useState([])
     const [apiInfoList, setApiInfoList] = useState([])
     const [unusedEndpoints, setUnusedEndpoints] = useState([])
@@ -791,8 +790,8 @@ function ApiEndpoints(props) {
     }, [apiCollectionId, endpointListFromConditions])
 
     useEffect(() => {
-        if (pageTitle !== stripCollectionHashSuffix(collectionsMap[apiCollectionId])) {
-            setPageTitle(stripCollectionHashSuffix(collectionsMap[apiCollectionId]))
+        if (pageTitle !== collectionsMap[apiCollectionId]) { 
+            setPageTitle(collectionsMap[apiCollectionId])
         }
 
         setDescription(collectionsObj?.description || "")

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
@@ -103,7 +103,7 @@ function EndpointShieldMetadata() {
             setAllowedEnvFields(response.allowedEnvFields || []);
             const agents = endpointShieldModules.map(module => ({
                 agentId: module.id,
-                hostname: module.name,
+                hostname: func.stripDeviceIdSuffix(module.name),
                 deviceId: module.additionalData?.deviceId || DEFAULT_VALUE,
                 agentVersion: module.currentVersion || DEFAULT_VALUE,
                 username: module.additionalData?.username || DEFAULT_VALUE,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
@@ -602,6 +602,7 @@ const transform = {
                 displayName: c.displayName,
                 splitApiCollectionName: splitApiCollectionName,
                 endpointId: endpointId,
+                endpointIdDisplay: endpointId ? func.stripDeviceIdSuffix(endpointId) : (c.endpointIdDisplay || ''),
                 sourceId: sourceId || c.sourceId,
                 serviceName: serviceName || c.serviceName,
                 displayNameComp: displayNameComp,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
@@ -602,6 +602,7 @@ const transform = {
                 displayName: c.displayName,
                 splitApiCollectionName: splitApiCollectionName,
                 endpointId: endpointId,
+                endpointIdDisplay: endpointId ? endpointId.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : (c.endpointIdDisplay || ''),
                 sourceId: sourceId || c.sourceId,
                 serviceName: serviceName || c.serviceName,
                 displayNameComp: displayNameComp,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
@@ -602,7 +602,6 @@ const transform = {
                 displayName: c.displayName,
                 splitApiCollectionName: splitApiCollectionName,
                 endpointId: endpointId,
-                endpointIdDisplay: endpointId ? func.stripAgentHashSuffix(endpointId) : (c.endpointIdDisplay || ''),
                 sourceId: sourceId || c.sourceId,
                 serviceName: serviceName || c.serviceName,
                 displayNameComp: displayNameComp,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/transform.js
@@ -602,7 +602,7 @@ const transform = {
                 displayName: c.displayName,
                 splitApiCollectionName: splitApiCollectionName,
                 endpointId: endpointId,
-                endpointIdDisplay: endpointId ? endpointId.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : (c.endpointIdDisplay || ''),
+                endpointIdDisplay: endpointId ? func.stripAgentHashSuffix(endpointId) : (c.endpointIdDisplay || ''),
                 sourceId: sourceId || c.sourceId,
                 serviceName: serviceName || c.serviceName,
                 displayNameComp: displayNameComp,

--- a/apps/dashboard/web/polaris_web/web/src/util/func.js
+++ b/apps/dashboard/web/polaris_web/web/src/util/func.js
@@ -102,12 +102,9 @@ const agenticCategoryMapping = {
   "ROGUE_AGENTS": ASI10,
 }
 
-const stripDeviceIdSuffix = (str) => str ? str.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : str;
-
 const func = {
   categoryMapping: categoryMapping,
   agenticCategoryMapping: agenticCategoryMapping,
-  stripDeviceIdSuffix,
   setToast (isActive, isError, message) {
     Store.getState().setToastConfig({
           isActive: isActive,
@@ -2549,7 +2546,12 @@ showConfirmationModal(modalContent, primaryActionContent, primaryAction) {
         mcpSecurityGranted,
         stiggFeatures
       }
-    }
+    },
+
+  stripDeviceIdSuffix(str) {
+    if (!str) return str;
+    return str.replace(/--[0-9a-f]{8}(?=\.|$)/i, '');
+  }
 }
 
 export default func

--- a/apps/dashboard/web/polaris_web/web/src/util/func.js
+++ b/apps/dashboard/web/polaris_web/web/src/util/func.js
@@ -102,9 +102,12 @@ const agenticCategoryMapping = {
   "ROGUE_AGENTS": ASI10,
 }
 
+const stripDeviceIdSuffix = (str) => str ? str.replace(/--[0-9a-f]{8}(?=\.|$)/i, '') : str;
+
 const func = {
   categoryMapping: categoryMapping,
   agenticCategoryMapping: agenticCategoryMapping,
+  stripDeviceIdSuffix,
   setToast (isActive, isError, message) {
     Store.getState().setToastConfig({
           isActive: isActive,

--- a/apps/dashboard/web/src/util/func.js
+++ b/apps/dashboard/web/src/util/func.js
@@ -877,9 +877,9 @@ export default {
         }
     },
     
-    stripDeviceIdSuffix(str) {
+    stripAgentHashSuffix(str) {
         if (!str) return str;
-        return str.replace(/--[0-9a-fA-F]{8}(?=\.|$)/g, '');
+        return str.replace(/--[0-9a-f]{8}(?=\.|$)/i, '');
     }
 
 }

--- a/apps/dashboard/web/src/util/func.js
+++ b/apps/dashboard/web/src/util/func.js
@@ -875,6 +875,11 @@ export default {
           }
           return result;
         }
-      }
+    },
+    
+    stripDeviceIdSuffix(str) {
+        if (!str) return str;
+        return str.replace(/--[0-9a-fA-F]{8}(?=\.|$)/g, '');
+    }
 
 }

--- a/apps/dashboard/web/src/util/func.js
+++ b/apps/dashboard/web/src/util/func.js
@@ -875,11 +875,6 @@ export default {
           }
           return result;
         }
-    },
-    
-    stripAgentHashSuffix(str) {
-        if (!str) return str;
-        return str.replace(/--[0-9a-f]{8}(?=\.|$)/i, '');
-    }
+      }
 
 }


### PR DESCRIPTION
Adds endpointIdDisplay and groupNameDisplay fields that strip the --<8hex> suffix from Atlas/Argus agent endpoint and device identifiers for cleaner UI display, keeping the raw endpointId intact for grouping and filtering logic.