### PR TITLE
Implement fetchAccountConfig API and integrate hybrid testing settings

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/AdminSettingsAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AdminSettingsAction.java
@@ -102,6 +102,27 @@ public class AdminSettingsAction extends UserAction {
     private boolean allowRetrospectiveMerging;
 
     private Map<String, Boolean> compulsoryDescription;
+    private boolean hybridTestingEnabled;
+
+    public String fetchAccountConfig() {
+        AccountSettings settings = AccountSettingsDao.instance.findOne(
+            AccountSettingsDao.generateFilter(),
+            Projections.include(AccountSettings.COMPULSORY_DESCRIPTION)
+        );
+        if (settings != null) {
+            compulsoryDescription = settings.getCompulsoryDescription();
+        }
+        if (Context.accountId.get() != null && Context.accountId.get() != 0) {
+            Account account = AccountsDao.instance.findOne(
+                Filters.eq(Constants.ID, Context.accountId.get()),
+                Projections.include(Account.HYBRID_TESTING_ENABLED)
+            );
+            if (account != null) {
+                hybridTestingEnabled = account.getHybridTestingEnabled();
+            }
+        }
+        return SUCCESS.toUpperCase();
+    }
 
     @Setter
     @Getter
@@ -795,6 +816,10 @@ public class AdminSettingsAction extends UserAction {
 
     public void setCompulsoryDescription(Map<String, Boolean> compulsoryDescription) {
         this.compulsoryDescription = compulsoryDescription;
+    }
+
+    public boolean isHybridTestingEnabled() {
+        return hybridTestingEnabled;
     }
 
     public void setProxyPattern(String proxyPattern) {

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -5367,6 +5367,24 @@
             </result>
         </action>
 
+        <action name="api/fetchAccountConfig" class="com.akto.action.AdminSettingsAction" method="fetchAccountConfig">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <result name="SUCCESS" type="json">
+                <param name="includeProperties">^compulsoryDescription.*,hybridTestingEnabled</param>
+            </result>
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="UNAUTHORIZED" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/updatePrivateCidrIps" class="com.akto.action.AdminSettingsAction" method="editPrivateCidrList">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/CompliancePage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/CompliancePage.jsx
@@ -297,10 +297,10 @@ function CompliancePage() {
     useEffect(() => {
         const fetchCompulsorySettings = async () => {
             try {
-                const {resp} = await settingFunctions.fetchAdminInfo();
-                
-                if (resp?.compulsoryDescription) {
-                    setCompulsorySettings(resp.compulsoryDescription);
+                const accountConfig = await settingFunctions.fetchAccountConfig();
+
+                if (accountConfig?.compulsoryDescription) {
+                    setCompulsorySettings(accountConfig.compulsoryDescription);
                 }
             } catch (error) {
             }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/IssuesPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/IssuesPage.jsx
@@ -352,10 +352,10 @@ function IssuesPage() {
     useEffect(() => {
         const fetchCompulsorySettings = async () => {
             try {
-                const { resp } = await settingFunctions.fetchAdminInfo();
+                const accountConfig = await settingFunctions.fetchAccountConfig();
 
-                if (resp?.compulsoryDescription) {
-                    setCompulsorySettings(resp.compulsoryDescription);
+                if (accountConfig?.compulsoryDescription) {
+                    setCompulsorySettings(accountConfig.compulsoryDescription);
                 }
             } catch (error) {
                 console.error("Error fetching compulsory settings:", error);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/about/About.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/about/About.jsx
@@ -127,7 +127,7 @@ function About() {
     const isOnPrem = window.DASHBOARD_MODE && window.DASHBOARD_MODE.toLowerCase() === 'on_prem'
 
     async function fetchDetails(){
-        const {arr, resp, accountSettingsDetails} = await settingFunctions.fetchAdminInfo()
+        const {arr, resp, accountSettingsDetails} = await settingFunctions.fetchAdminInfo(true)
         if(accountSettingsDetails?.timezone === 'Us/Pacific'){
             accountSettingsDetails.timezone = 'America/Los_Angeles';
         }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
@@ -145,6 +145,13 @@ const settingRequests = {
             data: {}
         })
     },
+    fetchAccountConfig() {
+        return request({
+            url: '/api/fetchAccountConfig',
+            method: 'post',
+            data: {}
+        })
+    },
     fetchTrafficMetricsDesciptions() {
         return request({
             url: '/api/fetchTrafficMetricsDesciptions',

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module.js
@@ -164,6 +164,9 @@ const settingFunctions = {
 
       await settingRequests.saveAktoGptConfig(arr)
     },
+    fetchAccountConfig: async function(){
+      return await settingRequests.fetchAccountConfig()
+    },
     fetchLoginInfo: async function(){
       let lastLogin = ''
       await settingRequests.fetchUserLastLoginTs().then((resp)=>{
@@ -171,8 +174,8 @@ const settingFunctions = {
       })
       return lastLogin
     },
-    fetchAdminInfo: async function(){
-      const loginInfo = await this.fetchLoginInfo()
+    fetchAdminInfo: async function(fetchLoginInfoFlag = false){
+      const loginInfo = fetchLoginInfoFlag ? await this.fetchLoginInfo() : ''
       let arr = []
       let resp = {}
       let accountSettingsDetails = {}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRoleSettings/TestRoleSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRoleSettings/TestRoleSettings.jsx
@@ -91,9 +91,9 @@ function TestRoleSettings() {
     let cancelled = false
     ;(async () => {
       try {
-        const { accountSettingsDetails } = await settingFunctions.fetchAdminInfo()
+        const accountConfig = await settingFunctions.fetchAccountConfig()
         if (cancelled) return
-        const hybrid = !!accountSettingsDetails?.hybridTestingEnabled
+        const hybrid = !!accountConfig?.hybridTestingEnabled
         setHybridTestingEnabled(hybrid)
         if (hybrid) {
           const { miniTestingServiceNames } = await api.fetchMiniTestingServiceNames()

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunResultPage/TestRunResultFlyout.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunResultPage/TestRunResultFlyout.jsx
@@ -214,10 +214,10 @@ function TestRunResultFlyout(props) {
     useEffect(() => {
         const fetchCompulsorySettings = async () => {
             try {
-                const { resp } = await settingFunctions.fetchAdminInfo();
+                const accountConfig = await settingFunctions.fetchAccountConfig();
 
-                if (resp?.compulsoryDescription) {
-                    setCompulsorySettings(resp.compulsoryDescription);
+                if (accountConfig?.compulsoryDescription) {
+                    setCompulsorySettings(accountConfig.compulsoryDescription);
                 }
             } catch (error) {
 


### PR DESCRIPTION
- Added fetchAccountConfig method in AdminSettingsAction to retrieve account configuration, including compulsory descriptions and hybrid testing status.
- Updated struts.xml to define the new API endpoint for fetchAccountConfig.
- Refactored frontend components to utilize fetchAccountConfig instead of fetchAdminInfo, ensuring the correct settings are applied in CompliancePage, IssuesPage, and TestRoleSettings.
- Introduced a new API request method in settings/api.js for fetching account configuration.