### PR TITLE
Fix typos, grammar errors, and hardcoded paths in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Step 2: Run tests
 ## How to get Started?
 
 ### Using docker-compose (works for any machine which has Docker installed)
-Run the following commands to install Akto. You'll need to have curl and Docker installed in order to run the container..
+Run the following commands to install Akto. You'll need to have curl and Docker installed to run the container.
 1. Clone the Akto repo by using this command `git clone https://github.com/akto-api-security/akto.git`
 2. Go to the cloned directory `cd akto` 
 3. Run `docker-compose up -d`

--- a/apps/akto-gateway/Readme.md
+++ b/apps/akto-gateway/Readme.md
@@ -35,7 +35,7 @@ akto-gateway/
 Build the JAR file using Maven:
 
 ```bash
-cd /Users/abhijeet/Documents/akto/akto/apps/akto-gateway
+cd apps/akto-gateway
 mvn clean package
 ```
 

--- a/libs/dao/src/main/java/com/akto/dao/test_editor/README.md
+++ b/libs/dao/src/main/java/com/akto/dao/test_editor/README.md
@@ -2,10 +2,10 @@
 
 # Filters
 
-Filters constitute of checks which are performed for checking whether an endpoint is eligible for a particular test. These filter configurations are maintained in yaml files under the setion ("apiSelectionFilters"). These filters can be of the following types - 
+Filters constitute of checks which are performed for checking whether an endpoint is eligible for a particular test. These filter configurations are maintained in yaml files under the section ("apiSelectionFilters"). These filters can be of the following types - 
 
 1. ## urlContains
-    This filter checks whether provided regex is present in url string excluding queryparams. In case of multiple regex's specified, this will try to match atleast one.
+    This filter checks whether provided regex is present in url string excluding queryparams. In case of multiple regex's specified, this will try to match at least one.
 
 2. ## userIdParamRegex
     This is not a filter in itself. A precheck will be triggered in case this condition exists in yaml
@@ -33,14 +33,14 @@ Filters constitute of checks which are performed for checking whether an endpoin
             - "login"
     Location can have the following values - 
     1. request-body - search in request body
-    2. response-body - search in reqresponseuest body
+    2. response-body - search in response body
     3. request-header - search in request header
     4. response-header - search in response header
     5. queryParam - search in queryParam
 
     KeyRegex can be any regex string.
 
-    A match is considered to be valid when any of the keyRegex strings is present in atleast 1 location. Also if there are multiple mustContainKey conditions, it's mandatory for each one to match
+    A match is considered to be valid when any of the keyRegex strings is present in at least 1 location. Also if there are multiple mustContainKey conditions, it's mandatory for each one to match
 
 8. ## versionMatchRegex
     This is a single regex string which should contain a match in the url string to be considered valid.
@@ -67,11 +67,11 @@ Filters constitute of checks which are performed for checking whether an endpoin
     
     SearchIn can contain the following values - 
     1. request-body - search in request body
-    2. response-body - search in reqresponseuest body
+    2. response-body - search in response body
     3. request-header - search in request header
     4. response-header - search in response header
     5. queryParam - search in queryParam
 
     
-    A match is considered to be valid when any of the paramRegex strings is present in atleast 1 searchIn location. Also if there are multiple containsParams conditions, it's mandatory for each one to match
+    A match is considered to be valid when any of the paramRegex strings is present in at least 1 searchIn location. Also if there are multiple containsParams conditions, it's mandatory for each one to match
     


### PR DESCRIPTION
## Summary

- **test_editor/README.md**: Fix `setion` → `section`, `atleast` → `at least` (3x), `reqresponseuest` → `response` (2x)
- **README.md**: Fix double period at end of sentence, simplify wording
- **akto-gateway/Readme.md**: Replace hardcoded developer machine path with relative path