### PR TITLE
fix: add exception logging in ExecutorNode and MongoDB indices for agent DAOs

### DIFF
--- a/libs/dao/src/main/java/com/akto/dao/agents/AgentRunDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/agents/AgentRunDao.java
@@ -1,13 +1,24 @@
 package com.akto.dao.agents;
 
 import com.akto.dao.AccountsContextDao;
+import com.akto.dao.MCollection;
 import com.akto.dto.agents.AgentRun;
 
 public class AgentRunDao extends AccountsContextDao<AgentRun> {
 
     public static final AgentRunDao instance = new AgentRunDao();
 
-    // TODO: create indices
+    public void createIndicesIfAbsent() {
+        // Index for looking up a run by its unique process id
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+                new String[]{AgentRun.PROCESS_ID}, true);
+        // Index for filtering runs by state (e.g. find all RUNNING agents)
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+                new String[]{AgentRun._STATE}, true);
+        // Index for time-based queries and sorting
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+                new String[]{AgentRun.CREATED_TIMESTAMP}, false);
+    }
 
     @Override
     public String getCollName() {

--- a/libs/dao/src/main/java/com/akto/dao/agents/AgentSubProcessSingleAttemptDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/agents/AgentSubProcessSingleAttemptDao.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.bson.conversions.Bson;
 
 import com.akto.dao.AccountsContextDao;
+import com.akto.dao.MCollection;
 import com.akto.dto.agents.AgentSubProcessSingleAttempt;
 import com.mongodb.client.model.Filters;
 
@@ -13,7 +14,19 @@ public class AgentSubProcessSingleAttemptDao extends AccountsContextDao<AgentSub
 
     public static final AgentSubProcessSingleAttemptDao instance = new AgentSubProcessSingleAttemptDao();
 
-    // TODO: create indices
+    public void createIndicesIfAbsent() {
+        // Index for fetching all attempts of a given process
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+                new String[]{AgentSubProcessSingleAttempt.PROCESS_ID}, true);
+        // Compound index for the primary lookup: process + sub-process + attempt
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+                new String[]{AgentSubProcessSingleAttempt.PROCESS_ID,
+                        AgentSubProcessSingleAttempt.SUB_PROCESS_ID,
+                        AgentSubProcessSingleAttempt.ATTEMPT_ID}, true);
+        // Index for querying by state (e.g. find all RUNNING attempts)
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+                new String[]{AgentSubProcessSingleAttempt._STATE}, true);
+    }
 
     public Bson getFiltersForAgentSubProcess(String processId, String subProcessId, int attemptId) {
         List<Bson> filters = new ArrayList<>();

--- a/libs/dao/src/main/java/com/akto/dto/test_editor/ExecutorNode.java
+++ b/libs/dao/src/main/java/com/akto/dto/test_editor/ExecutorNode.java
@@ -5,10 +5,14 @@ import java.util.Map;
 
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 
+import com.akto.log.LoggerMaker;
+import com.akto.log.LoggerMaker.LogDb;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ExecutorNode {
-    
+
+    private static final LoggerMaker logger = new LoggerMaker(ExecutorNode.class, LogDb.TESTING);
+
     private String nodeType;
     
     private List<ExecutorNode> childNodes;
@@ -67,6 +71,7 @@ public class ExecutorNode {
             Map<String,Object> mapValues = m.convertValue(this.getValues(), Map.class);
             str = (String) mapValues.get(key);
         } catch (Exception e) {
+            logger.errorAndAddToDb(e, "Error parsing ExecutorNode values as map for key: " + key);
             try {
                 List<Object> listValues = (List<Object>) this.getValues();
                 for (int i = 0; i < listValues.size(); i++) {
@@ -77,9 +82,8 @@ public class ExecutorNode {
                     }
                 }
             } catch (Exception er) {
-                // TODO: handle exception
+                logger.errorAndAddToDb(er, "Error parsing ExecutorNode values as list for key: " + key);
             }
-            // TODO: handle exception
         }
         return str;
     }


### PR DESCRIPTION
## Summary
- **ExecutorNode** (`libs/dao/.../dto/test_editor/ExecutorNode.java`): two `catch` blocks with `// TODO: handle exception` were silently swallowing parse errors. Replaced with `LoggerMaker.errorAndAddToDb` calls so failures are visible in testing logs.
- **AgentRunDao / AgentSubProcessSingleAttemptDao** (`libs/dao/.../dao/agents/`): both DAOs had `// TODO: create indices` placeholders. Implemented `createIndicesIfAbsent()` following the existing project pattern (`MCollection.createIndexIfAbsent`), covering fields already used in existing query filters.

## Changes
| File | Change |
|------|--------|
| `ExecutorNode.java` | Added `LoggerMaker` + logging in both catch blocks |
| `AgentRunDao.java` | Added `createIndicesIfAbsent()` with indices on `processId`, `state`, `createdTimestamp` |
| `AgentSubProcessSingleAttemptDao.java` | Added `createIndicesIfAbsent()` with index on `processId`, compound index on `(processId, subProcessId, attemptId)`, and index on `state` |

## Notes
- `createIndicesIfAbsent()` on both agent DAOs should be wired into the application startup routine alongside the equivalent calls on other DAOs (e.g. `AgenticTestingLogsDao`, `GuardrailsServiceLogsDao`).
- Local build was blocked by a pre-existing protobuf compatibility issue unrelated to these changes.