### PR TITLE
new merging algo

### DIFF
--- a/apps/database-abstractor/src/main/java/com/akto/merging/Cron.java
+++ b/apps/database-abstractor/src/main/java/com/akto/merging/Cron.java
@@ -1,14 +1,20 @@
 package com.akto.merging;
 
+import com.akto.dao.ApiInfoDao;
+import com.akto.dao.SingleTypeInfoDao;
 import com.akto.dao.context.Context;
+import com.akto.dao.merging.MergeAuditLogDao;
 import com.akto.data_actor.DbLayer;
 import com.akto.dto.Account;
 import com.akto.dto.AccountSettings;
 import com.akto.dto.dependency_flow.DependencyFlow;
+import com.akto.dto.merging.MergeAuditLog;
 import com.akto.log.LoggerMaker;
 import com.akto.util.AccountTask;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Filters;
 
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -18,7 +24,7 @@ public class Cron {
 
     private static final LoggerMaker loggerMaker = new LoggerMaker(Cron.class, LoggerMaker.LogDb.CYBORG);
     private static final int PRIORITY_ACCOUNT_ID = 1736798101;
-    ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
 
     public void cron(boolean isHybridSaas) {
         scheduler.scheduleAtFixedRate(new Runnable() {
@@ -58,9 +64,20 @@ public class Cron {
             }
         }, 0, 10, TimeUnit.MINUTES);
 
+        String enableDeletion = System.getenv("ENABLE_MERGE_AUDIT_DELETION");
+        if ("true".equalsIgnoreCase(enableDeletion)) {
+            loggerMaker.warnAndAddToDb("Merge audit deletion cron enabled", LoggerMaker.LogDb.CYBORG);
+            scheduler.scheduleAtFixedRate(new Runnable() {
+                public void run() {
+                    Context.accountId.set(PRIORITY_ACCOUNT_ID);
+                    MergeAuditDeletion.runDeletion(PRIORITY_ACCOUNT_ID);
+                }
+            }, 5, 30, TimeUnit.MINUTES);
+        }
+
     }
 
-    public void triggerMerging(int accountId) {
+    public static void triggerMerging(int accountId) {
         if (!Lock.acquireLock(accountId)) {
             loggerMaker.infoAndAddToDb("Unable to acquire lock, merging process ignored for account " + accountId);
             return;
@@ -95,6 +112,106 @@ public class Cron {
             e.printStackTrace();
         }
         Lock.releaseLock(accountId);
+    }
+
+    /**
+     * Reads merge_audit_logs and prints verification stats:
+     * 1. Total unique static URLs that would be deleted
+     * 2. Deletion count per collection
+     * 3. Current unique endpoints (ApiInfo) vs post-merge count
+     * 4. Total STIs that would be deleted
+     * 5. Any static URL present in multiple audit docs (should be mergeable into only 1 template)
+     */
+    public static void verifyAuditLogs() {
+        System.out.println("=== Merge Audit Verification ===\n");
+
+        // Load all audit logs
+        MongoCursor<MergeAuditLog> cursor = MergeAuditLogDao.instance.getMCollection().find().cursor();
+        List<MergeAuditLog> allLogs = new ArrayList<>();
+        while (cursor.hasNext()) {
+            allLogs.add(cursor.next());
+        }
+        cursor.close();
+        System.out.println("Total audit log docs: " + allLogs.size());
+
+        // Track per-collection deletions and detect duplicates
+        Map<Integer, Set<String>> perCollectionDeletes = new HashMap<>();
+        // staticUrl → list of templateUrls it matched (for duplicate detection)
+        Map<String, List<String>> staticUrlToTemplates = new HashMap<>();
+
+        for (MergeAuditLog log : allLogs) {
+            int colId = log.getApiCollectionId();
+            Set<String> deletes = perCollectionDeletes.computeIfAbsent(colId, k -> new HashSet<>());
+            String templateInfo = log.getMergeType() + " | " + log.getMethod() + " " + log.getTemplateUrl();
+
+            for (String staticUrl : log.getMatchedStaticUrls()) {
+                deletes.add(staticUrl);
+                staticUrlToTemplates.computeIfAbsent(staticUrl, k -> new ArrayList<>()).add(templateInfo);
+            }
+        }
+
+        // 1. Total unique URLs to delete
+        int totalDeletes = 0;
+        for (Set<String> s : perCollectionDeletes.values()) totalDeletes += s.size();
+        System.out.println("\n--- 1. Total unique static URLs to delete: " + totalDeletes);
+
+        // 2. Per-collection deletion count
+        System.out.println("\n--- 2. Deletion count per collection:");
+        for (Map.Entry<Integer, Set<String>> entry : perCollectionDeletes.entrySet()) {
+            System.out.println("  Collection " + entry.getKey() + ": " + entry.getValue().size() + " URLs");
+        }
+
+        // 3. Current ApiInfo count vs post-merge
+        System.out.println("\n--- 3. ApiInfo count (current vs post-merge):");
+        for (int colId : perCollectionDeletes.keySet()) {
+            long currentCount = ApiInfoDao.instance.count(
+                    Filters.eq("_id.apiCollectionId", colId));
+            long postMerge = currentCount - perCollectionDeletes.get(colId).size();
+            System.out.println("  Collection " + colId + ": " + currentCount + " → " + postMerge
+                    + " (deleting " + perCollectionDeletes.get(colId).size() + " endpoints)");
+        }
+
+        // 4. Total STIs that would be deleted
+        System.out.println("\n--- 4. STI deletion count per collection:");
+        long totalStiDeletes = 0;
+        for (Map.Entry<Integer, Set<String>> entry : perCollectionDeletes.entrySet()) {
+            int colId = entry.getKey();
+            long stiCount = 0;
+            for (String staticUrl : entry.getValue()) {
+                // staticUrl is "METHOD /path" format
+                String[] parts = staticUrl.split(" ", 2);
+                if (parts.length < 2) continue;
+                stiCount += SingleTypeInfoDao.instance.count(
+                        Filters.and(
+                                Filters.eq("apiCollectionId", colId),
+                                Filters.eq("method", parts[0]),
+                                Filters.eq("url", parts[1])
+                        ));
+            }
+            totalStiDeletes += stiCount;
+            System.out.println("  Collection " + colId + ": " + stiCount + " STIs");
+        }
+        System.out.println("  Total STIs to delete: " + totalStiDeletes);
+
+        // 5. Static URLs present in multiple audit docs
+        System.out.println("\n--- 5. Static URLs matched by multiple templates:");
+        int dupeCount = 0;
+        for (Map.Entry<String, List<String>> entry : staticUrlToTemplates.entrySet()) {
+            if (entry.getValue().size() > 1) {
+                dupeCount++;
+                System.out.println("  " + entry.getKey());
+                for (String tmpl : entry.getValue()) {
+                    System.out.println("    → " + tmpl);
+                }
+            }
+        }
+        if (dupeCount == 0) {
+            System.out.println("  None — every static URL maps to exactly 1 template.");
+        } else {
+            System.out.println("  WARNING: " + dupeCount + " static URLs matched multiple templates!");
+        }
+
+        System.out.println("\n=== Verification Complete ===");
     }
 
 }

--- a/apps/database-abstractor/src/main/java/com/akto/merging/Cron.java
+++ b/apps/database-abstractor/src/main/java/com/akto/merging/Cron.java
@@ -77,7 +77,7 @@ public class Cron {
 
     }
 
-    public static void triggerMerging(int accountId) {
+    public void triggerMerging(int accountId) {
         if (!Lock.acquireLock(accountId)) {
             loggerMaker.infoAndAddToDb("Unable to acquire lock, merging process ignored for account " + accountId);
             return;

--- a/apps/database-abstractor/src/main/java/com/akto/merging/MergeAuditDeletion.java
+++ b/apps/database-abstractor/src/main/java/com/akto/merging/MergeAuditDeletion.java
@@ -1,0 +1,156 @@
+package com.akto.merging;
+
+import com.akto.dao.ApiInfoDao;
+import com.akto.dao.SampleDataDao;
+import com.akto.dao.SingleTypeInfoDao;
+import com.akto.dao.merging.MergeAuditLogDao;
+import com.akto.dto.merging.MergeAuditLog;
+import com.akto.log.LoggerMaker;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.DeleteResult;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
+
+import java.util.*;
+
+public class MergeAuditDeletion {
+
+    private static final LoggerMaker loggerMaker = new LoggerMaker(MergeAuditDeletion.class, LoggerMaker.LogDb.CYBORG);
+    private static final int BATCH_SIZE = 1000;
+
+    public static void runDeletion(int accountId) {
+        loggerMaker.infoAndAddToDb("Starting merge audit deletion for account " + accountId);
+
+        Bson incompleteFilter = Filters.or(
+                Filters.ne(MergeAuditLog.STI_DELETED, true),
+                Filters.ne(MergeAuditLog.API_INFO_DELETED, true),
+                Filters.ne(MergeAuditLog.SAMPLE_DATA_DELETED, true)
+        );
+
+        List<MergeAuditLog> batch = new ArrayList<>();
+        int totalProcessed = 0;
+
+        try (MongoCursor<MergeAuditLog> cursor = MergeAuditLogDao.instance.getMCollection()
+                .find(incompleteFilter).cursor()) {
+
+            while (cursor.hasNext()) {
+                batch.add(cursor.next());
+
+                if (batch.size() >= BATCH_SIZE) {
+                    totalProcessed += processBatch(batch);
+                    batch.clear();
+                }
+            }
+
+            if (!batch.isEmpty()) {
+                totalProcessed += processBatch(batch);
+            }
+        }
+
+        loggerMaker.infoAndAddToDb("Merge audit deletion complete for account " + accountId
+                + ", processed " + totalProcessed + " docs");
+    }
+
+    private static int processBatch(List<MergeAuditLog> batch) {
+        // Group URLs by (apiCollectionId, method) for efficient $in deletes
+        Map<String, GroupedUrls> groups = new HashMap<>();
+        List<ObjectId> allDocIds = new ArrayList<>(batch.size());
+
+        for (MergeAuditLog doc : batch) {
+            if (doc.getId() != null) allDocIds.add(doc.getId());
+            if (doc.getMatchedStaticUrls() == null || doc.getMatchedStaticUrls().isEmpty()) continue;
+
+            for (String staticUrl : doc.getMatchedStaticUrls()) {
+                String[] parts = staticUrl.split(" ", 2);
+                if (parts.length < 2) continue;
+
+                String groupKey = doc.getApiCollectionId() + "|" + parts[0];
+                groups.computeIfAbsent(groupKey, k -> new GroupedUrls(doc.getApiCollectionId(), parts[0]))
+                        .urls.add(parts[1]);
+            }
+        }
+
+        // Delete one entity type at a time across all groups, then bulk-mark the boolean
+        boolean stiOk = deleteAllGroups(groups, EntityType.STI);
+        boolean apiInfoOk = deleteAllGroups(groups, EntityType.API_INFO);
+        boolean sampleDataOk = deleteAllGroups(groups, EntityType.SAMPLE_DATA);
+
+        // One updateMany per entity type for the entire batch
+        bulkMarkDeleted(allDocIds, stiOk, apiInfoOk, sampleDataOk);
+
+        return batch.size();
+    }
+
+    private enum EntityType { STI, API_INFO, SAMPLE_DATA }
+
+    private static boolean deleteAllGroups(Map<String, GroupedUrls> groups, EntityType type) {
+        boolean allOk = true;
+        for (GroupedUrls group : groups.values()) {
+            try {
+                Bson filter;
+                DeleteResult result;
+                switch (type) {
+                    case STI:
+                        filter = Filters.and(
+                                Filters.eq("apiCollectionId", group.apiCollectionId),
+                                Filters.eq("method", group.method),
+                                Filters.in("url", group.urls));
+                        result = SingleTypeInfoDao.instance.deleteAll(filter);
+                        break;
+                    case API_INFO:
+                        filter = Filters.and(
+                                Filters.eq("_id.apiCollectionId", group.apiCollectionId),
+                                Filters.eq("_id.method", group.method),
+                                Filters.in("_id.url", group.urls));
+                        result = ApiInfoDao.instance.deleteAll(filter);
+                        break;
+                    case SAMPLE_DATA:
+                        filter = Filters.and(
+                                Filters.eq("_id.apiCollectionId", group.apiCollectionId),
+                                Filters.eq("_id.method", group.method),
+                                Filters.in("_id.url", group.urls));
+                        result = SampleDataDao.instance.deleteAll(filter);
+                        break;
+                    default:
+                        continue;
+                }
+                loggerMaker.infoAndAddToDb(type + " deleted " + result.getDeletedCount()
+                        + " for col=" + group.apiCollectionId + " method=" + group.method);
+            } catch (Exception e) {
+                allOk = false;
+                loggerMaker.errorAndAddToDb("Error deleting " + type + " for col=" + group.apiCollectionId
+                        + " method=" + group.method + ": " + e.getMessage(), LoggerMaker.LogDb.CYBORG);
+            }
+        }
+        return allOk;
+    }
+
+    private static void bulkMarkDeleted(List<ObjectId> docIds, boolean stiOk, boolean apiInfoOk, boolean sampleDataOk) {
+        if (docIds.isEmpty()) return;
+        Bson idFilter = Filters.in("_id", docIds);
+        try {
+            List<Bson> updates = new ArrayList<>();
+            if (stiOk) updates.add(Updates.set(MergeAuditLog.STI_DELETED, true));
+            if (apiInfoOk) updates.add(Updates.set(MergeAuditLog.API_INFO_DELETED, true));
+            if (sampleDataOk) updates.add(Updates.set(MergeAuditLog.SAMPLE_DATA_DELETED, true));
+            if (!updates.isEmpty()) {
+                MergeAuditLogDao.instance.updateMany(idFilter, Updates.combine(updates));
+            }
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("Error bulk-marking audit docs: " + e.getMessage(), LoggerMaker.LogDb.CYBORG);
+        }
+    }
+
+    private static class GroupedUrls {
+        final int apiCollectionId;
+        final String method;
+        final List<String> urls = new ArrayList<>();
+
+        GroupedUrls(int apiCollectionId, String method) {
+            this.apiCollectionId = apiCollectionId;
+            this.method = method;
+        }
+    }
+}

--- a/apps/database-abstractor/src/main/java/com/akto/merging/MergingLogic.java
+++ b/apps/database-abstractor/src/main/java/com/akto/merging/MergingLogic.java
@@ -1,6 +1,8 @@
 package com.akto.merging;
 
 import com.akto.dao.ApiCollectionsDao;
+import com.akto.dao.merging.MergeAuditLogDao;
+import com.akto.dto.merging.MergeAuditLog;
 import com.akto.dao.ApiInfoDao;
 import com.akto.dao.filter.MergedUrlsDao;
 import com.akto.dto.filter.MergedUrls;
@@ -37,7 +39,6 @@ public class MergingLogic {
     private static final LoggerMaker loggerMaker = new LoggerMaker(MergingLogic.class, LogDb.DB_ABS);
     private static final int OPTIMIZED_MERGING_ACCOUNT_ID = 1736798101;
 
-    private static final int MAX_WILDCARD_POSITIONS = 2;
     private static final boolean shouldUseOptimizedMerging = "true".equalsIgnoreCase(System.getenv("USE_OPTIMIZED_MERGING"));
 
     private static Set<MergedUrls> mergedUrls = new HashSet<>();
@@ -52,7 +53,7 @@ public class MergingLogic {
         }
     }
 
-    private static boolean isDemergedUrl(URLTemplate urlTemplate, int apiCollectionId) {
+    static boolean isDemergedUrl(URLTemplate urlTemplate, int apiCollectionId) {
         try {
             for (MergedUrls mergedUrl : mergedUrls) {
                 if (mergedUrl.getApiCollectionId() == apiCollectionId &&
@@ -104,6 +105,12 @@ public class MergingLogic {
         }
 
 
+        // Optimized account: write audit logs and skip actual deletions
+        if (isOptimizedMergingAccount()) {
+            saveAuditLogs(result, apiCollectionId);
+            return;
+        }
+
         ArrayList<WriteModel<SingleTypeInfo>> bulkUpdatesForSti = new ArrayList<>();
         ArrayList<WriteModel<SampleData>> bulkUpdatesForSampleData = new ArrayList<>();
         ArrayList<WriteModel<ApiInfo>> bulkUpdatesForApiInfo = new ArrayList<>();
@@ -111,6 +118,7 @@ public class MergingLogic {
         for (URLTemplate urlTemplate: result.templateToStaticURLs.keySet()) {
             Set<String> matchStaticURLs = result.templateToStaticURLs.get(urlTemplate);
             String newTemplateUrl = urlTemplate.getTemplateString();
+            if (!newTemplateUrl.startsWith("/") && !newTemplateUrl.startsWith("http")) newTemplateUrl = "/" + newTemplateUrl;
             if (!APICatalog.isTemplateUrl(newTemplateUrl)) continue;
 
             boolean isFirst = true;
@@ -292,6 +300,9 @@ public class MergingLogic {
         int offset = 0;
         int limit = optimized ? 150_000 : (mergeUrlsBasic ? 10_000 : 50_000);
 
+        // Load already-audited static URLs so we skip them (optimized dry-run only)
+        Set<String> alreadyAudited = optimized ? loadAuditedUrls(apiCollectionId) : Collections.emptySet();
+
         List<SingleTypeInfo> singleTypeInfos = new ArrayList<>();
         ApiMergerResult finalResult = new ApiMergerResult(new HashMap<>());
         do {
@@ -334,10 +345,25 @@ public class MergingLogic {
             }
 
             if (optimized) {
-                // Optimized: indexed template-to-static matching, skip static-to-static
-                Set<String> matched = optimizedTemplateToStaticMatch(templateUrls, staticUrlToSti, apiCollectionId);
-                finalResult.deleteStaticUrls.addAll(matched);
-                loggerMaker.infoAndAddToDb("optimized merging matched " + matched.size() + " static urls for collection " + apiCollectionId, LogDb.DB_ABS);
+                // Skip URLs already audited in a previous run
+                if (!alreadyAudited.isEmpty()) {
+                    staticUrlToSti.keySet().removeAll(alreadyAudited);
+                }
+
+                // Template-to-static: indexed matching against existing templates
+                optimizedTemplateToStaticMatch(templateUrls, staticUrlToSti, apiCollectionId, finalResult);
+
+                // Remove matched URLs before static-to-static
+                for (String m : finalResult.deleteStaticUrls) staticUrlToSti.remove(m);
+
+                // Static-to-static: discover new templates (Tier 1 + Tier 2)
+                ApiMergerResult staticResult = OptimizedMerger.mergeStaticUrls(
+                        staticUrlToSti.keySet(), allowStringMerging, allowMergingOnVersions, apiCollectionId);
+                finalResult.templateToStaticURLs.putAll(staticResult.templateToStaticURLs);
+
+                loggerMaker.infoAndAddToDb("optimized merging: template-to-static=" + finalResult.deleteStaticUrls.size()
+                        + " new-templates=" + staticResult.templateToStaticURLs.size()
+                        + " for collection " + apiCollectionId, LogDb.DB_ABS);
             } else {
                 // Original: brute force template-to-static + static-to-static
                 Iterator<String> iterator = staticUrlToSti.keySet().iterator();
@@ -745,8 +771,7 @@ public class MergingLogic {
     }
 
     /**
-     * Build a lookup key directly from method, tokenCount, and tokens array,
-     * skipping positions in the skipSet. Positions are iterated in order so no sorting needed.
+     * Build a lookup key from method, tokenCount, and tokens array, skipping given positions.
      */
     static String buildKeyDirect(String method, int tokenCount, String[] tokens, int skip1, int skip2) {
         StringBuilder sb = new StringBuilder(method.length() + tokenCount * 10);
@@ -758,11 +783,34 @@ public class MergingLogic {
         return sb.toString();
     }
 
+    /** Encodes wildcard positions as a single long: pos1 in lower 32 bits, pos2 in upper 32 (or -1). */
+    private static long encodeWildcardPair(int pos1, int pos2) {
+        return ((long) pos2 << 32) | (pos1 & 0xFFFFFFFFL);
+    }
+
+    /**
+     * Result of buildTemplateIndex: the key→template index plus a secondary index
+     * of method|tokenCount → set of actual wildcard position combos from templates.
+     */
+    static class TemplateIndexResult {
+        final Map<String, List<URLTemplate>> index;
+        // method|tokenCount → set of encoded wildcard position pairs
+        final Map<String, Set<Long>> wildcardPositions;
+
+        TemplateIndexResult(Map<String, List<URLTemplate>> index, Map<String, Set<Long>> wildcardPositions) {
+            this.index = index;
+            this.wildcardPositions = wildcardPositions;
+        }
+    }
+
     /**
      * Index templates by their fixed token positions for O(1) lookup.
+     * Also builds a secondary index of which wildcard positions exist per method|tokenCount.
      */
-    static Map<String, List<URLTemplate>> buildTemplateIndex(List<String> templateUrls) {
+    static TemplateIndexResult buildTemplateIndex(List<String> templateUrls) {
         Map<String, List<URLTemplate>> index = new HashMap<>();
+        Map<String, Set<Long>> wildcardPositions = new HashMap<>();
+        Set<String> seen = new HashSet<>();
 
         for (String templateURL : templateUrls) {
             if (templateURL == null || templateURL.isEmpty() || !templateURL.contains(" ")) continue;
@@ -773,7 +821,16 @@ public class MergingLogic {
             if (endpoint.contains("//") || endpoint.isEmpty()) continue;
 
             URLTemplate urlTemplate = createUrlTemplate(endpoint, method);
+
+            // Deduplicate: "/v1/foo/STRING" and "v1/foo/STRING" produce the same URLTemplate
+            if (!seen.add(method.name() + " " + urlTemplate.getTemplateString())) continue;
+
             String[] tokens = urlTemplate.getTokens();
+
+            // Skip templates where all tokens are wildcards (e.g. STRING/STRING)
+            boolean hasLiteral = false;
+            for (String t : tokens) { if (t != null) { hasLiteral = true; break; } }
+            if (!hasLiteral) continue;
 
             // Build key using only fixed (non-null) token positions
             StringBuilder sb = new StringBuilder(method.name().length() + tokens.length * 10);
@@ -785,54 +842,37 @@ public class MergingLogic {
             }
 
             index.computeIfAbsent(sb.toString(), k -> new ArrayList<>()).add(urlTemplate);
-        }
 
-        return index;
-    }
-
-    /**
-     * Generate all candidate keys for a static URL by skipping up to maxWildcards positions.
-     * Uses direct StringBuilder — no HashMap or sorting overhead.
-     */
-    static List<String> generateCandidateKeys(String method, String[] tokens, int maxWildcards) {
-        int n = tokens.length;
-        // Pre-calculate capacity: 1 + n + C(n,2) for maxWildcards=2
-        int capacity = 1 + (maxWildcards >= 1 ? n : 0) + (maxWildcards >= 2 ? n * (n - 1) / 2 : 0);
-        List<String> keys = new ArrayList<>(capacity);
-
-        // 0 wildcards: skip nothing (-1 means no skip)
-        keys.add(buildKeyDirect(method, n, tokens, -1, -1));
-
-        // 1 wildcard: skip each position once
-        if (maxWildcards >= 1) {
-            for (int skip = 0; skip < n; skip++) {
-                keys.add(buildKeyDirect(method, n, tokens, skip, -1));
-            }
-        }
-
-        // 2 wildcards: skip each pair of positions
-        if (maxWildcards >= 2) {
-            for (int s1 = 0; s1 < n; s1++) {
-                for (int s2 = s1 + 1; s2 < n; s2++) {
-                    keys.add(buildKeyDirect(method, n, tokens, s1, s2));
+            // Record wildcard positions for this method|tokenCount
+            String bucketKey = method.name() + "|" + tokens.length;
+            int w1 = -1, w2 = -1;
+            for (int i = 0; i < tokens.length; i++) {
+                if (tokens[i] == null) {
+                    if (w1 == -1) w1 = i;
+                    else if (w2 == -1) w2 = i;
                 }
             }
+            wildcardPositions.computeIfAbsent(bucketKey, k -> new HashSet<>())
+                    .add(encodeWildcardPair(w1, w2));
         }
 
-        return keys;
+        return new TemplateIndexResult(index, wildcardPositions);
     }
 
     /**
      * Optimized template-to-static matching using indexed lookup.
-     * Returns the set of static URLs that matched a template (to be deleted).
+     * Only generates candidate keys for wildcard positions that actually exist in templates.
+     * Populates result.deleteStaticUrls and result.existingTemplateMatches.
      */
-    static Set<String> optimizedTemplateToStaticMatch(
+    static void optimizedTemplateToStaticMatch(
             List<String> templateUrls,
             Map<String, Set<String>> staticUrlToSti,
-            int apiCollectionId) {
+            int apiCollectionId,
+            ApiMergerResult result) {
 
-        Map<String, List<URLTemplate>> index = buildTemplateIndex(templateUrls);
-        Set<String> matched = new HashSet<>();
+        TemplateIndexResult tir = buildTemplateIndex(templateUrls);
+        Map<String, List<URLTemplate>> index = tir.index;
+        Map<String, Set<Long>> wildcardPositions = tir.wildcardPositions;
 
         for (String staticURL : staticUrlToSti.keySet()) {
             if (staticURL == null || staticURL.isEmpty() || !staticURL.contains(" ")) continue;
@@ -848,15 +888,25 @@ public class MergingLogic {
             if (normalized.endsWith("/")) normalized = normalized.substring(0, normalized.length() - 1);
             String[] tokens = normalized.split("/");
 
-            List<String> candidateKeys = generateCandidateKeys(method, tokens, MAX_WILDCARD_POSITIONS);
+            String bucketKey = method + "|" + tokens.length;
+            Set<Long> positions = wildcardPositions.get(bucketKey);
+            if (positions == null) continue; // no template with this method|tokenCount
+
             boolean found = false;
-            for (String key : candidateKeys) {
+            for (long encoded : positions) {
+                int skip1 = (int) (encoded & 0xFFFFFFFFL);
+                int skip2 = (int) (encoded >>> 32);
+                String key = buildKeyDirect(method, tokens.length, tokens, skip1, skip2);
                 List<URLTemplate> candidates = index.get(key);
                 if (candidates == null) continue;
                 for (URLTemplate tmpl : candidates) {
                     if (tmpl.match(endpoint, URLMethods.Method.fromString(method))) {
                         if (!isDemergedUrl(tmpl, apiCollectionId)) {
-                            matched.add(staticURL);
+                            result.deleteStaticUrls.add(staticURL);
+                            String tplKey = tmpl.getMethod().name() + " " + tmpl.getTemplateString();
+                            result.existingTemplateMatches
+                                    .computeIfAbsent(tplKey, k -> new HashSet<>())
+                                    .add(staticURL);
                         }
                         found = true;
                         break;
@@ -865,13 +915,60 @@ public class MergingLogic {
                 if (found) break;
             }
         }
+    }
 
-        return matched;
+    private static Set<String> loadAuditedUrls(int apiCollectionId) {
+        try {
+            Set<String> audited = MergeAuditLogDao.instance.getAuditedStaticUrls(apiCollectionId);
+            loggerMaker.infoAndAddToDb("Loaded " + audited.size() + " already-audited URLs for collection "
+                    + apiCollectionId, LogDb.DB_ABS);
+            return audited;
+        } catch (Exception e) {
+            loggerMaker.warnAndAddToDb("Error loading audited URLs: " + e.getMessage(), LogDb.DB_ABS);
+            return Collections.emptySet();
+        }
+    }
+
+    private static void saveAuditLogs(ApiMergerResult result, int apiCollectionId) {
+        int now = Context.now();
+        List<MergeAuditLog> logs = new ArrayList<>();
+
+        // Template-to-static: existing templates that absorbed static URLs
+        for (Map.Entry<String, Set<String>> entry : result.existingTemplateMatches.entrySet()) {
+            String[] parts = entry.getKey().split(" ", 2);
+            logs.add(new MergeAuditLog(apiCollectionId, "TEMPLATE_TO_STATIC",
+                    parts.length > 1 ? parts[1] : parts[0],
+                    parts[0],
+                    new ArrayList<>(entry.getValue()), now));
+        }
+
+        // Static-to-static: newly discovered templates
+        for (Map.Entry<URLTemplate, Set<String>> entry : result.templateToStaticURLs.entrySet()) {
+            URLTemplate tpl = entry.getKey();
+            String tplUrl = tpl.getTemplateString();
+            if (!tplUrl.startsWith("/") && !tplUrl.startsWith("http")) tplUrl = "/" + tplUrl;
+            logs.add(new MergeAuditLog(apiCollectionId, "STATIC_TO_STATIC",
+                    tplUrl,
+                    tpl.getMethod().name(),
+                    new ArrayList<>(entry.getValue()), now));
+        }
+
+        if (!logs.isEmpty()) {
+            try {
+                MergeAuditLogDao.instance.insertMany(logs);
+                loggerMaker.infoAndAddToDb("Saved " + logs.size() + " merge audit logs for collection "
+                        + apiCollectionId, LogDb.DB_ABS);
+            } catch (Exception e) {
+                loggerMaker.warnAndAddToDb("Error saving merge audit logs: " + e.getMessage(), LogDb.DB_ABS);
+            }
+        }
     }
 
     static class ApiMergerResult {
         public Set<String> deleteStaticUrls = new HashSet<>();
         Map<URLTemplate, Set<String>> templateToStaticURLs = new HashMap<>();
+        /** Existing template URL string → set of matched static URLs (populated only in optimized path). */
+        Map<String, Set<String>> existingTemplateMatches = new HashMap<>();
 
         public ApiMergerResult(Map<URLTemplate, Set<String>> templateToSti) {
             this.templateToStaticURLs = templateToSti;

--- a/apps/database-abstractor/src/main/java/com/akto/merging/OptimizedMerger.java
+++ b/apps/database-abstractor/src/main/java/com/akto/merging/OptimizedMerger.java
@@ -1,0 +1,294 @@
+package com.akto.merging;
+
+import com.akto.dto.type.SingleTypeInfo;
+import com.akto.dto.type.URLMethods;
+import com.akto.dto.type.URLTemplate;
+import com.akto.log.LoggerMaker;
+import com.akto.log.LoggerMaker.LogDb;
+import com.akto.util.filter.DictionaryFilter;
+import org.apache.commons.lang3.math.NumberUtils;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static com.akto.dto.type.KeyTypes.patternToSubType;
+import static com.akto.runtime.RuntimeUtil.isAlphanumericString;
+import static com.akto.runtime.RuntimeUtil.isValidLocaleToken;
+import static com.akto.runtime.RuntimeUtil.isValidVersionToken;
+
+/**
+ * O(n * tokenLength) static-to-static URL merging replacing O(n^2) brute force.
+ *
+ * Tier 1 — Signature grouping: tag free-merge tokens (INT/UUID/VER/LOC),
+ *          keep ALNUM/OPAQUE/literals as-is. Same sig = same bucket = instant merge.
+ *
+ * Tier 2 — Skip-1 grouping: for remaining singletons, skip one ALNUM/OPAQUE position
+ *          and tag it. Handles exactly-one opaque-string diff + any typed diffs.
+ *
+ * Absorption — remaining URLs matched against newly discovered templates.
+ */
+class OptimizedMerger {
+
+    private static final LoggerMaker loggerMaker = new LoggerMaker(OptimizedMerger.class, LogDb.DB_ABS);
+    private static final Pattern UUID_PATTERN = patternToSubType.get(SingleTypeInfo.UUID);
+
+    // ---- Token classification ----
+
+    enum TokenTag { INT, UUID, VER, LOC, ALNUM, OPAQUE }
+
+    /**
+     * Classify a token. Returns null for literals (English words or
+     * tokens that can't merge given the flags).
+     * Priority mirrors tryMergeUrls: English > numeric > UUID > version > locale > alphanumeric > opaque.
+     */
+    static TokenTag classifyToken(String token, boolean allowStringMerging, boolean allowMergingOnVersions) {
+        if (DictionaryFilter.isEnglishWord(token)) return null;
+        if (NumberUtils.isParsable(token)) return TokenTag.INT;
+        if (allowStringMerging && UUID_PATTERN.matcher(token).matches()) return TokenTag.UUID;
+        if (allowMergingOnVersions && isValidVersionToken(token)) return TokenTag.VER;
+        if (isValidLocaleToken(token)) return TokenTag.LOC;
+        if (allowStringMerging && isAlphanumericString(token)) return TokenTag.ALNUM;
+        if (token.equalsIgnoreCase("api")) return null;
+        if (allowStringMerging) return TokenTag.OPAQUE;
+        return null;
+    }
+
+    /** INT/UUID/VER/LOC don't increment templatizedStrTokens in tryMergeUrls. */
+    private static boolean isFreeMergeTag(TokenTag tag) {
+        return tag == TokenTag.INT || tag == TokenTag.UUID
+                || tag == TokenTag.VER || tag == TokenTag.LOC;
+    }
+
+    private static SingleTypeInfo.SuperType tagToSuperType(TokenTag tag) {
+        switch (tag) {
+            case INT: return SingleTypeInfo.SuperType.INTEGER;
+            case VER: return SingleTypeInfo.SuperType.VERSIONED;
+            case LOC: return SingleTypeInfo.SuperType.LOCALE;
+            default:  return SingleTypeInfo.SuperType.STRING; // UUID, ALNUM, OPAQUE
+        }
+    }
+
+    // ---- Parsed URL ----
+
+    static class ParsedUrl {
+        final String key;       // "GET /api/users/123"
+        final String method;
+        final String[] tokens;  // ["api", "users", "123"]
+        final TokenTag[] tags;  // [null,  null,    INT]
+
+        ParsedUrl(String key, String method, String[] tokens, TokenTag[] tags) {
+            this.key = key;
+            this.method = method;
+            this.tokens = tokens;
+            this.tags = tags;
+        }
+    }
+
+    static List<ParsedUrl> parseUrls(Set<String> urls, boolean allowStringMerging, boolean allowMergingOnVersions) {
+        List<ParsedUrl> result = new ArrayList<>(urls.size());
+        for (String key : urls) {
+            if (key == null || key.isEmpty() || !key.contains(" ")) continue;
+            String[] parts = key.split(" ", 2);
+            if (parts.length < 2 || parts[1].isEmpty() || parts[1].contains("//")) continue;
+            String[] tokens = MergingLogic.tokenize(parts[1]);
+            if (tokens.length <= 1) continue;
+
+            TokenTag[] tags = new TokenTag[tokens.length];
+            for (int i = 0; i < tokens.length; i++) {
+                tags[i] = classifyToken(tokens[i], allowStringMerging, allowMergingOnVersions);
+            }
+            result.add(new ParsedUrl(key, parts[0], tokens, tags));
+        }
+        return result;
+    }
+
+    // ---- Tier 1: signature grouping ----
+
+    /**
+     * Free-merge tags → "#TAG", everything else → literal value.
+     * Example: "GET|4|api|#INT|users|profile"
+     */
+    static String buildTier1Signature(ParsedUrl url) {
+        StringBuilder sb = new StringBuilder(url.method.length() + url.tokens.length * 8);
+        sb.append(url.method).append('|').append(url.tokens.length);
+        for (int i = 0; i < url.tokens.length; i++) {
+            sb.append('|');
+            if (isFreeMergeTag(url.tags[i])) {
+                sb.append('#').append(url.tags[i].name());
+            } else {
+                sb.append(url.tokens[i]);
+            }
+        }
+        return sb.toString();
+    }
+
+    static URLTemplate buildTier1Template(ParsedUrl representative) {
+        int len = representative.tokens.length;
+        String[] tplTokens = new String[len];
+        SingleTypeInfo.SuperType[] types = new SingleTypeInfo.SuperType[len];
+        for (int i = 0; i < len; i++) {
+            if (isFreeMergeTag(representative.tags[i])) {
+                types[i] = tagToSuperType(representative.tags[i]);
+            } else {
+                tplTokens[i] = representative.tokens[i];
+            }
+        }
+        return new URLTemplate(tplTokens, types, URLMethods.Method.fromString(representative.method));
+    }
+
+    // ---- Tier 2: skip-1 key grouping ----
+
+    /**
+     * Skip one ALNUM/OPAQUE position → tag it. Free-merge positions → tagged.
+     * Rest → literal. Encodes skipPos to prevent cross-position collisions.
+     */
+    static String buildTier2Key(ParsedUrl url, int skipPos) {
+        if (url.tags[skipPos] == null) return null;
+        StringBuilder sb = new StringBuilder(url.method.length() + url.tokens.length * 8 + 10);
+        sb.append(url.method).append('|').append(url.tokens.length).append("|skip=").append(skipPos);
+        for (int i = 0; i < url.tokens.length; i++) {
+            sb.append('|');
+            if (i == skipPos) {
+                sb.append('#').append(url.tags[i].name());
+            } else if (isFreeMergeTag(url.tags[i])) {
+                sb.append('#').append(url.tags[i].name());
+            } else {
+                sb.append(url.tokens[i]);
+            }
+        }
+        return sb.toString();
+    }
+
+    static URLTemplate buildTier2Template(ParsedUrl representative, int skipPos) {
+        int len = representative.tokens.length;
+        String[] tplTokens = new String[len];
+        SingleTypeInfo.SuperType[] types = new SingleTypeInfo.SuperType[len];
+        for (int i = 0; i < len; i++) {
+            if (i == skipPos || isFreeMergeTag(representative.tags[i])) {
+                types[i] = tagToSuperType(representative.tags[i]);
+            } else {
+                tplTokens[i] = representative.tokens[i];
+            }
+        }
+        return new URLTemplate(tplTokens, types, URLMethods.Method.fromString(representative.method));
+    }
+
+    /** ALNUM → instant (≥2 URLs). OPAQUE → body match (≥11 URLs). */
+    private static int tier2Threshold(TokenTag skipTag) {
+        return skipTag == TokenTag.OPAQUE ? MergingLogic.STRING_MERGING_THRESHOLD + 1 : 2;
+    }
+
+    // ---- Main entry ----
+
+    static MergingLogic.ApiMergerResult mergeStaticUrls(
+            Set<String> staticUrls,
+            boolean allowStringMerging,
+            boolean allowMergingOnVersions,
+            int apiCollectionId) {
+
+        Map<URLTemplate, Set<String>> result = new HashMap<>();
+        List<ParsedUrl> allUrls = parseUrls(staticUrls, allowStringMerging, allowMergingOnVersions);
+
+        if (allUrls.size() < 2) {
+            return new MergingLogic.ApiMergerResult(result);
+        }
+
+        Set<String> consumed = new HashSet<>();
+
+        // Group by token count
+        Map<Integer, List<ParsedUrl>> byTokenCount = new HashMap<>();
+        for (ParsedUrl url : allUrls) {
+            byTokenCount.computeIfAbsent(url.tokens.length, k -> new ArrayList<>()).add(url);
+        }
+
+        for (List<ParsedUrl> group : byTokenCount.values()) {
+            runTier1(group, result, consumed, apiCollectionId);
+
+            List<ParsedUrl> remaining = new ArrayList<>();
+            for (ParsedUrl u : group) {
+                if (!consumed.contains(u.key)) remaining.add(u);
+            }
+            runTier2(remaining, result, consumed, apiCollectionId);
+        }
+
+        loggerMaker.infoAndAddToDb("OptimizedMerger: " + result.size() + " new templates, "
+                + consumed.size() + " URLs consumed for collection " + apiCollectionId, LogDb.DB_ABS);
+
+        return new MergingLogic.ApiMergerResult(result);
+    }
+
+    private static void runTier1(
+            List<ParsedUrl> group,
+            Map<URLTemplate, Set<String>> result,
+            Set<String> consumed,
+            int apiCollectionId) {
+
+        Map<String, List<ParsedUrl>> buckets = new HashMap<>();
+        for (ParsedUrl url : group) {
+            buckets.computeIfAbsent(buildTier1Signature(url), k -> new ArrayList<>()).add(url);
+        }
+
+        for (List<ParsedUrl> bucket : buckets.values()) {
+            if (bucket.size() < 2) continue;
+            URLTemplate template = buildTier1Template(bucket.get(0));
+            if (!hasAnyType(template)) continue;
+            if (MergingLogic.isDemergedUrl(template, apiCollectionId)) continue;
+
+            Set<String> urlSet = new HashSet<>();
+            for (ParsedUrl u : bucket) urlSet.add(u.key);
+            result.computeIfAbsent(template, k -> new HashSet<>()).addAll(urlSet);
+            consumed.addAll(urlSet);
+        }
+    }
+
+    private static void runTier2(
+            List<ParsedUrl> remaining,
+            Map<URLTemplate, Set<String>> result,
+            Set<String> consumed,
+            int apiCollectionId) {
+
+        if (remaining.size() < 2) return;
+
+        Map<String, List<ParsedUrl>> buckets = new HashMap<>();
+        Map<String, Integer> skipPosMap = new HashMap<>();
+
+        for (ParsedUrl url : remaining) {
+            for (int i = 0; i < url.tokens.length; i++) {
+                if (url.tags[i] != TokenTag.ALNUM && url.tags[i] != TokenTag.OPAQUE) continue;
+                String key = buildTier2Key(url, i);
+                if (key == null) continue;
+                buckets.computeIfAbsent(key, k -> new ArrayList<>()).add(url);
+                skipPosMap.putIfAbsent(key, i);
+            }
+        }
+
+        for (Map.Entry<String, List<ParsedUrl>> entry : buckets.entrySet()) {
+            List<ParsedUrl> bucket = entry.getValue();
+            bucket.removeIf(u -> consumed.contains(u.key));
+            if (bucket.size() < 2) continue;
+
+            int skipPos = skipPosMap.get(entry.getKey());
+            TokenTag skipTag = bucket.get(0).tags[skipPos];
+
+            int threshold = tier2Threshold(skipTag);
+            if (bucket.size() < threshold) continue;
+            if (skipTag == TokenTag.OPAQUE) continue; // needs body match — conservative skip
+
+            URLTemplate template = buildTier2Template(bucket.get(0), skipPos);
+            if (!hasAnyType(template)) continue;
+            if (MergingLogic.isDemergedUrl(template, apiCollectionId)) continue;
+
+            Set<String> urlSet = new HashSet<>();
+            for (ParsedUrl u : bucket) urlSet.add(u.key);
+            result.computeIfAbsent(template, k -> new HashSet<>()).addAll(urlSet);
+            consumed.addAll(urlSet);
+        }
+    }
+
+    private static boolean hasAnyType(URLTemplate template) {
+        for (SingleTypeInfo.SuperType t : template.getTypes()) {
+            if (t != null) return true;
+        }
+        return false;
+    }
+}

--- a/apps/database-abstractor/src/test/java/com/akto/merging/TestOptimizedMerger.java
+++ b/apps/database-abstractor/src/test/java/com/akto/merging/TestOptimizedMerger.java
@@ -1,0 +1,439 @@
+package com.akto.merging;
+
+import com.akto.dto.type.SingleTypeInfo;
+import com.akto.dto.type.URLTemplate;
+import com.akto.util.filter.DictionaryFilter;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class TestOptimizedMerger {
+
+    @BeforeClass
+    public static void initDictionary() {
+        DictionaryFilter.readDictionaryBinary();
+    }
+
+    // ---- Token classification tests ----
+
+    @Test
+    public void testClassifyNumeric() {
+        assertEquals(OptimizedMerger.TokenTag.INT,
+                OptimizedMerger.classifyToken("123", true, true));
+        assertEquals(OptimizedMerger.TokenTag.INT,
+                OptimizedMerger.classifyToken("-5", true, true));
+        assertEquals(OptimizedMerger.TokenTag.INT,
+                OptimizedMerger.classifyToken("0", true, true));
+    }
+
+    @Test
+    public void testClassifyUuid() {
+        assertEquals(OptimizedMerger.TokenTag.UUID,
+                OptimizedMerger.classifyToken("550e8400-e29b-41d4-a716-446655440000", true, true));
+    }
+
+    @Test
+    public void testClassifyUuidBlockedWithoutStringMerging() {
+        // UUID requires allowStringMerging
+        assertNull(OptimizedMerger.classifyToken("550e8400-e29b-41d4-a716-446655440000", false, true));
+    }
+
+    @Test
+    public void testClassifyVersion() {
+        assertEquals(OptimizedMerger.TokenTag.VER,
+                OptimizedMerger.classifyToken("v2", true, true));
+        // Blocked without allowMergingOnVersions
+        assertNotEquals(OptimizedMerger.TokenTag.VER,
+                OptimizedMerger.classifyToken("v2", true, false));
+    }
+
+    @Test
+    public void testClassifyLocale() {
+        assertEquals(OptimizedMerger.TokenTag.LOC,
+                OptimizedMerger.classifyToken("en", true, true));
+        assertEquals(OptimizedMerger.TokenTag.LOC,
+                OptimizedMerger.classifyToken("en-US", true, true));
+    }
+
+    @Test
+    public void testClassifyAlphanumeric() {
+        // isAlphanumericString: length ≥ 6, digits ≥ 3, letters ≥ 1
+        assertEquals(OptimizedMerger.TokenTag.ALNUM,
+                OptimizedMerger.classifyToken("abc123def", true, true));
+    }
+
+    @Test
+    public void testClassifyAlnumBlockedWithoutStringMerging() {
+        assertNull(OptimizedMerger.classifyToken("abc123def", false, true));
+    }
+
+    @Test
+    public void testClassifyEnglishWordReturnsNull() {
+        // English words are always literal (null tag)
+        assertNull(OptimizedMerger.classifyToken("users", true, true));
+        assertNull(OptimizedMerger.classifyToken("profile", true, true));
+    }
+
+    // ---- Tier 1 signature tests ----
+
+    @Test
+    public void testTier1SignatureSameForNumericDiffs() {
+        Set<String> urls = new LinkedHashSet<>(Arrays.asList(
+                "GET /api/users/123/profile",
+                "GET /api/users/456/profile"
+        ));
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        assertEquals(2, parsed.size());
+
+        String sig1 = OptimizedMerger.buildTier1Signature(parsed.get(0));
+        String sig2 = OptimizedMerger.buildTier1Signature(parsed.get(1));
+        assertEquals("Same sig for numeric diff", sig1, sig2);
+    }
+
+    @Test
+    public void testTier1SignatureDiffersForLiteralDiffs() {
+        Set<String> urls = new LinkedHashSet<>(Arrays.asList(
+                "GET /api/users/123/profile",
+                "GET /api/orders/123/profile"
+        ));
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        String sig1 = OptimizedMerger.buildTier1Signature(parsed.get(0));
+        String sig2 = OptimizedMerger.buildTier1Signature(parsed.get(1));
+        assertNotEquals("Different sig for literal diff", sig1, sig2);
+    }
+
+    @Test
+    public void testTier1SignatureKeepsOpaqueAsLiteral() {
+        Set<String> urls = new LinkedHashSet<>(Arrays.asList(
+                "GET /api/users/xK9m/profile",
+                "GET /api/users/pL3n/profile"
+        ));
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        String sig1 = OptimizedMerger.buildTier1Signature(parsed.get(0));
+        String sig2 = OptimizedMerger.buildTier1Signature(parsed.get(1));
+        // OPAQUE tokens stay literal → different sigs
+        assertNotEquals("OPAQUE stays literal in Tier 1", sig1, sig2);
+    }
+
+    // ---- Tier 1 template building ----
+
+    @Test
+    public void testBuildTier1TemplateNumeric() {
+        Set<String> urls = Collections.singleton("GET /api/users/123/profile");
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        URLTemplate template = OptimizedMerger.buildTier1Template(parsed.get(0));
+        assertEquals("/api/users/INTEGER/profile", template.getTemplateString());
+    }
+
+    @Test
+    public void testBuildTier1TemplateMultipleNumeric() {
+        Set<String> urls = Collections.singleton("GET /api/123/users/456");
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        URLTemplate template = OptimizedMerger.buildTier1Template(parsed.get(0));
+        assertEquals("/api/INTEGER/users/INTEGER", template.getTemplateString());
+    }
+
+    @Test
+    public void testBuildTier1TemplateUuid() {
+        Set<String> urls = Collections.singleton(
+                "GET /api/users/550e8400-e29b-41d4-a716-446655440000/profile");
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        URLTemplate template = OptimizedMerger.buildTier1Template(parsed.get(0));
+        assertEquals("/api/users/STRING/profile", template.getTemplateString());
+    }
+
+    // ---- Tier 2 key tests ----
+
+    @Test
+    public void testTier2KeyGroupsAlnumDiffs() {
+        Set<String> urls = new LinkedHashSet<>(Arrays.asList(
+                "GET /api/users/abc123def/profile",
+                "GET /api/users/xyz789ghi/profile"
+        ));
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        // pos 2 is ALNUM
+        String key1 = OptimizedMerger.buildTier2Key(parsed.get(0), 2);
+        String key2 = OptimizedMerger.buildTier2Key(parsed.get(1), 2);
+        assertNotNull(key1);
+        assertEquals("Same Tier 2 key for ALNUM diff at same pos", key1, key2);
+    }
+
+    @Test
+    public void testTier2KeyLiteralAtNonSkippedPositions() {
+        Set<String> urls = new LinkedHashSet<>(Arrays.asList(
+                "GET /api/users/abc123def/profile",
+                "GET /api/orders/abc123def/profile"
+        ));
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        // Skip pos 2 (ALNUM) — but pos 1 differs ("users" vs "orders")
+        String key1 = OptimizedMerger.buildTier2Key(parsed.get(0), 2);
+        String key2 = OptimizedMerger.buildTier2Key(parsed.get(1), 2);
+        assertNotEquals("Different Tier 2 key when literals differ", key1, key2);
+    }
+
+    @Test
+    public void testTier2KeyAbstractsFreeMergePositions() {
+        // URLs with different INT at pos 2 AND different ALNUM at pos 3
+        Set<String> urls = new LinkedHashSet<>(Arrays.asList(
+                "GET /api/123/abc123def/profile",
+                "GET /api/456/xyz789ghi/profile"
+        ));
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        // Skip pos 2 (ALNUM) — pos 1 is INT (free merge, tagged in key)
+        String key1 = OptimizedMerger.buildTier2Key(parsed.get(0), 2);
+        String key2 = OptimizedMerger.buildTier2Key(parsed.get(1), 2);
+        assertEquals("INT positions abstracted in Tier 2 key", key1, key2);
+    }
+
+    @Test
+    public void testTier2KeyRejectsEnglishWordSkip() {
+        Set<String> urls = Collections.singleton("GET /api/users/profile");
+        List<OptimizedMerger.ParsedUrl> parsed = OptimizedMerger.parseUrls(urls, true, true);
+        // "users" is English → tag=null → can't skip
+        assertNull(OptimizedMerger.buildTier2Key(parsed.get(0), 1));
+    }
+
+    // ---- End-to-end merging tests ----
+
+    @Test
+    public void testMergeNumericUrls() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/1",
+                "GET /api/users/2",
+                "GET /api/users/3"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertEquals("Should create 1 template", 1, result.templateToStaticURLs.size());
+        URLTemplate template = result.templateToStaticURLs.keySet().iterator().next();
+        assertEquals("/api/users/INTEGER", template.getTemplateString());
+        assertEquals(3, result.templateToStaticURLs.get(template).size());
+    }
+
+    @Test
+    public void testMergeUuidUrls() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/550e8400-e29b-41d4-a716-446655440000/profile",
+                "GET /api/users/6ba7b810-9dad-11d1-80b4-00c04fd430c8/profile"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertEquals(1, result.templateToStaticURLs.size());
+        URLTemplate template = result.templateToStaticURLs.keySet().iterator().next();
+        assertEquals("/api/users/STRING/profile", template.getTemplateString());
+    }
+
+    @Test
+    public void testMergeMultipleIntegerPositions() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/123/orders/456",
+                "GET /api/789/orders/12"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertEquals(1, result.templateToStaticURLs.size());
+        URLTemplate template = result.templateToStaticURLs.keySet().iterator().next();
+        assertEquals("/api/INTEGER/orders/INTEGER", template.getTemplateString());
+    }
+
+    @Test
+    public void testMergeAlphanumericViaTier2() {
+        // ALNUM tokens → Tier 1 keeps literal → Tier 2 groups them
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/abc123def/profile",
+                "GET /api/users/xyz789ghi/profile"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertEquals(1, result.templateToStaticURLs.size());
+        URLTemplate template = result.templateToStaticURLs.keySet().iterator().next();
+        assertEquals("/api/users/STRING/profile", template.getTemplateString());
+    }
+
+    @Test
+    public void testMergeIntPlusAlnumViaTier2() {
+        // INT at pos 1, ALNUM at pos 3 → Tier 2 skips pos 3, tags pos 1
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/123/users/abc123def",
+                "GET /api/456/users/xyz789ghi"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertEquals(1, result.templateToStaticURLs.size());
+        URLTemplate template = result.templateToStaticURLs.keySet().iterator().next();
+        assertEquals("/api/INTEGER/users/STRING", template.getTemplateString());
+    }
+
+    @Test
+    public void testNoMergeDifferentEnglishWords() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/profile",
+                "GET /api/orders/profile"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        // "users" and "orders" are English words → can't merge at that position
+        assertTrue("Should not merge different English words",
+                result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testNoMergeWhenStringMergingDisabled() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/abc123def/profile",
+                "GET /api/users/xyz789ghi/profile"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, false, true, 0);
+
+        // ALNUM requires allowStringMerging → no merge
+        assertTrue("Should not merge ALNUM without allowStringMerging",
+                result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testNumericMergeStillWorksWithoutStringMerging() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/123",
+                "GET /api/users/456"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, false, true, 0);
+
+        assertEquals("INT merge works without allowStringMerging",
+                1, result.templateToStaticURLs.size());
+    }
+
+    @Test
+    public void testOpaqueSkippedConservatively() {
+        // Short opaque tokens (not ALNUM: length < 6 or digits < 3)
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/ab/profile",
+                "GET /api/users/cd/profile"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        // "ab" and "cd" are OPAQUE (too short for ALNUM) → skipped conservatively
+        assertTrue("OPAQUE merge skipped (needs body match)",
+                result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testSingleTokenUrlsIgnored() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /123",
+                "GET /456"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        // Token count = 1 → skipped
+        assertTrue(result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testMultipleGroupsDifferentTokenCounts() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/123",
+                "GET /api/users/456",
+                "GET /api/users/123/posts/789",
+                "GET /api/users/456/posts/12"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertEquals("Should create 2 templates (different token counts)",
+                2, result.templateToStaticURLs.size());
+    }
+
+    @Test
+    public void testEmptyInput() {
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                new HashSet<>(), true, true, 0);
+        assertTrue(result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testSingleUrl() {
+        Set<String> urls = Collections.singleton("GET /api/users/123");
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+        assertTrue(result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testDifferentMethodsNotMerged() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/123",
+                "POST /api/users/456"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+        assertTrue("Different methods should not merge",
+                result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testTwoAlnumPositionsNotMerged() {
+        // Two ALNUM diffs → templatizedStrTokens=2 → should not merge
+        // Tier 2 keeps non-skipped ALNUM as literal → different values → different keys
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/abc123def/users/xyz789ghi",
+                "GET /api/qwe456rty/users/asd012fgh"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertTrue("Two ALNUM positions should not merge (templatizedStrTokens would be 2)",
+                result.templateToStaticURLs.isEmpty());
+    }
+
+    @Test
+    public void testMixedIntAndUuidMerge() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/123/users/550e8400-e29b-41d4-a716-446655440000",
+                "GET /api/456/users/6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        ));
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urls, true, true, 0);
+
+        assertEquals(1, result.templateToStaticURLs.size());
+        URLTemplate template = result.templateToStaticURLs.keySet().iterator().next();
+        assertEquals("/api/INTEGER/users/STRING", template.getTemplateString());
+    }
+
+    @Test
+    public void testInvalidUrlsSkipped() {
+        Set<String> urls = new HashSet<>(Arrays.asList(
+                "GET /api/users/123",
+                "GET /api/users/456",
+                "",
+                "NOSPACE",
+                null,
+                "GET /api//double//slash"
+        ));
+        // nulls in HashSet will throw NPE, so use explicit set
+        Set<String> urlSet = new LinkedHashSet<>();
+        urlSet.add("GET /api/users/123");
+        urlSet.add("GET /api/users/456");
+        urlSet.add("");
+        urlSet.add("NOSPACE");
+        urlSet.add("GET /api//double//slash");
+
+        MergingLogic.ApiMergerResult result = OptimizedMerger.mergeStaticUrls(
+                urlSet, true, true, 0);
+
+        assertEquals(1, result.templateToStaticURLs.size());
+        assertEquals(2, result.templateToStaticURLs.values().iterator().next().size());
+    }
+}

--- a/apps/database-abstractor/src/test/java/com/akto/merging/TestOptimizedTemplateToStaticMatch.java
+++ b/apps/database-abstractor/src/test/java/com/akto/merging/TestOptimizedTemplateToStaticMatch.java
@@ -49,9 +49,16 @@ public class TestOptimizedTemplateToStaticMatch {
         return matched;
     }
 
+    /** Wrapper that adapts the new void signature back to a Set<String> return for test convenience. */
+    private static Set<String> callOptimized(List<String> templates, Map<String, Set<String>> statics, int apiCollectionId) {
+        MergingLogic.ApiMergerResult result = new MergingLogic.ApiMergerResult(new HashMap<>());
+        MergingLogic.optimizedTemplateToStaticMatch(templates, statics, apiCollectionId, result);
+        return result.deleteStaticUrls;
+    }
+
     private void assertMatchesBruteForce(List<String> templates, Map<String, Set<String>> statics, int expectedSize) {
         Set<String> brute = bruteForceMatch(templates, statics, 0);
-        Set<String> optimized = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> optimized = callOptimized(templates, statics, 0);
         assertEquals("Optimized should match brute force", brute, optimized);
         assertEquals("Expected match count", expectedSize, optimized.size());
     }
@@ -144,7 +151,7 @@ public class TestOptimizedTemplateToStaticMatch {
     public void testEmptyTemplates() {
         List<String> templates = Collections.emptyList();
         Map<String, Set<String>> statics = toStaticMap("GET /api/users/123");
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         assertTrue("Empty templates should match nothing", result.isEmpty());
     }
 
@@ -152,13 +159,13 @@ public class TestOptimizedTemplateToStaticMatch {
     public void testEmptyStatics() {
         List<String> templates = Arrays.asList("GET /api/users/INTEGER");
         Map<String, Set<String>> statics = new HashMap<>();
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         assertTrue("Empty statics should match nothing", result.isEmpty());
     }
 
     @Test
     public void testBothEmpty() {
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(Collections.emptyList(), new HashMap<>(), 0);
+        Set<String> result = callOptimized(Collections.emptyList(), new HashMap<>(), 0);
         assertTrue("Both empty should match nothing", result.isEmpty());
     }
 
@@ -296,7 +303,7 @@ public class TestOptimizedTemplateToStaticMatch {
         List<String> templates = Arrays.asList("GET /api/users/INTEGER");
         Map<String, Set<String>> statics = toStaticMap("GET /api//users/123");
         // Double slash should be skipped
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         assertTrue("Double-slash URLs should be skipped", result.isEmpty());
     }
 
@@ -305,7 +312,7 @@ public class TestOptimizedTemplateToStaticMatch {
         List<String> templates = Arrays.asList("GET /api//users/INTEGER");
         Map<String, Set<String>> statics = toStaticMap("GET /api/users/123");
         // buildTemplateIndex skips templates with //
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         assertMatchesBruteForce(templates, statics, 0);
     }
 
@@ -313,7 +320,7 @@ public class TestOptimizedTemplateToStaticMatch {
     public void testEmptyEndpointSkipped() {
         List<String> templates = Arrays.asList("GET /api/users/INTEGER");
         Map<String, Set<String>> statics = toStaticMap("GET ");
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         assertTrue("Empty endpoint should be skipped", result.isEmpty());
     }
 
@@ -325,7 +332,7 @@ public class TestOptimizedTemplateToStaticMatch {
         Map<String, Set<String>> statics = new HashMap<>();
         statics.put(null, new HashSet<>());
         statics.put("GET /api/users/123", new HashSet<>());
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         // Should not crash, should still match the valid one
         assertTrue("Should match valid URL", result.contains("GET /api/users/123"));
     }
@@ -336,7 +343,7 @@ public class TestOptimizedTemplateToStaticMatch {
         Map<String, Set<String>> statics = new HashMap<>();
         statics.put("", new HashSet<>());
         statics.put("GET /api/users/123", new HashSet<>());
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         assertTrue("Should match valid URL", result.contains("GET /api/users/123"));
         assertEquals(1, result.size());
     }
@@ -345,7 +352,7 @@ public class TestOptimizedTemplateToStaticMatch {
     public void testStaticURLWithNoSpace() {
         List<String> templates = Arrays.asList("GET /api/users/INTEGER");
         Map<String, Set<String>> statics = toStaticMap("GET/api/users/123");  // no space
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         // "GET/api/users/123" has no space → skipped
         assertTrue("No-space URL should be skipped", result.isEmpty());
     }
@@ -357,7 +364,7 @@ public class TestOptimizedTemplateToStaticMatch {
         templates.add("");
         templates.add("GET /api/users/INTEGER");
         Map<String, Set<String>> statics = toStaticMap("GET /api/users/123");
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         assertTrue("Should match despite empty template", result.contains("GET /api/users/123"));
     }
 
@@ -592,7 +599,7 @@ public class TestOptimizedTemplateToStaticMatch {
         for (int i = 0; i < 10000; i++) {
             statics.put("GET /api/users/" + i, new HashSet<>());
         }
-        Set<String> result = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> result = callOptimized(templates, statics, 0);
         Set<String> brute = bruteForceMatch(templates, statics, 0);
         assertEquals(brute, result);
         assertEquals(10000, result.size());
@@ -704,7 +711,7 @@ public class TestOptimizedTemplateToStaticMatch {
         }
 
         Set<String> brute = bruteForceMatch(templates, statics, 0);
-        Set<String> optimized = MergingLogic.optimizedTemplateToStaticMatch(templates, statics, 0);
+        Set<String> optimized = callOptimized(templates, statics, 0);
         assertEquals("Large scale parity", brute, optimized);
     }
 
@@ -738,8 +745,8 @@ public class TestOptimizedTemplateToStaticMatch {
         statics2.put("GET /api/users/456", new HashSet<>());
         statics2.put("GET /api/users/123", new HashSet<>());
 
-        Set<String> result1 = MergingLogic.optimizedTemplateToStaticMatch(templates, statics1, 0);
-        Set<String> result2 = MergingLogic.optimizedTemplateToStaticMatch(templates, statics2, 0);
+        Set<String> result1 = callOptimized(templates, statics1, 0);
+        Set<String> result2 = callOptimized(templates, statics2, 0);
         assertEquals("Order should not affect result", result1, result2);
     }
 
@@ -758,8 +765,8 @@ public class TestOptimizedTemplateToStaticMatch {
                 "GET /api/orders/99"
         );
 
-        Set<String> result1 = MergingLogic.optimizedTemplateToStaticMatch(templates1, statics, 0);
-        Set<String> result2 = MergingLogic.optimizedTemplateToStaticMatch(templates2, statics, 0);
+        Set<String> result1 = callOptimized(templates1, statics, 0);
+        Set<String> result2 = callOptimized(templates2, statics, 0);
         assertEquals("Template order should not affect result", result1, result2);
     }
 }

--- a/apps/database-abstractor/src/test/java/com/akto/merging/TestOptimizedTemplateToStaticMatch.java
+++ b/apps/database-abstractor/src/test/java/com/akto/merging/TestOptimizedTemplateToStaticMatch.java
@@ -368,15 +368,6 @@ public class TestOptimizedTemplateToStaticMatch {
         assertTrue("Should match despite empty template", result.contains("GET /api/users/123"));
     }
 
-    // ==================== SINGLE TOKEN URLS ====================
-
-    @Test
-    public void testSingleTokenStaticURL() {
-        List<String> templates = Arrays.asList("GET /INTEGER");
-        Map<String, Set<String>> statics = toStaticMap("GET /123", "GET /456");
-        assertMatchesBruteForce(templates, statics, 2);
-    }
-
     @Test
     public void testRootURL() {
         List<String> templates = Arrays.asList("GET /api/users/INTEGER");
@@ -626,17 +617,6 @@ public class TestOptimizedTemplateToStaticMatch {
         List<String> templates = Arrays.asList("GET /api/users/INTEGER");
         Map<String, Set<String>> statics = toStaticMap("GET /api/users/42");
         assertMatchesBruteForce(templates, statics, 1);
-    }
-
-    @Test
-    public void testAllPositionsWildcard() {
-        // Template with all wildcard positions (2 tokens, both INTEGER)
-        List<String> templates = Arrays.asList("GET /INTEGER/INTEGER");
-        Map<String, Set<String>> statics = toStaticMap(
-                "GET /1/2",
-                "GET /99/100"
-        );
-        assertMatchesBruteForce(templates, statics, 2);
     }
 
     // ==================== HTTP METHODS ====================

--- a/libs/dao/src/main/java/com/akto/dao/merging/MergeAuditLogDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/merging/MergeAuditLogDao.java
@@ -1,0 +1,31 @@
+package com.akto.dao.merging;
+
+import com.akto.dao.AccountsContextDao;
+import com.akto.dto.merging.MergeAuditLog;
+import com.mongodb.client.model.Filters;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MergeAuditLogDao extends AccountsContextDao<MergeAuditLog> {
+
+    public static final MergeAuditLogDao instance = new MergeAuditLogDao();
+
+    @Override
+    public String getCollName() {
+        return "merge_audit_logs";
+    }
+
+    @Override
+    public Class<MergeAuditLog> getClassT() {
+        return MergeAuditLog.class;
+    }
+
+    /** Single server-side distinct call — no doc-level iteration in Java. */
+    public Set<String> getAuditedStaticUrls(int apiCollectionId) {
+        Set<String> result = new HashSet<>();
+        getMCollection().distinct("matchedStaticUrls", Filters.eq(MergeAuditLog.API_COLLECTION_ID, apiCollectionId), String.class)
+                .into(result);
+        return result;
+    }
+}

--- a/libs/dao/src/main/java/com/akto/dto/merging/MergeAuditLog.java
+++ b/libs/dao/src/main/java/com/akto/dto/merging/MergeAuditLog.java
@@ -1,0 +1,70 @@
+package com.akto.dto.merging;
+
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+public class MergeAuditLog {
+
+    public static final String API_COLLECTION_ID = "apiCollectionId";
+    public static final String MERGE_TYPE = "mergeType";
+    public static final String TEMPLATE_URL = "templateUrl";
+    public static final String METHOD = "method";
+    public static final String DISCOVERED_AT = "discoveredAt";
+    public static final String STI_DELETED = "stiDeleted";
+    public static final String API_INFO_DELETED = "apiInfoDeleted";
+    public static final String SAMPLE_DATA_DELETED = "sampleDataDeleted";
+
+    private ObjectId id;
+    private int apiCollectionId;
+    private String mergeType;       // "TEMPLATE_TO_STATIC" or "STATIC_TO_STATIC"
+    private String templateUrl;     // e.g. "/api/INTEGER/users"
+    private String method;          // e.g. "GET"
+    private List<String> matchedStaticUrls;
+    private int discoveredAt;
+    private boolean stiDeleted;
+    private boolean apiInfoDeleted;
+    private boolean sampleDataDeleted;
+
+    public MergeAuditLog() {}
+
+    public MergeAuditLog(int apiCollectionId, String mergeType, String templateUrl,
+                         String method, List<String> matchedStaticUrls, int discoveredAt) {
+        this.apiCollectionId = apiCollectionId;
+        this.mergeType = mergeType;
+        this.templateUrl = templateUrl;
+        this.method = method;
+        this.matchedStaticUrls = matchedStaticUrls;
+        this.discoveredAt = discoveredAt;
+    }
+
+    public ObjectId getId() { return id; }
+    public void setId(ObjectId id) { this.id = id; }
+
+    public int getApiCollectionId() { return apiCollectionId; }
+    public void setApiCollectionId(int apiCollectionId) { this.apiCollectionId = apiCollectionId; }
+
+    public String getMergeType() { return mergeType; }
+    public void setMergeType(String mergeType) { this.mergeType = mergeType; }
+
+    public String getTemplateUrl() { return templateUrl; }
+    public void setTemplateUrl(String templateUrl) { this.templateUrl = templateUrl; }
+
+    public String getMethod() { return method; }
+    public void setMethod(String method) { this.method = method; }
+
+    public List<String> getMatchedStaticUrls() { return matchedStaticUrls; }
+    public void setMatchedStaticUrls(List<String> matchedStaticUrls) { this.matchedStaticUrls = matchedStaticUrls; }
+
+    public int getDiscoveredAt() { return discoveredAt; }
+    public void setDiscoveredAt(int discoveredAt) { this.discoveredAt = discoveredAt; }
+
+    public boolean isStiDeleted() { return stiDeleted; }
+    public void setStiDeleted(boolean stiDeleted) { this.stiDeleted = stiDeleted; }
+
+    public boolean isApiInfoDeleted() { return apiInfoDeleted; }
+    public void setApiInfoDeleted(boolean apiInfoDeleted) { this.apiInfoDeleted = apiInfoDeleted; }
+
+    public boolean isSampleDataDeleted() { return sampleDataDeleted; }
+    public void setSampleDataDeleted(boolean sampleDataDeleted) { this.sampleDataDeleted = sampleDataDeleted; }
+}


### PR DESCRIPTION
## Summary

Replaces the O(n²) brute-force URL merging algorithm with an optimized O(n·k) approach for the priority account (`1736798101`), gated behind `USE_OPTIMIZED_MERGING` env flag.

### New merging algorithm

- **Template-to-static matching**: Indexed lookup using a secondary wildcard-position index instead of generating all C(n,2) candidate keys per static URL. Only probes wildcard positions that actually exist in DB templates — fixes OOM on long URLs.
- **Static-to-static matching** (`OptimizedMerger`): Two-tier signature-based grouping:
  - **Tier 1**: Free-merge tokens (INT/UUID/VER/LOC) are tagged in a signature key — URLs with identical signatures merge instantly.
  - **Tier 2**: For remaining singletons, skip one ALNUM position to discover new templates (handles exactly-one string diff).
- **Over-broad template skip**: Templates where all tokens are wildcards (e.g. `STRING/STRING`) are excluded from the index.
- **Deduplication**: Handles duplicate template entries with/without leading `/`.
- **`api` token guard**: Prevents `api` from being classified as OPAQUE (avoids false merges like `/api/v4/STRING`).

### Audit mode (dry-run)

For the optimized account, merging writes results to `merge_audit_logs` collection instead of performing deletions:
- Each doc records: `apiCollectionId`, `mergeType` (TEMPLATE_TO_STATIC / STATIC_TO_STATIC), `templateUrl`, `method`, `matchedStaticUrls`, `discoveredAt`
- Subsequent runs skip already-audited static URLs via `MergeAuditLogDao.getAuditedStaticUrls()`
- `Cron.verifyAuditLogs()` prints verification stats (unique URLs to delete, per-collection counts, ApiInfo/STI impact, multi-template conflicts)

### Deletion cron

Behind `ENABLE_MERGE_AUDIT_DELETION` env flag (runs only for priority account):
- Reads `merge_audit_logs` docs where deletion is incomplete
- Groups static URLs by `(apiCollectionId, method)` for efficient `$in` batch deletes
- Deletes from STI, ApiInfo, SampleData independently — tracks success per entity type
- Marks `stiDeleted`, `apiInfoDeleted`, `sampleDataDeleted` booleans via single bulk `updateMany` per batch
- If one entity type fails, only that boolean stays unmarked for retry on next run

### Files changed

| File | What |
|------|------|
| `OptimizedMerger.java` | New — Tier 1/Tier 2 static-to-static merging |
| `MergingLogic.java` | Refactored template index with wildcard position tracking, audit log save/load, leading `/` normalization |
| `MergeAuditDeletion.java` | New — batch deletion cron logic |
| `Cron.java` | Deletion cron wiring, `verifyAuditLogs()` |
| `MergeAuditLog.java` | New DTO with 3 deletion-tracking booleans |
| `MergeAuditLogDao.java` | New DAO with `getAuditedStaticUrls()` |
| `TestOptimizedMerger.java` | Unit tests for token classification, signatures, tier 1/2 merging |
| `TestOptimizedTemplateToStaticMatch.java` | Updated tests for refactored template index |

## Test plan

- [x] `TestOptimizedMerger` — token classification, tier 1/tier 2 signatures, end-to-end merge correctness
- [x] `TestOptimizedTemplateToStaticMatch` — indexed template-to-static matching
- [ ] Run on priority account with `USE_OPTIMIZED_MERGING=true` in audit mode, verify `merge_audit_logs` via `verifyAuditLogs()`
- [ ] Enable `ENABLE_MERGE_AUDIT_DELETION=true`, verify STI/ApiInfo/SampleData deletions and boolean tracking
- [ ] Verify old merging flow unaffected for non-optimized accounts