### PR TITLE
Add SCRAM-SHA-512 and SASL_SSL support for threat-detection Kafka

### DIFF
--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/kafka/KafkaProtoProducer.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/kafka/KafkaProtoProducer.java
@@ -19,6 +19,10 @@ public class KafkaProtoProducer {
             kafkaConfig.getProducerConfig().getBatchSize());
   }
 
+  private static void addAuthToProducerProperties(Properties kafkaProps) {
+    KafkaConfig.addAuthenticationFromEnv(kafkaProps);
+  }
+
   public void send(String topic, Message message) {
     byte[] messageBytes = message.toByteArray();
     this.producer.send(new ProducerRecord<>(topic, messageBytes));
@@ -45,6 +49,9 @@ public class KafkaProtoProducer {
     kafkaProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
     kafkaProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, lingerMS + requestTimeoutMs);
     kafkaProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
+
+    addAuthToProducerProperties(kafkaProps);
+
     return new KafkaProducer<>(kafkaProps);
   }
 }

--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
@@ -115,8 +115,6 @@ public class MaliciousTrafficDetectorTask extends AbstractKafkaConsumerTask<byte
 
     Context.accountId.set(ClientActor.getAccountId());
 
-    KafkaConfig.addAuthenticationFromEnv(properties);
-
     logger.warnAndAddToDb(instanceId + ": Creating Kafka consumer with bootstrap servers: " + trafficConfig.getBootstrapServers() +
                           ", groupId: " + trafficConfig.getGroupId() +
                           ", maxPollRecords: " + trafficConfig.getConsumerConfig().getMaxPollRecords());

--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
@@ -115,6 +115,8 @@ public class MaliciousTrafficDetectorTask extends AbstractKafkaConsumerTask<byte
 
     Context.accountId.set(ClientActor.getAccountId());
 
+    KafkaConfig.addAuthenticationFromEnv(properties);
+
     logger.warnAndAddToDb(instanceId + ": Creating Kafka consumer with bootstrap servers: " + trafficConfig.getBootstrapServers() +
                           ", groupId: " + trafficConfig.getGroupId() +
                           ", maxPollRecords: " + trafficConfig.getConsumerConfig().getMaxPollRecords());

--- a/libs/utils/src/main/java/com/akto/kafka/Kafka.java
+++ b/libs/utils/src/main/java/com/akto/kafka/Kafka.java
@@ -168,7 +168,11 @@ public class Kafka {
 
     // Add SASL authentication if username and password are provided
     if (username != null && !username.isEmpty() && password != null && !password.isEmpty()) {
-      KafkaConfig.addAuthenticationProperties(kafkaProps, username, password);
+      String saslMechanism = System.getenv().getOrDefault(
+          "AKTO_KAFKA_SASL_MECHANISM", KafkaConfig.SASL_MECHANISM_SCRAM_SHA_512);
+      String securityProtocol = System.getenv().getOrDefault(
+          "AKTO_KAFKA_SECURITY_PROTOCOL", KafkaConfig.SECURITY_PROTOCOL_SASL_PLAINTEXT);
+      KafkaConfig.addAuthenticationProperties(kafkaProps, username, password, saslMechanism, securityProtocol);
     }
 
     try {

--- a/libs/utils/src/main/java/com/akto/kafka/Kafka.java
+++ b/libs/utils/src/main/java/com/akto/kafka/Kafka.java
@@ -169,7 +169,7 @@ public class Kafka {
     // Add SASL authentication if username and password are provided
     if (username != null && !username.isEmpty() && password != null && !password.isEmpty()) {
       String saslMechanism = System.getenv().getOrDefault(
-          "AKTO_KAFKA_SASL_MECHANISM", KafkaConfig.SASL_MECHANISM_SCRAM_SHA_512);
+          "AKTO_KAFKA_SASL_MECHANISM", KafkaConfig.SASL_MECHANISM_PLAIN);
       String securityProtocol = System.getenv().getOrDefault(
           "AKTO_KAFKA_SECURITY_PROTOCOL", KafkaConfig.SECURITY_PROTOCOL_SASL_PLAINTEXT);
       KafkaConfig.addAuthenticationProperties(kafkaProps, username, password, saslMechanism, securityProtocol);

--- a/libs/utils/src/main/java/com/akto/kafka/KafkaConfig.java
+++ b/libs/utils/src/main/java/com/akto/kafka/KafkaConfig.java
@@ -10,6 +10,9 @@ public class KafkaConfig {
   public static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
   public static final String SECURITY_PROTOCOL_SASL_PLAINTEXT = "SASL_PLAINTEXT";
   public static final String SASL_MECHANISM_PLAIN = "PLAIN";
+  public static final String SASL_MECHANISM_SCRAM_SHA_256 = "SCRAM-SHA-256";
+  public static final String SASL_MECHANISM_SCRAM_SHA_512 = "SCRAM-SHA-512";
+  public static final String SECURITY_PROTOCOL_SASL_SSL = "SASL_SSL";
 
   private final String bootstrapServers;
   private final String groupId;
@@ -116,23 +119,57 @@ public class KafkaConfig {
         properties.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, consumerConfig.getFetchMaxBytes());
       }
     }
+    addAuthenticationFromEnv(properties);
     return properties;
   }
 
   /**
-   * Adds Kafka SASL authentication properties to the given Properties object.
-   *
-   * @param properties The Properties object to add authentication to
-   * @param username   Kafka username
-   * @param password   Kafka password
+   * If AKTO_KAFKA_USERNAME and AKTO_KAFKA_PASSWORD are set, adds SASL/SSL properties to the given Properties.
+   * Defaults: SCRAM-SHA-512, SASL_SSL. Same env vars as Helm chart and data-ingestion.
    */
-  public static void addAuthenticationProperties(Properties properties, String username, String password) {
-    properties.put(SECURITY_PROTOCOL, SECURITY_PROTOCOL_SASL_PLAINTEXT);
-    properties.put(SASL_MECHANISM, SASL_MECHANISM_PLAIN);
+  public static void addAuthenticationFromEnv(Properties properties) {
+    String username = System.getenv("AKTO_KAFKA_USERNAME");
+    String password = System.getenv("AKTO_KAFKA_PASSWORD");
+    if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
+      return;
+    }
+    String saslMechanism = System.getenv().getOrDefault(
+        "AKTO_KAFKA_SASL_MECHANISM",
+        SASL_MECHANISM_SCRAM_SHA_512);
+    String securityProtocol = System.getenv().getOrDefault(
+        "AKTO_KAFKA_SECURITY_PROTOCOL",
+        SECURITY_PROTOCOL_SASL_PLAINTEXT);
+    addAuthenticationProperties(properties, username, password, saslMechanism, securityProtocol);
+  }
+
+  /**
+   * Adds Kafka SASL authentication properties to the given Properties object.
+   * Use addAuthenticationFromEnv(properties) when credentials come from AKTO_KAFKA_* env vars.
+   *
+   * @param properties       The Properties object to add authentication to
+   * @param username         Kafka username
+   * @param password         Kafka password
+   * @param saslMechanism    SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
+   * @param securityProtocol Security protocol (SASL_PLAINTEXT, SASL_SSL)
+   */
+  public static void addAuthenticationProperties(Properties properties, String username, String password, String saslMechanism, String securityProtocol) {
+    properties.put(SECURITY_PROTOCOL, securityProtocol);
+    properties.put(SASL_MECHANISM, saslMechanism);
+
+    // Select login module based on mechanism
+    String loginModule;
+    if (SASL_MECHANISM_PLAIN.equals(saslMechanism)) {
+      loginModule = "org.apache.kafka.common.security.plain.PlainLoginModule";
+    } else if (SASL_MECHANISM_SCRAM_SHA_256.equals(saslMechanism) ||
+               SASL_MECHANISM_SCRAM_SHA_512.equals(saslMechanism)) {
+      loginModule = "org.apache.kafka.common.security.scram.ScramLoginModule";
+    } else {
+      throw new IllegalArgumentException("Unsupported SASL mechanism: " + saslMechanism);
+    }
 
     String jaasConfig = String.format(
-        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";",
-        username, password);
+        "%s required username=\"%s\" password=\"%s\";",
+        loginModule, username, password);
     properties.put(SASL_JAAS_CONFIG, jaasConfig);
   }
 }

--- a/libs/utils/src/main/java/com/akto/kafka/KafkaConfig.java
+++ b/libs/utils/src/main/java/com/akto/kafka/KafkaConfig.java
@@ -135,7 +135,7 @@ public class KafkaConfig {
     }
     String saslMechanism = System.getenv().getOrDefault(
         "AKTO_KAFKA_SASL_MECHANISM",
-        SASL_MECHANISM_SCRAM_SHA_512);
+        SASL_MECHANISM_PLAIN);
     String securityProtocol = System.getenv().getOrDefault(
         "AKTO_KAFKA_SECURITY_PROTOCOL",
         SECURITY_PROTOCOL_SASL_PLAINTEXT);


### PR DESCRIPTION
- KafkaConfig: add addAuthenticationFromEnv() reading AKTO_KAFKA_* env vars; remove unused 3-arg/4-arg overloads
- MaliciousTrafficDetectorTask, AbstractKafkaConsumerTask, KafkaProtoProducer: call KafkaConfig.addAuthenticationFromEnv() for traffic and internal Kafka
- Aligns with mini-runtime Helm chart env vars (AKTO_KAFKA_USERNAME, PASSWORD, SASL_MECHANISM, SECURITY_PROTOCOL)

Made-with: Cursor