### PR TITLE
feat(metrics): add Kafka consumer and processing metrics for threat-detection

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/metrics/configs/threatDetectionConfig.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/metrics/configs/threatDetectionConfig.js
@@ -1,8 +1,26 @@
 export const threatDetectionConfig = {
     moduleType: 'THREAT_DETECTION',
     title: 'Threat Detection Metrics',
-    metrics: ['CPU_USAGE_PERCENT', 'HEAP_MEMORY_USED_MB', 'NON_HEAP_MEMORY_USED_MB'],
+    metrics: [
+        'KAFKA_RECORDS_LAG_MAX',
+        'KAFKA_RECORDS_CONSUMED_RATE',
+        'KAFKA_FETCH_AVG_LATENCY',
+        'KAFKA_BYTES_CONSUMED_RATE',
+        'TD_KAFKA_RECORD_COUNT',
+        'TD_KAFKA_RECORD_SIZE',
+        'TD_KAFKA_LATENCY',
+        'CPU_USAGE_PERCENT',
+        'HEAP_MEMORY_USED_MB',
+        'NON_HEAP_MEMORY_USED_MB',
+    ],
     metricNames: {
+        'KAFKA_RECORDS_LAG_MAX': { title: 'Kafka Records Lag', description: 'Max consumer lag across partitions' },
+        'KAFKA_RECORDS_CONSUMED_RATE': { title: 'Kafka Consumed Rate', description: 'Records consumed per second' },
+        'KAFKA_FETCH_AVG_LATENCY': { title: 'Kafka Fetch Latency', description: 'Average fetch latency in ms' },
+        'KAFKA_BYTES_CONSUMED_RATE': { title: 'Kafka Bytes Rate', description: 'Bytes consumed per second' },
+        'TD_KAFKA_RECORD_COUNT': { title: 'Records Processed', description: 'Total Kafka records processed' },
+        'TD_KAFKA_RECORD_SIZE': { title: 'Records Size', description: 'Total bytes of Kafka records processed' },
+        'TD_KAFKA_LATENCY': { title: 'Processing Latency', description: 'Average per-record processing latency in ms' },
         'CPU_USAGE_PERCENT': { title: 'CPU Usage', description: 'CPU usage percentage' },
         'HEAP_MEMORY_USED_MB': { title: 'Heap Memory Used', description: 'Heap memory used in MB' },
         'NON_HEAP_MEMORY_USED_MB': { title: 'Non-Heap Memory Used', description: 'Non-heap memory used in MB' }

--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/Main.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/Main.java
@@ -1,10 +1,14 @@
 package com.akto.threat.detection;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.HashMap;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -119,7 +123,9 @@ public class Main {
 
     String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yy-MM-dd HH:mm:ss"));
     logger.warnAndAddToDb("Initialization finished starting DetectorTask at " + currentTime);
-    new MaliciousTrafficDetectorTask(trafficKafka, internalKafka, localRedis, distributionCalculator, apiDistributionEnabled, instanceId).run();
+    MaliciousTrafficDetectorTask detectorTask = new MaliciousTrafficDetectorTask(trafficKafka, internalKafka, localRedis, distributionCalculator, apiDistributionEnabled, instanceId);
+    scheduleKafkaMetricsPoller(detectorTask);
+    detectorTask.run();
 
     new SendMaliciousEventsToBackend(internalKafka, KafkaTopic.ThreatDetection.ALERTS).run();
 
@@ -219,6 +225,38 @@ public class Main {
         .setKeySerializer(Serializer.STRING)
         .setValueSerializer(Serializer.BYTE_ARRAY)
         .build();
+  }
+
+  private static void scheduleKafkaMetricsPoller(MaliciousTrafficDetectorTask detectorTask) {
+    scheduler.scheduleAtFixedRate(() -> {
+      try {
+        Consumer<String, byte[]> consumer = detectorTask.getKafkaConsumer();
+        if (consumer == null) return;
+
+        for (Map.Entry<MetricName, ? extends Metric> entry : consumer.metrics().entrySet()) {
+          MetricName key = entry.getKey();
+          Metric value = entry.getValue();
+
+          if (key.tags().containsKey("partition") || key.tags().containsKey("topic")) {
+            continue;
+          }
+
+          double metricValue = Double.isNaN((double) value.metricValue()) ? 0d : (double) value.metricValue();
+
+          if (key.name().equals("records-lag-max")) {
+            AllMetrics.instance.setKafkaRecordsLagMax((float) metricValue);
+          } else if (key.name().equals("records-consumed-rate")) {
+            AllMetrics.instance.setKafkaRecordsConsumedRate((float) metricValue);
+          } else if (key.name().equals("fetch-latency-avg")) {
+            AllMetrics.instance.setKafkaFetchAvgLatency((float) metricValue);
+          } else if (key.name().equals("bytes-consumed-rate")) {
+            AllMetrics.instance.setKafkaBytesConsumedRate((float) metricValue);
+          }
+        }
+      } catch (Exception e) {
+        logger.errorAndAddToDb("Failed to collect Kafka consumer metrics: " + e.getMessage());
+      }
+    }, 0, 1, TimeUnit.MINUTES);
   }
 
   private static void validateAndInitializeDeployment(boolean isHybridDeployment) throws Exception {

--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/AbstractKafkaConsumerTask.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/AbstractKafkaConsumerTask.java
@@ -79,4 +79,8 @@ public abstract class AbstractKafkaConsumerTask<V> implements Task {
   protected void beforePollLoop() {}
 
   abstract void processRecords(ConsumerRecords<String, V> records);
+
+  public Consumer<String, V> getKafkaConsumer() {
+    return kafkaConsumer;
+  }
 }

--- a/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
+++ b/apps/threat-detection/src/main/java/com/akto/threat/detection/tasks/MaliciousTrafficDetectorTask.java
@@ -179,6 +179,8 @@ public class MaliciousTrafficDetectorTask extends AbstractKafkaConsumerTask<byte
       }
 
       for (ConsumerRecord<String, byte[]> record : records) {
+        AllMetrics.instance.setTdKafkaRecordCount(1);
+        AllMetrics.instance.setTdKafkaRecordSize(record.serializedValueSize());
         HttpResponseParam httpResponseParam = HttpResponseParam.parseFrom(record.value());
         if (MAX_KAFKA_DEBUG_MSGS > 0) {
           MAX_KAFKA_DEBUG_MSGS--;
@@ -187,7 +189,9 @@ public class MaliciousTrafficDetectorTask extends AbstractKafkaConsumerTask<byte
         if (ignoreTrafficFilter(httpResponseParam)) {
           continue;
         }
+        long startTime = System.currentTimeMillis();
         processRecord(httpResponseParam);
+        AllMetrics.instance.setTdKafkaProcessLatency(System.currentTimeMillis() - startTime);
       }
     } catch (Exception e) {
       logger.errorAndAddToDb("Error observed in processing record " + e.getMessage());

--- a/libs/utils/src/main/java/com/akto/metrics/AllMetrics.java
+++ b/libs/utils/src/main/java/com/akto/metrics/AllMetrics.java
@@ -31,15 +31,24 @@ public class AllMetrics {
         Organization organization = OrgUtils.getOrganizationCached(accountId);
         String orgId = organization.getId();
 
-        if(LogDb.RUNTIME.equals(module)){
-            runtimeKafkaRecordCount = new SumMetric("RT_KAFKA_RECORD_COUNT", 60, accountId, orgId, moduleType);
-            runtimeKafkaRecordSize = new SumMetric("RT_KAFKA_RECORD_SIZE", 60, accountId, orgId, moduleType);
-            runtimeProcessLatency = new LatencyMetric("RT_KAFKA_LATENCY", 60, accountId, orgId, moduleType);
-            runtimeApiReceivedCount = new SumMetric("RT_API_RECEIVED_COUNT", 60, accountId, orgId, moduleType);
+        if(moduleType.equals(ModuleInfo.ModuleType.MINI_RUNTIME.name()) || moduleType.equals(ModuleInfo.ModuleType.THREAT_DETECTION.name())){
             kafkaRecordsLagMax = new MaxMetric("KAFKA_RECORDS_LAG_MAX", 60, accountId, orgId, moduleType);
             kafkaRecordsConsumedRate = new GaugeMetric("KAFKA_RECORDS_CONSUMED_RATE", 60, accountId, orgId, moduleType);
             kafkaFetchAvgLatency = new GaugeMetric("KAFKA_FETCH_AVG_LATENCY", 60, accountId, orgId, moduleType);
             kafkaBytesConsumedRate = new GaugeMetric("KAFKA_BYTES_CONSUMED_RATE", 60, accountId, orgId, moduleType);
+        }
+
+        if(moduleType.equals(ModuleInfo.ModuleType.THREAT_DETECTION.name())){
+            tdKafkaRecordCount = new SumMetric("TD_KAFKA_RECORD_COUNT", 60, accountId, orgId, moduleType);
+            tdKafkaRecordSize = new SumMetric("TD_KAFKA_RECORD_SIZE", 60, accountId, orgId, moduleType);
+            tdKafkaProcessLatency = new LatencyMetric("TD_KAFKA_LATENCY", 60, accountId, orgId, moduleType);
+        }
+
+        if(moduleType.equals(ModuleInfo.ModuleType.MINI_RUNTIME.name())){
+            runtimeKafkaRecordCount = new SumMetric("RT_KAFKA_RECORD_COUNT", 60, accountId, orgId, moduleType);
+            runtimeKafkaRecordSize = new SumMetric("RT_KAFKA_RECORD_SIZE", 60, accountId, orgId, moduleType);
+            runtimeProcessLatency = new LatencyMetric("RT_KAFKA_LATENCY", 60, accountId, orgId, moduleType);
+            runtimeApiReceivedCount = new SumMetric("RT_API_RECEIVED_COUNT", 60, accountId, orgId, moduleType);
             cyborgNewApiCount = new SumMetric("CYBORG_NEW_API_COUNT", 60, accountId, orgId, moduleType);
             cyborgTotalApiCount = new SumMetric("CYBORG_TOTAL_API_COUNT", 60, accountId, orgId, moduleType);
             deltaCatalogTotalCount = new SumMetric("DELTA_CATALOG_TOTAL_COUNT", 60, accountId, orgId, moduleType);
@@ -59,7 +68,7 @@ public class AllMetrics {
             pgDataSizeInMb = new SumMetric("PG_DATA_SIZE_IN_MB", 60, accountId, orgId, moduleType);
         }
 
-        if(LogDb.TESTING.equals(module)){
+        if(moduleType.equals(ModuleInfo.ModuleType.MINI_TESTING.name())){
             testingRunCount = new SumMetric("TESTING_RUN_COUNT", 60, accountId, orgId, moduleType);
             testingRunLatency = new LatencyMetric("TESTING_RUN_LATENCY", 60, accountId, orgId, moduleType);
             sampleDataFetchLatency = new LatencyMetric("SAMPLE_DATA_FETCH_LATENCY", 60, accountId, orgId, moduleType);
@@ -91,6 +100,7 @@ public class AllMetrics {
                 pgDataSizeInMb, kafkaRecordsLagMax, kafkaRecordsConsumedRate, kafkaFetchAvgLatency,
                 kafkaBytesConsumedRate, cyborgNewApiCount, cyborgTotalApiCount, deltaCatalogNewCount, deltaCatalogTotalCount,
                 cyborgApiPayloadSize, multipleSampleDataFetchLatency, runtimeApiReceivedCount,
+                tdKafkaRecordCount, tdKafkaRecordSize, tdKafkaProcessLatency,
                 cpuUsagePercent, heapMemoryUsedMb, heapMemoryMaxMb, nonHeapMemoryUsedMb, threadCount,
                 availableProcessors, totalPhysicalMemoryMb);
 
@@ -170,6 +180,9 @@ public class AllMetrics {
     private Metric runtimeKafkaRecordCount;
     private Metric runtimeKafkaRecordSize;
     private Metric runtimeProcessLatency = null;
+    private Metric tdKafkaRecordCount = null;
+    private Metric tdKafkaRecordSize = null;
+    private Metric tdKafkaProcessLatency = null;
     private Metric postgreSampleDataInsertedCount = null;
     private Metric postgreSampleDataInsertLatency = null;
     private Metric mergingJobLatency = null;
@@ -223,6 +236,21 @@ public class AllMetrics {
     public void setRuntimeProcessLatency(float val){
         if(runtimeProcessLatency != null)
             runtimeProcessLatency.record(val);
+    }
+
+    public void setTdKafkaRecordCount(float val){
+        if(tdKafkaRecordCount != null)
+            tdKafkaRecordCount.record(val);
+    }
+
+    public void setTdKafkaRecordSize(float val){
+        if(tdKafkaRecordSize != null)
+            tdKafkaRecordSize.record(val);
+    }
+
+    public void setTdKafkaProcessLatency(float val){
+        if(tdKafkaProcessLatency != null)
+            tdKafkaProcessLatency.record(val);
     }
 
     public void setRuntimeApiReceivedCount(float val){


### PR DESCRIPTION
## Summary

- Extends `AllMetrics` to collect Kafka consumer metrics (`KAFKA_RECORDS_LAG_MAX`, `KAFKA_RECORDS_CONSUMED_RATE`, `KAFKA_FETCH_AVG_LATENCY`, `KAFKA_BYTES_CONSUMED_RATE`) for the `THREAT_DETECTION` module, matching what mini-runtime already reports
- Adds three TD-specific processing metrics: `TD_KAFKA_RECORD_COUNT`, `TD_KAFKA_RECORD_SIZE`, `TD_KAFKA_LATENCY` — recorded per-record in `MaliciousTrafficDetectorTask`
- Schedules a 1-minute Kafka consumer metrics poller in `threat-detection/Main.java` (via `scheduleKafkaMetricsPoller`)
- Refactors `AllMetrics.init()` to gate metric groups on `moduleType` string (via `ModuleInfo.ModuleType`) instead of `LogDb` enum — more consistent with how metrics are stored and queried
- Exposes all 7 new metrics in `threatDetectionConfig.js` for dashboard display

## Test plan

- [ ] Deploy threat-detection module and verify `TD_KAFKA_*` and `KAFKA_RECORDS_*` metrics appear in `metrics_data` collection with `moduleType=THREAT_DETECTION`
- [ ] Confirm mini-runtime metrics are unaffected (`RT_KAFKA_*` still populate correctly)
- [ ] Open Threat Detection Metrics page in dashboard and verify all 10 charts render

🤖 Generated with [Claude Code](https://claude.com/claude-code)