### PR TITLE
refactor(dao): simplify server selection logic in GuardrailPolicies

### DIFF
--- a/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
+++ b/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
@@ -133,13 +133,14 @@ public class GuardrailPolicies {
                     .map(serverId -> new SelectedServer(serverId, serverId))
                     .collect(java.util.stream.Collectors.toList());
         }
-        if (contextSource != null && contextSource != CONTEXT_SOURCE.AGENTIC) {
-            return new ArrayList<>();
-        }
-        if (!applyToAllServers) {
-            return new ArrayList<>();
-        }
-        return fetchApplicableServersByContext(Constants.AKTO_MCP_SERVER_TAG);
+        return new ArrayList<>();
+        // if (contextSource != null && contextSource != CONTEXT_SOURCE.AGENTIC) {
+        //     return new ArrayList<>();
+        // }
+        // if (!applyToAllServers) {
+        //     return new ArrayList<>();
+        // }
+        // return fetchApplicableServersByContext(Constants.AKTO_MCP_SERVER_TAG);
     }
 
     public List<SelectedServer> getEffectiveSelectedAgentServers() {
@@ -151,13 +152,14 @@ public class GuardrailPolicies {
                     .map(serverId -> new SelectedServer(serverId, serverId))
                     .collect(java.util.stream.Collectors.toList());
         }
-        if (contextSource != null && contextSource != CONTEXT_SOURCE.AGENTIC) {
-            return new ArrayList<>();
-        }
-        if (!applyToAllServers) {
-            return new ArrayList<>();
-        }
-        return fetchApplicableServersByContext(Constants.AKTO_GEN_AI_TAG);
+        return new ArrayList<>();
+        // if (contextSource != null && contextSource != CONTEXT_SOURCE.AGENTIC) {
+        //     return new ArrayList<>();
+        // }
+        // if (!applyToAllServers) {
+        //     return new ArrayList<>();
+        // }
+        // return fetchApplicableServersByContext(Constants.AKTO_GEN_AI_TAG);
     }
 
     // filters collections by the policy's contextSource tag (key="source", value=contextSource.name())


### PR DESCRIPTION
Removed conditional checks for contextSource and applyToAllServers in the getApplicableServers methods, returning an empty list instead. This change streamlines the server selection process and prepares for future enhancements.