### PR TITLE
feat: classify HTTP traffic headers (user-agent, referer) into API tags

### DIFF
--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
@@ -216,10 +216,11 @@ public class AktoPolicyNew {
 
         Map<String, List<String>> reqHeaders = httpResponseParams.getRequestParams().getHeaders();
         String ua = RuntimeUtil.getHeaderValue(reqHeaders, "user-agent");
-        addClassifiedTag(apiInfo, "user-agent", UserAgentClassifier.classify(ua), ua);
+        addClassifiedTag(apiInfo, "user-agent", UserAgentClassifier.classify(ua).name(), ua);
 
         String referer = RuntimeUtil.getHeaderValue(reqHeaders, "referer");
-        addClassifiedTag(apiInfo, "referer", referer, referer);
+        String refererHost = UserAgentClassifier.extractRefererHost(referer);
+        addClassifiedTag(apiInfo, "referer", refererHost, refererHost);
 
     }
 

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
@@ -5,6 +5,8 @@ import com.akto.dao.context.Context;
 import com.akto.dto.*;
 import com.akto.dto.ApiInfo.ApiInfoKey;
 import com.akto.dto.runtime_filters.RuntimeFilter;
+import com.akto.dto.traffic.CollectionTags;
+import com.akto.runtime.RuntimeUtil;
 import com.akto.runtime.policies.*;
 import com.akto.runtime.utils.Utils;
 import com.akto.dto.type.APICatalog;
@@ -36,6 +38,28 @@ public class AktoPolicyNew {
     private DataActor dataActor = DataActorFactory.fetchInstance();
 
     private static final LoggerMaker loggerMaker = new LoggerMaker(AktoPolicyNew.class, LogDb.RUNTIME);
+
+    private static final List<String> BOT_KEYWORDS = Arrays.asList(
+        "bot", "crawler", "spider", "scraper", "slurp", "googlebot",
+        "bingbot", "yandex", "duckduckbot", "baiduspider", "semrush",
+        "ahrefsbot", "mj12bot", "facebookexternalhit", "twitterbot"
+    );
+
+    private static String classifyUserAgent(String ua) {
+        if (ua == null || ua.isEmpty()) return null;
+        String lower = ua.toLowerCase();
+        for (String keyword : BOT_KEYWORDS) {
+            if (lower.contains(keyword)) return "bot";
+        }
+        if (lower.contains("mobile") || lower.contains("android") || lower.contains("iphone") || lower.contains("ipad")) {
+            return "mobile";
+        }
+        if (lower.contains("mozilla") || lower.contains("chrome") || lower.contains("safari")
+                || lower.contains("firefox") || lower.contains("edge") || lower.contains("opera")) {
+            return "browser";
+        }
+        return "programmatic";
+    }
 
     public void fetchFilters() {
         this.filters = dataActor.fetchRuntimeFilters();
@@ -211,6 +235,24 @@ public class AktoPolicyNew {
         apiInfo.setLastSeen(httpResponseParams.getTimeOrNow());
 
         apiInfo.setParentMcpToolNames(httpResponseParams.getParentMcpToolNames());
+
+        String ua = RuntimeUtil.getHeaderValue(httpResponseParams.getRequestParams().getHeaders(), "user-agent");
+        String uaCategory = classifyUserAgent(ua);
+        if (uaCategory != null) {
+            CollectionTags uaTag = new CollectionTags(Context.now(), "user-agent-category", uaCategory, CollectionTags.TagSource.KUBERNETES);
+            List<CollectionTags> existingTags = apiInfo.getTagsList();
+            if (existingTags == null) {
+                existingTags = new ArrayList<>();
+                apiInfo.setTagsList(existingTags);
+            }
+            boolean alreadyPresent = existingTags.stream().anyMatch(t ->
+                Objects.equals(t.getKeyName(), uaTag.getKeyName()) &&
+                Objects.equals(t.getValue(), uaTag.getValue())
+            );
+            if (!alreadyPresent) {
+                existingTags.add(uaTag);
+            }
+        }
 
     }
 

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
@@ -238,7 +238,7 @@ public class AktoPolicyNew {
                 return;
             }
         }
-        existingTags.add(new CollectionTags(Context.now(), headerKey, category, CollectionTags.TagSource.USER));
+        existingTags.add(new CollectionTags(Context.now(), headerKey, category, CollectionTags.TagSource.AKTO));
     }
 
     public PolicyCatalog getApiInfoFromMap(ApiInfo.ApiInfoKey apiInfoKey) {

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
@@ -238,7 +238,7 @@ public class AktoPolicyNew {
                 return;
             }
         }
-        existingTags.add(new CollectionTags(Context.now(), headerKey, category, CollectionTags.TagSource.KUBERNETES));
+        existingTags.add(new CollectionTags(Context.now(), headerKey, category, CollectionTags.TagSource.USER));
     }
 
     public PolicyCatalog getApiInfoFromMap(ApiInfo.ApiInfoKey apiInfoKey) {

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
@@ -39,28 +39,6 @@ public class AktoPolicyNew {
 
     private static final LoggerMaker loggerMaker = new LoggerMaker(AktoPolicyNew.class, LogDb.RUNTIME);
 
-    private static final List<String> BOT_KEYWORDS = Arrays.asList(
-        "bot", "crawler", "spider", "scraper", "slurp", "googlebot",
-        "bingbot", "yandex", "duckduckbot", "baiduspider", "semrush",
-        "ahrefsbot", "mj12bot", "facebookexternalhit", "twitterbot"
-    );
-
-    private static String classifyUserAgent(String ua) {
-        if (ua == null || ua.isEmpty()) return null;
-        String lower = ua.toLowerCase();
-        for (String keyword : BOT_KEYWORDS) {
-            if (lower.contains(keyword)) return "bot";
-        }
-        if (lower.contains("mobile") || lower.contains("android") || lower.contains("iphone") || lower.contains("ipad")) {
-            return "mobile";
-        }
-        if (lower.contains("mozilla") || lower.contains("chrome") || lower.contains("safari")
-                || lower.contains("firefox") || lower.contains("edge") || lower.contains("opera")) {
-            return "browser";
-        }
-        return "programmatic";
-    }
-
     public void fetchFilters() {
         this.filters = dataActor.fetchRuntimeFilters();
         loggerMaker.infoAndAddToDb("Fetched " + filters.size() + " filters from db");
@@ -236,24 +214,31 @@ public class AktoPolicyNew {
 
         apiInfo.setParentMcpToolNames(httpResponseParams.getParentMcpToolNames());
 
-        String ua = RuntimeUtil.getHeaderValue(httpResponseParams.getRequestParams().getHeaders(), "user-agent");
-        String uaCategory = classifyUserAgent(ua);
-        if (uaCategory != null) {
-            CollectionTags uaTag = new CollectionTags(Context.now(), "user-agent-category", uaCategory, CollectionTags.TagSource.KUBERNETES);
-            List<CollectionTags> existingTags = apiInfo.getTagsList();
-            if (existingTags == null) {
-                existingTags = new ArrayList<>();
-                apiInfo.setTagsList(existingTags);
-            }
-            boolean alreadyPresent = existingTags.stream().anyMatch(t ->
-                Objects.equals(t.getKeyName(), uaTag.getKeyName()) &&
-                Objects.equals(t.getValue(), uaTag.getValue())
-            );
-            if (!alreadyPresent) {
-                existingTags.add(uaTag);
+        Map<String, List<String>> reqHeaders = httpResponseParams.getRequestParams().getHeaders();
+        String ua = RuntimeUtil.getHeaderValue(reqHeaders, "user-agent");
+        addClassifiedTag(apiInfo, "user-agent", UserAgentClassifier.classify(ua), ua);
+
+        String referer = RuntimeUtil.getHeaderValue(reqHeaders, "referer");
+        String requestHost = RuntimeUtil.getHeaderValue(reqHeaders, "host");
+        addClassifiedTag(apiInfo, "referer", UserAgentClassifier.classifyReferer(referer, requestHost), referer);
+
+    }
+
+    private static void addClassifiedTag(ApiInfo apiInfo, String headerKey, String category, String rawValue) {
+        if (category == null || rawValue == null || rawValue.isEmpty()) return;
+        List<CollectionTags> existingTags = apiInfo.getTagsList();
+        if (existingTags == null) {
+            existingTags = new ArrayList<>();
+            apiInfo.setTagsList(existingTags);
+        }
+        for (CollectionTags tag : existingTags) {
+            if (Objects.equals(tag.getKeyName(), headerKey)) {
+                tag.setValue(category);
+                tag.setLastUpdatedTs(Context.now());
+                return;
             }
         }
-
+        existingTags.add(new CollectionTags(Context.now(), headerKey, category, CollectionTags.TagSource.KUBERNETES));
     }
 
     public PolicyCatalog getApiInfoFromMap(ApiInfo.ApiInfoKey apiInfoKey) {

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/AktoPolicyNew.java
@@ -219,8 +219,7 @@ public class AktoPolicyNew {
         addClassifiedTag(apiInfo, "user-agent", UserAgentClassifier.classify(ua), ua);
 
         String referer = RuntimeUtil.getHeaderValue(reqHeaders, "referer");
-        String requestHost = RuntimeUtil.getHeaderValue(reqHeaders, "host");
-        addClassifiedTag(apiInfo, "referer", UserAgentClassifier.classifyReferer(referer, requestHost), referer);
+        addClassifiedTag(apiInfo, "referer", referer, referer);
 
     }
 

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
@@ -1,29 +1,102 @@
 package com.akto.hybrid_runtime.policies;
 
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class UserAgentClassifier {
 
-    // Priority order: Infra → Bot → AI Agent → Mobile App → Browser → Service
-    // Each entry: { category, keyword1, keyword2, ... }
-    private static final List<String[]> UA_RULES = Arrays.asList(
-        new String[]{"Infra",       "kube-probe", "elb-healthchecker", "googlehc", "consul", "prometheus", "datadog", "newrelic", "pingdom", "uptimerobot", "nagios", "zabbix", "catchpoint"},
-        new String[]{"Bot",         "bot", "crawl", "spider", "slurp", "facebookexternalhit", "twitterbot", "ahrefsbot", "semrushbot", "duckduckbot", "mj12bot", "screaming frog"},
-        new String[]{"AI Agent",    "langchain", "llamaindex", "openai", "anthropic", "cohere", "huggingface", "llama", "litellm", "autogpt"},
-        new String[]{"Mobile App",  "okhttp", "alamofire", "cfnetwork", "nsurlsession", "dart/", "flutter", "reactnative", "expo", "retrofit"},
-        new String[]{"Browser",     "mozilla/", "chrome/", "firefox/", "safari/", "edge/", "opera/", "chromium/"},
-        new String[]{"Service",     "python-requests", "python-httpx", "axios", "curl/", "wget/", "go-http-client", "java/", "node-fetch", "got/", "ruby", "php", "httpie", "insomnia", "postman"}
-    );
+    public enum Category {
+        INFRA, BOT, AI_AGENT, MOBILE_APP, BROWSER, API_CLIENT, UNKNOWN
+    }
 
-    public static String classify(String ua) {
-        if (ua == null || ua.isEmpty()) return null;
-        String lower = ua.toLowerCase();
-        for (String[] rule : UA_RULES) {
-            for (int i = 1; i < rule.length; i++) {
-                if (lower.contains(rule[i])) return rule[0];
+    private static class Rule {
+        final Category category;
+        final List<Pattern> patterns;
+
+        Rule(Category category, String... regexes) {
+            this.category = category;
+            List<Pattern> compiled = new ArrayList<>();
+            for (String p : regexes) {
+                compiled.add(Pattern.compile(p, Pattern.CASE_INSENSITIVE));
             }
+            this.patterns = Collections.unmodifiableList(compiled);
         }
-        return null;
+
+        boolean matches(String ua) {
+            for (Pattern p : patterns) {
+                if (p.matcher(ua).find()) return true;
+            }
+            return false;
+        }
+    }
+
+    private static final List<Rule> RULES;
+
+    static {
+        List<Rule> rules = new ArrayList<>();
+        rules.add(new Rule(Category.INFRA,
+            "\\bkube-probe\\b", "\\belb-healthchecker\\b", "\\bgooglehc\\b",
+            "\\bgce-health-check\\b", "\\bconsul\\b", "\\bprometheus\\b",
+            "\\bgrafana-agent\\b", "\\bdatadog\\b", "\\bnewrelic\\b",
+            "\\bpingdom\\b", "\\buptimerobot\\b", "\\bnagios\\b",
+            "\\bzabbix\\b", "\\bcatchpoint\\b", "\\benvoy\\b",
+            "\\bistio\\b", "\\blinkerd\\b", "\\bcloudflare\\b",
+            "\\bakamai\\b", "\\bfastly\\b"
+        ));
+        rules.add(new Rule(Category.BOT,
+            "\\bgooglebot\\b", "\\bbingbot\\b", "\\bapplebot\\b",
+            "\\byandexbot\\b", "\\bduckduckbot\\b", "\\bbytespider\\b",
+            "\\bfacebookexternalhit\\b", "\\btwitterbot\\b", "\\blinkedinbot\\b",
+            "\\bslackbot\\b", "\\bdiscordbot\\b", "\\btelegrambot\\b",
+            "\\bahrefsbot\\b", "\\bsemrushbot\\b", "\\bmj12bot\\b",
+            "\\bcrawl\\b", "\\bspider\\b", "\\bslurp\\b", "\\bbot\\b"
+        ));
+        rules.add(new Rule(Category.AI_AGENT,
+            "\\blangchain\\b", "\\bllamaindex\\b", "\\blitellm\\b",
+            "\\bautogpt\\b", "\\bcrewai\\b", "\\bsemantic-kernel\\b",
+            "\\bopenai-python\\b", "\\banthropic-sdk\\b", "\\bvercel ai\\b"
+        ));
+        rules.add(new Rule(Category.MOBILE_APP,
+            "android.*okhttp", "dalvik.*okhttp", "android", "dalvik",
+            "cfnetwork.*darwin", "iphone", "ipad", "ios", "nsurlsession",
+            "\\bflutter\\b", "\\bdart/\\b", "\\breactnative\\b", "\\bexpo\\b"
+        ));
+        rules.add(new Rule(Category.BROWSER,
+            "\\bedg/\\d+", "\\bchrome/\\d+", "\\bfirefox/\\d+",
+            "\\bsafari/\\d+", "\\bopr/\\d+", "\\bchromium/\\d+"
+        ));
+        rules.add(new Rule(Category.API_CLIENT,
+            "\\bpython-requests\\b", "\\bhttpx\\b", "\\baiohttp\\b",
+            "\\burllib\\b", "\\baxios\\b", "\\bnode-fetch\\b",
+            "\\bfetch\\b", "\\bgot/\\b", "\\bcurl/\\d+", "\\bwget/\\d+",
+            "\\bgo-http-client\\b", "\\bokhttp/\\d+", "\\bapache-httpclient\\b",
+            "\\bjava/\\d+", "\\bjava-http-client\\b", "\\bpostmanruntime\\b",
+            "\\binsomnia\\b", "\\bhttpie\\b", "\\bruby\\b", "\\bphp\\b", "\\bgrpc\\b"
+        ));
+        RULES = Collections.unmodifiableList(rules);
+    }
+
+    public static Category classify(String ua) {
+        if (ua == null || ua.trim().isEmpty()) return Category.UNKNOWN;
+        String normalized = ua.toLowerCase(Locale.ROOT);
+        for (Rule rule : RULES) {
+            if (rule.matches(normalized)) return rule.category;
+        }
+        return Category.UNKNOWN;
+    }
+
+    public static String extractRefererHost(String referer) {
+        if (referer == null || referer.trim().isEmpty()) return null;
+        try {
+            String host = new URI(referer).getHost();
+            return (host != null && !host.trim().isEmpty()) ? host : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
@@ -1,0 +1,35 @@
+package com.akto.hybrid_runtime.policies;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UserAgentClassifier {
+
+    // Priority order: Infra → Bot → AI Agent → Mobile App → Browser → Service
+    // Each entry: { category, keyword1, keyword2, ... }
+    private static final List<String[]> UA_RULES = Arrays.asList(
+        new String[]{"Infra",       "kube-probe", "elb-healthchecker", "googlehc", "consul", "prometheus", "datadog", "newrelic", "pingdom", "uptimerobot", "nagios", "zabbix", "catchpoint"},
+        new String[]{"Bot",         "bot", "crawl", "spider", "slurp", "facebookexternalhit", "twitterbot", "ahrefsbot", "semrushbot", "duckduckbot", "mj12bot", "screaming frog"},
+        new String[]{"AI Agent",    "langchain", "llamaindex", "openai", "anthropic", "cohere", "huggingface", "llama", "litellm", "autogpt"},
+        new String[]{"Mobile App",  "okhttp", "alamofire", "cfnetwork", "nsurlsession", "dart/", "flutter", "reactnative", "expo", "retrofit"},
+        new String[]{"Browser",     "mozilla/", "chrome/", "firefox/", "safari/", "edge/", "opera/", "chromium/"},
+        new String[]{"Service",     "python-requests", "python-httpx", "axios", "curl/", "wget/", "go-http-client", "java/", "node-fetch", "got/", "ruby", "php", "httpie", "insomnia", "postman"}
+    );
+
+    public static String classify(String ua) {
+        if (ua == null || ua.isEmpty()) return null;
+        String lower = ua.toLowerCase();
+        for (String[] rule : UA_RULES) {
+            for (int i = 1; i < rule.length; i++) {
+                if (lower.contains(rule[i])) return rule[0];
+            }
+        }
+        return null;
+    }
+
+    public static String classifyReferer(String referer, String requestHost) {
+        if (referer == null || referer.isEmpty()) return null;
+        if (requestHost != null && referer.contains(requestHost)) return "Same-origin";
+        return "External";
+    }
+}

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
@@ -22,7 +22,7 @@ public class UserAgentClassifier {
             this.category = category;
             List<Pattern> compiled = new ArrayList<>();
             for (String p : regexes) {
-                compiled.add(Pattern.compile(p, Pattern.CASE_INSENSITIVE));
+                compiled.add(Pattern.compile(p));
             }
             this.patterns = Collections.unmodifiableList(compiled);
         }

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/policies/UserAgentClassifier.java
@@ -26,10 +26,4 @@ public class UserAgentClassifier {
         }
         return null;
     }
-
-    public static String classifyReferer(String referer, String requestHost) {
-        if (referer == null || referer.isEmpty()) return null;
-        if (requestHost != null && referer.contains(requestHost)) return "Same-origin";
-        return "External";
-    }
 }

--- a/libs/dao/src/main/java/com/akto/dto/ApiInfo.java
+++ b/libs/dao/src/main/java/com/akto/dto/ApiInfo.java
@@ -1,6 +1,7 @@
 package com.akto.dto;
 
 import com.akto.dao.context.Context;
+import com.akto.dto.traffic.CollectionTags;
 import com.akto.dto.type.URLMethods;
 import com.akto.dto.type.URLStatic;
 import com.akto.dto.type.URLTemplate;
@@ -47,6 +48,9 @@ public class ApiInfo {
 
     public static final String LAST_CALCULATED_TIME = "lastCalculatedTime";
     private int lastCalculatedTime;
+
+    public static final String TAGS_STRING = "tagsList";
+    private List<CollectionTags> tagsList;
 
     public static final String PARENT_MCP_TOOL_NAMES = "parentMcpToolNames";
     private List<String> parentMcpToolNames;
@@ -233,6 +237,22 @@ public class ApiInfo {
 
         this.apiAccessTypes.addAll(that.getApiAccessTypes());
 
+        if (that.tagsList != null && !that.tagsList.isEmpty()) {
+            if (this.tagsList == null) {
+                this.tagsList = new ArrayList<>(that.tagsList);
+            } else {
+                for (CollectionTags tag : that.tagsList) {
+                    boolean alreadyPresent = this.tagsList.stream().anyMatch(t ->
+                        Objects.equals(t.getKeyName(), tag.getKeyName()) &&
+                        Objects.equals(t.getValue(), tag.getValue())
+                    );
+                    if (!alreadyPresent) {
+                        this.tagsList.add(tag);
+                    }
+                }
+            }
+        }
+
     }
 
     public void setViolations(Map<String, Integer> violations) {
@@ -395,5 +415,13 @@ public class ApiInfo {
 
     public void setParentMcpToolNames(List<String> parentMcpToolNames) {
         this.parentMcpToolNames = parentMcpToolNames;
+    }
+
+    public List<CollectionTags> getTagsList() {
+        return tagsList;
+    }
+
+    public void setTagsList(List<CollectionTags> tagsList) {
+        this.tagsList = tagsList;
     }
 }

--- a/libs/dao/src/main/java/com/akto/dto/traffic/CollectionTags.java
+++ b/libs/dao/src/main/java/com/akto/dto/traffic/CollectionTags.java
@@ -37,7 +37,8 @@ public class CollectionTags {
 
     public enum TagSource {
         KUBERNETES, 
-        USER
+        USER,
+        AKTO
     }
 
     TagSource source;

--- a/libs/utils/src/main/java/com/akto/bulk_update_util/ApiInfoBulkUpdate.java
+++ b/libs/utils/src/main/java/com/akto/bulk_update_util/ApiInfoBulkUpdate.java
@@ -53,12 +53,12 @@ public class ApiInfoBulkUpdate {
             // last seen
             subUpdates.add(Updates.set(ApiInfo.LAST_SEEN, apiInfo.getLastSeen()));
 
-            // tagsList — user-agent categories accumulated across traffic
+            // tagsList — keyed by headerKey; $set replaces the whole array so updates to existing keyNames are applied
             List<CollectionTags> tagsList = apiInfo.getTagsList();
-            if (tagsList == null || tagsList.isEmpty()) {
-                subUpdates.add(Updates.setOnInsert(ApiInfo.TAGS_STRING, new ArrayList<>()));
+            if (tagsList != null && !tagsList.isEmpty()) {
+                subUpdates.add(Updates.set(ApiInfo.TAGS_STRING, tagsList));
             } else {
-                subUpdates.add(Updates.addEachToSet(ApiInfo.TAGS_STRING, new ArrayList<>(tagsList)));
+                subUpdates.add(Updates.setOnInsert(ApiInfo.TAGS_STRING, new ArrayList<>()));
             }
 
             subUpdates.add(Updates.setOnInsert(SingleTypeInfo._COLLECTION_IDS, Arrays.asList(apiInfo.getId().getApiCollectionId())));

--- a/libs/utils/src/main/java/com/akto/bulk_update_util/ApiInfoBulkUpdate.java
+++ b/libs/utils/src/main/java/com/akto/bulk_update_util/ApiInfoBulkUpdate.java
@@ -2,6 +2,7 @@ package com.akto.bulk_update_util;
 
 import com.akto.dao.ApiInfoDao;
 import com.akto.dto.ApiInfo;
+import com.akto.dto.traffic.CollectionTags;
 import com.akto.dto.type.SingleTypeInfo;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.UpdateOptions;
@@ -51,6 +52,14 @@ public class ApiInfoBulkUpdate {
 
             // last seen
             subUpdates.add(Updates.set(ApiInfo.LAST_SEEN, apiInfo.getLastSeen()));
+
+            // tagsList — user-agent categories accumulated across traffic
+            List<CollectionTags> tagsList = apiInfo.getTagsList();
+            if (tagsList == null || tagsList.isEmpty()) {
+                subUpdates.add(Updates.setOnInsert(ApiInfo.TAGS_STRING, new ArrayList<>()));
+            } else {
+                subUpdates.add(Updates.addEachToSet(ApiInfo.TAGS_STRING, new ArrayList<>(tagsList)));
+            }
 
             subUpdates.add(Updates.setOnInsert(SingleTypeInfo._COLLECTION_IDS, Arrays.asList(apiInfo.getId().getApiCollectionId())));
 


### PR DESCRIPTION
## Summary

Classifies \`user-agent\` and \`referer\` headers from Kafka traffic into named categories and stores them as \`tagsList\` on \`ApiInfo\` in MongoDB. Each API endpoint accumulates tags as traffic flows through it — enabling traffic source analysis (browser vs bot vs infra vs AI agent, etc).

## Flow

\`\`\`
Kafka message
  └─► SampleParser.parse()
        └─► HttpResponseParams
              └─► Main.handleResponseParams()
                    └─► HttpCallParser.syncFunction()
                          ├─► AktoPolicyNew.process()  ← per message
                          │     ├─► UserAgentClassifier.classify(ua)
                          │     │     └─► INFRA → BOT → AI_AGENT → MOBILE_APP
                          │     │               → BROWSER → API_CLIENT → UNKNOWN
                          │     ├─► UserAgentClassifier.extractRefererHost(referer)
                          │     └─► addClassifiedTag(apiInfo, keyName, value)
                          │           ├─► update value if keyName already exists
                          │           └─► append new entry if keyName is new
                          └─► APICatalogSync.syncWithDB()  ← periodic batch
                                └─► ApiInfoBulkUpdate.getUpdatesForApiInfo()
                                      └─► $set tagsList atomically
\`\`\`

## User-Agent Classification Priority

| Priority | Category | Example UAs |
|----------|----------|-------------|
| 1 | INFRA | kube-probe, prometheus, datadog, envoy |
| 2 | BOT | Googlebot, Bingbot, AhrefsBot, crawler |
| 3 | AI_AGENT | langchain, openai-python, litellm, crewai |
| 4 | MOBILE_APP | okhttp, CFNetwork, flutter, android, dart |
| 5 | BROWSER | Chrome, Firefox, Safari, Edge, Chromium |
| 6 | API_CLIENT | curl, python-requests, axios, grpc, postman |
| 7 | UNKNOWN | anything that matches no rule |

First match wins. Regex patterns are compiled once at class load (static block).

## Merge Behaviour for tagsList

- **Same \`keyName\` exists** → update \`value\` + \`lastUpdatedTs\`
- **New \`keyName\`** → append to list
- **DB write** uses \`$set\` on entire array — required because \`CollectionTags\` are objects; \`$addEachToSet\` cannot deduplicate by \`keyName\` alone
- **\`ApiInfo.merge()\`** deduplicates by \`keyName\` + \`value\` pair when merging in-memory catalogs

## Files Changed

| File | Change |
|------|--------|
| \`UserAgentClassifier.java\` | **New** — regex-based priority classifier returning \`Category\` enum; \`extractRefererHost()\` parses hostname from referer URL |
| \`AktoPolicyNew.java\` | Extracts UA + referer per request, classifies, calls \`addClassifiedTag()\` to update \`ApiInfo.tagsList\` in memory |
| \`ApiInfo.java\` | Added \`tagsList: List<CollectionTags>\` field, constant, getter/setter, merge logic |
| \`ApiInfoBulkUpdate.java\` | Writes \`tagsList\` via \`$set\` (both mini-runtime and cyborg paths) |
| \`KafkaProducerExample.java\` | Added \`referer-test\` mode and updated \`load\` mode with 10k unique hosts, 20 paths, 5 methods, randomised UA + referer |