### PR TITLE
feat(guardrails): blocked-host policy UI (block host/path step)

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/GuardrailPoliciesAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/GuardrailPoliciesAction.java
@@ -254,6 +254,9 @@ public class GuardrailPoliciesAction extends UserAction {
         if (p.getSelectedAgentServersV2() != null) {
             updates.add(Updates.set("selectedAgentServersV2", p.getSelectedAgentServersV2()));
         }
+        if (p.getBlockedHosts() != null) {
+            updates.add(Updates.set("blockedHosts", p.getBlockedHosts()));
+        }
         if (StringUtils.isNotBlank(p.getBehaviour())) {
             updates.add(Updates.set("behaviour", p.getBehaviour()));
         }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailPolicies.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailPolicies.jsx
@@ -474,6 +474,8 @@ function GuardrailPolicies() {
                 // Add V2 fields for enhanced server data
                 selectedMcpServersV2: guardrailData.selectedMcpServersV2 || [],
                 selectedAgentServersV2: guardrailData.selectedAgentServersV2 || [],
+                // Block-only host blocklist
+                blockedHosts: guardrailData.blockedHosts || [],
                 deniedTopics: guardrailData.deniedTopics || [],
                 regexPatterns: guardrailData.regexPatterns || [],
                 // Add V2 field for enhanced regex data

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
@@ -43,6 +43,8 @@ import {
     AnomalyDetectionConfig,
     ToolsGuardrailsStep,
     ToolsGuardrailsConfig,
+    BlockedHostsStep,
+    BlockedHostsConfig,
     ServerSettingsStep,
     ServerSettingsConfig
 } from './steps';
@@ -129,6 +131,11 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
     const [enableMaliciousTools, setEnableMaliciousTools] = useState(true);
     const [enableToolNameDescriptionMismatch, setEnableToolNameDescriptionMismatch] = useState(true);
 
+    // Step 11: Blocked hosts/paths (block-only)
+    // Host + path suggestions are sourced from the browser extension configs.
+    const [blockedHosts, setBlockedHosts] = useState([]);
+    const [browserConfigs, setBrowserConfigs] = useState([]);
+
     // Step 10: Server settings
     const [applyToAllServers, setApplyToAllServers] = useState(true);
     const [selectedMcpServers, setSelectedMcpServers] = useState([]);
@@ -195,6 +202,8 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
         enableToolMisuse,
         enableMaliciousTools,
         enableToolNameDescriptionMismatch,
+        // Step 11
+        blockedHosts,
         // Step 10
         applyToAllServers,
         selectedMcpServers,
@@ -270,6 +279,16 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
             });
         }
 
+        // "Block host / path" is an internal-only step - shown for @akto.io users only.
+        if (func.isAktoUser()) {
+            steps.push({
+                number: BlockedHostsConfig.number,
+                title: BlockedHostsConfig.title,
+                summary: BlockedHostsConfig.getSummary(storedStateData),
+                ...BlockedHostsConfig.validate(storedStateData)
+            });
+        }
+
         steps.push({
             number: ServerSettingsConfig.number,
             title: ServerSettingsConfig.title,
@@ -296,6 +315,23 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
             setCollectionsLoading(false);
         }
     }, [allCollections]);
+
+    // Load browser extension configs - these supply host + path autosuggestions
+    // for the "Block host / path" step.
+    useEffect(() => {
+        let isActive = true;
+        (async () => {
+            try {
+                const response = await guardrailApi.fetchBrowserExtensionConfigs();
+                if (isActive && response?.browserExtensionConfigs) {
+                    setBrowserConfigs(response.browserExtensionConfigs);
+                }
+            } catch (error) {
+                console.error("Error fetching browser extension configs:", error);
+            }
+        })();
+        return () => { isActive = false; };
+    }, []);
 
     // Auto-scroll to bottom when new messages are added
     useEffect(() => {
@@ -415,6 +451,7 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
         setApplyToAllServers(true);
         setSelectedMcpServers([]);
         setSelectedAgentServers([]);
+        setBlockedHosts([]);
         setApplyOnResponse(false);
         setApplyOnRequest(false);
         setPolicyBehaviour(GUARDRAIL_BEHAVIOUR.BLOCK);
@@ -539,6 +576,11 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
         setApplyOnResponse(policy.applyOnResponse || false);
         setApplyOnRequest(policy.applyOnRequest || false);
         setApplyToAllServers(policy.applyToAllServers ?? true);
+
+        // Blocked hosts (block-only glob patterns: { pattern })
+        setBlockedHosts((policy.blockedHosts || []).map(entry => ({
+            pattern: entry.pattern || ""
+        })));
     };
 
     const handleClose = () => {
@@ -583,6 +625,11 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                         name: server ? server.label : serverId.toString()
                     };
                 });
+
+            // Drop empty rows and normalize the glob patterns before persisting.
+            const cleanedBlockedHosts = (blockedHosts || [])
+                .filter(entry => entry && (entry.pattern || "").trim())
+                .map(entry => ({ pattern: entry.pattern.trim() }));
 
             const b = normalizeBehaviourValue(policyBehaviour);
             const guardrailData = {
@@ -649,6 +696,7 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                 selectedAgentServers: selectedAgentServers,
                 selectedMcpServersV2: transformedMcpServers,
                 selectedAgentServersV2: transformedAgentServers,
+                blockedHosts: cleanedBlockedHosts,
                 applyOnResponse,
                 applyOnRequest,
                 ...(isEditMode && editingPolicy ? { hexId: editingPolicy.hexId } : {})
@@ -802,6 +850,21 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                         setEnableToolNameDescriptionMismatch={setEnableToolNameDescriptionMismatch}
                     />
                 );
+            case 11: {
+                // Host suggestions come from the browser extension configs.
+                const hostSuggestions = Array.from(new Set(
+                    (browserConfigs || [])
+                        .map(c => (c.host || "").trim())
+                        .filter(Boolean)
+                )).sort();
+                return (
+                    <BlockedHostsStep
+                        blockedHosts={blockedHosts}
+                        setBlockedHosts={setBlockedHosts}
+                        hostSuggestions={hostSuggestions}
+                    />
+                );
+            }
             case 10:
                 return (
                     <ServerSettingsStep
@@ -885,6 +948,9 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
             applyToAllServers: applyToAllServers,
             selectedMcpServers: selectedMcpServers,
             selectedAgentServers: selectedAgentServers,
+            blockedHosts: (blockedHosts || [])
+                .filter(entry => entry && (entry.pattern || "").trim())
+                .map(entry => ({ pattern: entry.pattern.trim() })),
             applyOnResponse: applyOnResponse,
             applyOnRequest: applyOnRequest
         };

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/BlockedHostsStep.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/BlockedHostsStep.jsx
@@ -1,0 +1,198 @@
+import { useState } from "react";
+import {
+    VerticalStack,
+    HorizontalStack,
+    Box,
+    Text,
+    Button,
+    Badge,
+    Autocomplete,
+    Icon
+} from "@shopify/polaris";
+import { DeleteMajor } from "@shopify/polaris-icons";
+
+// Entry kept as an object so it can be extended later without breaking stored data.
+// `pattern` is a glob matched against "host+path" (e.g. "chatgpt.com/*", "*/v1/chat/completions").
+const createEntry = (pattern) => ({ pattern });
+
+// Lowercase/trim and strip any scheme prefix; keep "*" and "/".
+const normalizePattern = (raw) =>
+    (raw || "").trim().toLowerCase().replace(/^https?:\/\//, "");
+
+// Host/path glob characters: letters, digits and . - _ / : ~ % plus the * wildcard.
+const PATTERN_ALLOWED = /^[a-z0-9.\-_/:~%*]+$/;
+
+// The host part (before the first "/") must be either exactly "*" (any host) or a domain whose
+// labels may contain "*" but whose final label (TLD) is concrete - so "chatgpt.com",
+// "*.openai.com", "localhost" are valid, while "*.*" (no real TLD) is not.
+const HOST_PART = /^(\*|(?:[a-z0-9*]([a-z0-9*-]*[a-z0-9*])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?)$/;
+
+// Validate a normalized pattern. Returns an error string, or "" when valid.
+const validatePattern = (p) => {
+    if (!p) {
+        return "Enter a host or path pattern";
+    }
+    if (/\s/.test(p)) {
+        return "Pattern cannot contain spaces";
+    }
+    if (!PATTERN_ALLOWED.test(p)) {
+        return "Use only letters, numbers and . - _ / : and * (wildcard)";
+    }
+    // A pattern made only of wildcards / slashes (e.g. "*", "/*", "*/*") would block everything.
+    if (/^[*/]+$/.test(p)) {
+        return "Pattern is too broad - include a host or path (e.g. chatgpt.com/*)";
+    }
+    // The host part (before the first "/") must be a real domain or "*" for any host.
+    const slash = p.indexOf("/");
+    const hostPart = slash === -1 ? p : p.slice(0, slash);
+    if (!HOST_PART.test(hostPart)) {
+        return "Host must be a domain (e.g. chatgpt.com, *.openai.com) or * for any host - not " + hostPart;
+    }
+    return "";
+};
+
+export const BlockedHostsConfig = {
+    number: 11,
+    title: "Block host / path",
+
+    validate: () => ({ isValid: true, errorMessage: null }),
+
+    getSummary: ({ blockedHosts }) => {
+        const rows = (blockedHosts || []).filter((r) => (r.pattern || "").trim());
+        if (rows.length === 0) {
+            return "";
+        }
+        const names = rows.map((r) => r.pattern.trim()).slice(0, 2).join(", ");
+        const more = rows.length > 2 ? ` +${rows.length - 2}` : "";
+        return `Blocking ${rows.length} pattern${rows.length === 1 ? "" : "s"}: ${names}${more}`;
+    }
+};
+
+const BlockedHostsStep = ({ blockedHosts, setBlockedHosts, hostSuggestions = [] }) => {
+    const entries = blockedHosts || [];
+    const [inputValue, setInputValue] = useState("");
+    const [error, setError] = useState("");
+
+    const existingPatterns = entries.map((e) => (e.pattern || "").trim().toLowerCase());
+
+    const addPattern = (value) => {
+        const p = normalizePattern(value);
+        if (!p) {
+            setInputValue("");
+            setError("");
+            return;
+        }
+        const validationError = validatePattern(p);
+        if (validationError) {
+            setError(validationError);
+            return;
+        }
+        if (existingPatterns.includes(p)) {
+            setError("This pattern is already in the block list");
+            return;
+        }
+        setBlockedHosts([...entries, createEntry(p)]);
+        setInputValue("");
+        setError("");
+    };
+
+    const removePattern = (index) => {
+        setBlockedHosts(entries.filter((_, i) => i !== index));
+    };
+
+    const handleInputChange = (value) => {
+        setInputValue(value);
+        if (error) {
+            setError("");
+        }
+    };
+
+    const options = hostSuggestions
+        .filter((h) => !existingPatterns.includes(h.toLowerCase()))
+        .filter((h) => h.toLowerCase().includes(inputValue.toLowerCase()))
+        .slice(0, 8)
+        .map((h) => ({ value: h, label: h }));
+
+    return (
+        <VerticalStack gap="5">
+            <Text variant="bodyMd" tone="subdued">
+                Block traffic by host or path pattern. Use <Text as="span" fontWeight="semibold">*</Text> as
+                a wildcard (it matches anything, including <Text as="span" fontWeight="semibold">/</Text>).
+                Examples: <Text as="span" fontWeight="semibold">chatgpt.com/*</Text> (whole host),{" "}
+                <Text as="span" fontWeight="semibold">*/v1/chat/completions</Text> (any host),{" "}
+                <Text as="span" fontWeight="semibold">deepseek.com/api/v1/*</Text> (path prefix).
+            </Text>
+
+            <Autocomplete
+                options={options}
+                selected={[]}
+                onSelect={(selected) => addPattern(selected[0])}
+                textField={
+                    <Autocomplete.TextField
+                        label="Host or path pattern"
+                        value={inputValue}
+                        onChange={handleInputChange}
+                        placeholder="e.g. chatgpt.com/*  or  */v1/chat/completions"
+                        autoComplete="off"
+                        error={error || undefined}
+                        connectedRight={
+                            <Button onClick={() => addPattern(inputValue)} disabled={!inputValue.trim()}>
+                                Add
+                            </Button>
+                        }
+                        onKeyPress={(e) => {
+                            if (e.key === "Enter") {
+                                e.preventDefault();
+                                addPattern(inputValue);
+                            }
+                        }}
+                    />
+                }
+            />
+
+            <VerticalStack gap="3">
+                <HorizontalStack gap="2" blockAlign="center">
+                    <Text variant="headingSm" as="h3">Blocked patterns</Text>
+                    {entries.length > 0 && <Badge status="critical">{`${entries.length}`}</Badge>}
+                </HorizontalStack>
+
+                {entries.length === 0 ? (
+                    <Box padding="6" borderColor="border" borderWidth="1" borderRadius="3" background="bg-subdued">
+                        <Text variant="bodySm" tone="subdued" alignment="center">
+                            No patterns blocked yet. Add a host or path pattern above to start blocking traffic.
+                        </Text>
+                    </Box>
+                ) : (
+                    <VerticalStack gap="2">
+                        {entries.map((entry, index) => (
+                            <Box
+                                key={index}
+                                paddingBlockStart="3"
+                                paddingBlockEnd="3"
+                                paddingInlineStart="4"
+                                paddingInlineEnd="3"
+                                borderColor="border"
+                                borderWidth="1"
+                                borderRadius="3"
+                                background="bg-surface"
+                            >
+                                <HorizontalStack align="space-between" blockAlign="center">
+                                    <Text variant="bodyMd" fontWeight="semibold" alignment="start">{entry.pattern}</Text>
+                                    <Button
+                                        plain
+                                        monochrome
+                                        icon={<Icon source={DeleteMajor} color="critical" />}
+                                        onClick={() => removePattern(index)}
+                                        accessibilityLabel={`Delete ${entry.pattern}`}
+                                    />
+                                </HorizontalStack>
+                            </Box>
+                        ))}
+                    </VerticalStack>
+                )}
+            </VerticalStack>
+        </VerticalStack>
+    );
+};
+
+export default BlockedHostsStep;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/index.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/index.js
@@ -8,4 +8,5 @@ export { default as CustomGuardrailsStep, CustomGuardrailsConfig } from './Custo
 export { default as UsageGuardrailsStep, UsageGuardrailsConfig } from './UsageGuardrailsStep';
 export { default as AnomalyDetectionStep, AnomalyDetectionConfig } from './AnomalyDetectionStep';
 export { default as ToolsGuardrailsStep, ToolsGuardrailsConfig } from './ToolsGuardrailsStep';
+export { default as BlockedHostsStep, BlockedHostsConfig } from './BlockedHostsStep';
 export { default as ServerSettingsStep, ServerSettingsConfig } from './ServerSettingsStep';

--- a/apps/dashboard/web/polaris_web/web/src/util/func.js
+++ b/apps/dashboard/web/polaris_web/web/src/util/func.js
@@ -2566,6 +2566,10 @@ showConfirmationModal(modalContent, primaryActionContent, primaryAction) {
         || window.USER_NAME.indexOf("@razorpay.com")>0;
     },
 
+    isAktoUser(){
+      return !!window?.USER_NAME && window.USER_NAME.toLowerCase().indexOf("@akto.io") > 0;
+    },
+
     isTempAccount(){
       if (!window?.USER_NAME) return false;
       

--- a/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
+++ b/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
@@ -79,6 +79,11 @@ public class GuardrailPolicies {
     private boolean applyOnRequest;
     private boolean applyToAllServers;
 
+    // Blocked host/path list — any traffic from a listed host is blocked outright.
+    // Modeled as objects (not bare strings) so the entry schema can be extended later
+    // (e.g. match type, per-entry behaviour) without a data migration.
+    private List<BlockedHostEntry> blockedHosts;
+
     /** Policy-wide rule behaviour: {@code "block"}, {@code "warn"}, or {@code "alert"}. */
     private String behaviour;
 
@@ -241,6 +246,28 @@ public class GuardrailPolicies {
         public SelectedServer(String id, String name) {
             this.id = id;
             this.name = name;
+        }
+    }
+
+    /**
+     * A single blocked host entry. This feature only ever blocks (no allow semantics).
+     * Each entry is a glob pattern matched against the request's {@code host + path}, where
+     * {@code *} matches any sequence of characters (including {@code /}). Examples:
+     *  - {@code "chatgpt.com"}            -> block every path on that host
+     *  - {@code "chatgpt.com/*"}          -> block all paths on chatgpt.com
+     *  - {@code "*\/v1/chat/completions"} -> block that path on any host
+     *  - {@code "deepseek.com/api/v1/*"}  -> block everything under that prefix
+     * Kept as an object (rather than a plain string) so it can be extended later without a
+     * data migration.
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class BlockedHostEntry {
+        private String pattern;
+
+        public BlockedHostEntry(String pattern) {
+            this.pattern = pattern;
         }
     }
 


### PR DESCRIPTION
Dashboard-only slice of the blocked-host guardrail feature, branched fresh from master. Adds a "Block host / path" step to the create/edit guardrail flow where users enter glob patterns (e.g. chatgpt.com/*, *.openai.com/*) that are stored on the policy's blockedHosts list.

- BlockedHostsStep.jsx: pattern input with validation (host must be a real domain or *, rejects over-broad patterns like */*)
- CreateGuardrailPage.jsx / GuardrailPolicies.jsx: wire the step in, persist and repopulate blockedHosts on edit
- GuardrailPoliciesAction.java: persist blockedHosts updates
- libs/dao GuardrailPolicies.java: BlockedHostEntry DTO (required by the action)

Backend matching (guardrails-service Go) lives on feature/guardrail-test.