### PR TITLE
feature/guardrail-browser-llm: add Select Browser LLMs dropdown in se…

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
@@ -140,6 +140,7 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
     const [applyToAllServers, setApplyToAllServers] = useState(true);
     const [selectedMcpServers, setSelectedMcpServers] = useState([]);
     const [selectedAgentServers, setSelectedAgentServers] = useState([]);
+    const [selectedBrowserLlms, setSelectedBrowserLlms] = useState([]);
     const [applyOnResponse, setApplyOnResponse] = useState(false);
     const [applyOnRequest, setApplyOnRequest] = useState(false);
     const [policyBehaviour, setPolicyBehaviour] = useState(GUARDRAIL_BEHAVIOUR.BLOCK);
@@ -147,6 +148,7 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
     // Collections data
     const [mcpServers, setMcpServers] = useState([]);
     const [agentServers, setAgentServers] = useState([]);
+    const [browserLlmServers, setBrowserLlmServers] = useState([]);
     const [collectionsLoading, setCollectionsLoading] = useState(false);
 
     // Get collections from PersistStore
@@ -208,8 +210,10 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
         applyToAllServers,
         selectedMcpServers,
         selectedAgentServers,
+        selectedBrowserLlms,
         mcpServers,
         agentServers,
+        browserLlmServers,
         applyOnRequest,
         applyOnResponse,
         policyBehaviour
@@ -381,8 +385,22 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                 isInline: !collection.envType?.some(tag => tag.keyName === 'mode' && tag.value === 'observe')
             }));
 
+            const browserLlmCollections = allCollections.filter(collection => {
+                const hasBrowserLlmEnvType = collection.envType && collection.envType.some(envType =>
+                    envType.keyName === 'browser-llm'
+                );
+                return hasBrowserLlmEnvType && !isVisibilityOnly(collection);
+            })
+            .sort((a, b) => (b.startTs || 0) - (a.startTs || 0))
+            .map(collection => ({
+                label: collection.displayName,
+                value: collection.id.toString(),
+                isInline: !collection.envType?.some(tag => tag.keyName === 'mode' && tag.value === 'observe')
+            }));
+
             setMcpServers(mcpServerCollections);
             setAgentServers(agentServerCollections);
+            setBrowserLlmServers(browserLlmCollections);
         } catch (error) {
             console.error("Error filtering collections:", error);
         } finally {
@@ -450,6 +468,7 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
         setApplyToAllServers(true);
         setSelectedMcpServers([]);
         setSelectedAgentServers([]);
+        setSelectedBrowserLlms([]);
         setBlockedHosts([]);
         setApplyOnResponse(false);
         setApplyOnRequest(false);
@@ -567,11 +586,26 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                 ? policy.selectedMcpServersV2.map(server => server.id)
                 : policy.selectedMcpServers || []
         );
-        setSelectedAgentServers(
-            policy.selectedAgentServersV2?.length > 0
-                ? policy.selectedAgentServersV2.map(server => server.id)
-                : policy.selectedAgentServers || []
-        );
+
+        // selectedAgentServersV2 stores both gen-ai and browser-llm entries.
+        // Split them back into their respective dropdowns using allCollections envType.
+        const rawAgentServers = policy.selectedAgentServersV2?.length > 0
+            ? policy.selectedAgentServersV2.map(server => server.id)
+            : policy.selectedAgentServers || [];
+
+        const agentIds = [];
+        const browserLlmIds = [];
+        rawAgentServers.forEach(id => {
+            const col = allCollections?.find(c => c.id?.toString() === id?.toString());
+            const isBrowserLlm = col?.envType?.some(e => e.keyName === 'browser-llm');
+            if (isBrowserLlm) {
+                browserLlmIds.push(id);
+            } else {
+                agentIds.push(id);
+            }
+        });
+        setSelectedAgentServers(agentIds);
+        setSelectedBrowserLlms(browserLlmIds);
         setApplyOnResponse(policy.applyOnResponse || false);
         setApplyOnRequest(policy.applyOnRequest || false);
         setApplyToAllServers(policy.applyToAllServers ?? true);
@@ -615,15 +649,26 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                     };
                 });
 
-            const transformedAgentServers = selectedAgentServers
-                .filter(serverId => serverId)
-                .map(serverId => {
-                    const server = agentServers.find(s => s.value === serverId || s.value === serverId.toString());
-                    return {
-                        id: serverId.toString(),
-                        name: server ? server.label : serverId.toString()
-                    };
-                });
+            const transformedAgentServers = [
+                ...selectedAgentServers
+                    .filter(serverId => serverId)
+                    .map(serverId => {
+                        const server = agentServers.find(s => s.value === serverId || s.value === serverId.toString());
+                        return {
+                            id: serverId.toString(),
+                            name: server ? server.label : serverId.toString()
+                        };
+                    }),
+                ...selectedBrowserLlms
+                    .filter(serverId => serverId)
+                    .map(serverId => {
+                        const server = browserLlmServers.find(s => s.value === serverId || s.value === serverId.toString());
+                        return {
+                            id: serverId.toString(),
+                            name: server ? server.label : serverId.toString()
+                        };
+                    })
+            ];
 
             // Drop empty rows and normalize the glob patterns before persisting.
             const cleanedBlockedHosts = (blockedHosts || [])
@@ -692,7 +737,7 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                 confidenceScore: enableExternalModel ? confidenceScore : null,
                 applyToAllServers,
                 selectedMcpServers: selectedMcpServers,
-                selectedAgentServers: selectedAgentServers,
+                selectedAgentServers: [...selectedAgentServers, ...selectedBrowserLlms],
                 selectedMcpServersV2: transformedMcpServers,
                 selectedAgentServersV2: transformedAgentServers,
                 blockedHosts: cleanedBlockedHosts,
@@ -873,12 +918,15 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                         setSelectedMcpServers={setSelectedMcpServers}
                         selectedAgentServers={selectedAgentServers}
                         setSelectedAgentServers={setSelectedAgentServers}
+                        selectedBrowserLlms={selectedBrowserLlms}
+                        setSelectedBrowserLlms={setSelectedBrowserLlms}
                         applyOnResponse={applyOnResponse}
                         setApplyOnResponse={setApplyOnResponse}
                         applyOnRequest={applyOnRequest}
                         setApplyOnRequest={setApplyOnRequest}
                         mcpServers={mcpServers}
                         agentServers={agentServers}
+                        browserLlmServers={browserLlmServers}
                         collectionsLoading={collectionsLoading}
                         policyBehaviour={policyBehaviour}
                         setPolicyBehaviour={setPolicyBehaviour}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/ServerSettingsStep.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/ServerSettingsStep.jsx
@@ -14,14 +14,14 @@ export const ServerSettingsConfig = {
         return { isValid: true, errorMessage: null };
     },
 
-    getSummary: ({ applyToAllServers, selectedMcpServers, selectedAgentServers, mcpServers, agentServers, applyOnRequest, applyOnResponse, policyBehaviour }) => {
+    getSummary: ({ applyToAllServers, selectedMcpServers, selectedAgentServers, selectedBrowserLlms, mcpServers, agentServers, browserLlmServers, applyOnRequest, applyOnResponse, policyBehaviour }) => {
         const appSettings = (applyOnRequest || applyOnResponse) ?
             ` - ${applyOnRequest ? 'Req' : ''}${applyOnRequest && applyOnResponse ? '/' : ''}${applyOnResponse ? 'Res' : ''}` : '';
         const behaviourSuffix = policyBehaviour ? `Rule behaviour: ${policyBehaviour}` : '';
         let summary = '';
-        if (selectedMcpServers?.length > 0 || selectedAgentServers?.length > 0) {
+        if (selectedMcpServers?.length > 0 || selectedAgentServers?.length > 0 || selectedBrowserLlms?.length > 0) {
             const serverSummary = [];
-            if (selectedMcpServers.length > 0) {
+            if (selectedMcpServers?.length > 0) {
                 const mcpNames = selectedMcpServers
                     .map(serverId => {
                         const server = mcpServers?.find(s => s.value === serverId);
@@ -31,7 +31,7 @@ export const ServerSettingsConfig = {
                 const mcpMore = selectedMcpServers.length > 2 ? ` +${selectedMcpServers.length - 2}` : '';
                 serverSummary.push(`MCP: ${mcpNames.join(", ")}${mcpMore}`);
             }
-            if (selectedAgentServers.length > 0) {
+            if (selectedAgentServers?.length > 0) {
                 const agentNames = selectedAgentServers
                     .map(serverId => {
                         const server = agentServers?.find(s => s.value === serverId);
@@ -40,6 +40,16 @@ export const ServerSettingsConfig = {
                     .slice(0, 2);
                 const agentMore = selectedAgentServers.length > 2 ? ` +${selectedAgentServers.length - 2}` : '';
                 serverSummary.push(`Agent: ${agentNames.join(", ")}${agentMore}`);
+            }
+            if (selectedBrowserLlms?.length > 0) {
+                const browserNames = selectedBrowserLlms
+                    .map(serverId => {
+                        const server = browserLlmServers?.find(s => s.value === serverId);
+                        return server ? server.label : serverId;
+                    })
+                    .slice(0, 2);
+                const browserMore = selectedBrowserLlms.length > 2 ? ` +${selectedBrowserLlms.length - 2}` : '';
+                serverSummary.push(`Browser LLM: ${browserNames.join(", ")}${browserMore}`);
             }
             summary = `${serverSummary.join(", ")}`;
         }
@@ -58,12 +68,15 @@ const ServerSettingsStep = ({
     setSelectedMcpServers,
     selectedAgentServers,
     setSelectedAgentServers,
+    selectedBrowserLlms,
+    setSelectedBrowserLlms,
     applyOnResponse,
     setApplyOnResponse,
     applyOnRequest,
     setApplyOnRequest,
     mcpServers,
     agentServers,
+    browserLlmServers,
     collectionsLoading,
     policyBehaviour,
     setPolicyBehaviour
@@ -79,7 +92,10 @@ const ServerSettingsStep = ({
     const compatibleAgentServers = isBlockMode
         ? (agentServers || []).filter(s => s.isInline)
         : (agentServers || []);
-    const totalCompatibleCount = compatibleMcpServers.length + compatibleAgentServers.length;
+    const compatibleBrowserLlmServers = isBlockMode
+        ? (browserLlmServers || []).filter(s => s.isInline)
+        : (browserLlmServers || []);
+    const totalCompatibleCount = compatibleMcpServers.length + compatibleAgentServers.length + compatibleBrowserLlmServers.length;
 
     const mcpServersWithDisabled = isBlockMode
         ? (mcpServers || []).map(s => ({ ...s, disabled: !s.isInline }))
@@ -87,10 +103,14 @@ const ServerSettingsStep = ({
     const agentServersWithDisabled = isBlockMode
         ? (agentServers || []).map(s => ({ ...s, disabled: !s.isInline }))
         : (agentServers || []);
+    const browserLlmServersWithDisabled = isBlockMode
+        ? (browserLlmServers || []).map(s => ({ ...s, disabled: !s.isInline }))
+        : (browserLlmServers || []);
 
     const hasIncompatibleServers = isBlockMode && (
         (mcpServers || []).some(s => !s.isInline) ||
-        (agentServers || []).some(s => !s.isInline)
+        (agentServers || []).some(s => !s.isInline) ||
+        (browserLlmServers || []).some(s => !s.isInline)
     );
 
     useEffect(() => {
@@ -111,6 +131,14 @@ const ServerSettingsStep = ({
                 setSelectedAgentServers(compatible);
             }
         }
+        if (selectedBrowserLlms?.length > 0) {
+            const compatible = selectedBrowserLlms.filter(val =>
+                (browserLlmServers || []).find(s => s.value === val && s.isInline)
+            );
+            if (compatible.length !== selectedBrowserLlms.length) {
+                setSelectedBrowserLlms(compatible);
+            }
+        }
     }, [policyBehaviour]);
 
     const handleClosePopover = useCallback(() => {
@@ -123,6 +151,9 @@ const ServerSettingsStep = ({
         s.label.toLowerCase().includes(searchLower)
     );
     const filteredPopoverAgent = compatibleAgentServers.filter(s =>
+        s.label.toLowerCase().includes(searchLower)
+    );
+    const filteredPopoverBrowserLlm = compatibleBrowserLlmServers.filter(s =>
         s.label.toLowerCase().includes(searchLower)
     );
 
@@ -209,7 +240,22 @@ const ServerSettingsStep = ({
                                                                         </div>
                                                                     </VerticalStack>
                                                                 )}
-                                                                {filteredPopoverMcp.length === 0 && filteredPopoverAgent.length === 0 && (
+                                                                {(filteredPopoverMcp.length > 0 || filteredPopoverAgent.length > 0) && filteredPopoverBrowserLlm.length > 0 && (
+                                                                    <Divider />
+                                                                )}
+                                                                {filteredPopoverBrowserLlm.length > 0 && (
+                                                                    <VerticalStack gap="2">
+                                                                        <Text variant="bodySm" fontWeight="semibold" tone="subdued">
+                                                                            Browser LLMs ({filteredPopoverBrowserLlm.length})
+                                                                        </Text>
+                                                                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                                                                            {filteredPopoverBrowserLlm.map(s => (
+                                                                                <Tag key={s.value}>{s.label}</Tag>
+                                                                            ))}
+                                                                        </div>
+                                                                    </VerticalStack>
+                                                                )}
+                                                                {filteredPopoverMcp.length === 0 && filteredPopoverAgent.length === 0 && filteredPopoverBrowserLlm.length === 0 && (
                                                                     <Text variant="bodyMd" tone="subdued">No servers found</Text>
                                                                 )}
                                                             </VerticalStack>
@@ -266,6 +312,17 @@ const ServerSettingsStep = ({
                                     showSelectAllMinOptions={isBlockMode ? 99999 : 1}
                                     disabled={collectionsLoading}
                                     value={selectedAgentServers.length > 0 ? `${selectedAgentServers.length} agent server${selectedAgentServers.length === 1 ? "" : "s"} selected` : undefined}
+                                />
+                                <DropdownSearch
+                                    label="Select Browser LLMs"
+                                    placeholder="Choose browser LLMs where guardrail should be applied"
+                                    optionsList={browserLlmServersWithDisabled}
+                                    setSelected={setSelectedBrowserLlms}
+                                    preSelected={selectedBrowserLlms}
+                                    allowMultiple={true}
+                                    showSelectAllMinOptions={isBlockMode ? 99999 : 1}
+                                    disabled={collectionsLoading}
+                                    value={selectedBrowserLlms.length > 0 ? `${selectedBrowserLlms.length} browser LLM${selectedBrowserLlms.length === 1 ? "" : "s"} selected` : undefined}
                                 />
                             </VerticalStack>
                         )}


### PR DESCRIPTION
…rver settings

- Filter collections with envType keyName 'browser-llm' into a separate browserLlmServers list
- Show a new 'Select Browser LLMs' dropdown alongside MCP/Agent dropdowns in ServerSettingsStep
- On save, merge browser LLM selections into selectedAgentServersV2 (same backend field)
- On edit/load, split selectedAgentServersV2 back by envType into agent vs browser-llm dropdowns
- Block-mode inline filtering and auto-deselect applied to browser LLMs consistently
- Step summary and 'Apply to all' popover updated to include browser LLM counts/names