### PR TITLE
feat: surface guardrail behaviour (block/warn/alert) in activity table

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ActivityLog.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/ActivityLog.jsx
@@ -17,7 +17,7 @@ import GetPrettifyEndpoint from '../../observe/GetPrettifyEndpoint';
 import PersistStore from "../../../../main/PersistStore";
 import { labelMap } from '../../../../main/labelHelperMap';
 import { isAgenticSecurityCategory, isEndpointSecurityCategory, mapLabel } from '../../../../main/labelHelper';
-import { extractRuleViolated } from '../utils/formatUtils';
+import { extractRuleViolated, extractBehaviour, getBehaviourTone } from '../utils/formatUtils';
   
  export const ActivityLog = ({ activityLog, actorDetails, loading = false }) => {
     const [itemStrings] = useState([
@@ -88,6 +88,10 @@ import { extractRuleViolated } from '../utils/formatUtils';
         const ruleViolated = (isAgenticSecurityCategory() || isEndpointSecurityCategory())
           ? extractRuleViolated(metadata)
           : null;
+        const behaviour = (isAgenticSecurityCategory() || isEndpointSecurityCategory())
+          ? extractBehaviour(metadata)
+          : null;
+        const behaviourTone = getBehaviourTone(behaviour);
 
         return (
           <IndexTable.Row
@@ -111,6 +115,13 @@ import { extractRuleViolated } from '../utils/formatUtils';
                 <Text variant="bodyMd" fontWeight="medium" as="span">
                   {ruleViolated}
                 </Text>
+              </IndexTable.Cell>
+            )}
+            {(isAgenticSecurityCategory() || isEndpointSecurityCategory()) && (
+              <IndexTable.Cell>
+                {behaviour ? (
+                  <Badge tone={behaviourTone}>{func.toSentenceCase(behaviour)}</Badge>
+                ) : "-"}
               </IndexTable.Cell>
             )}
             <IndexTable.Cell>
@@ -180,6 +191,7 @@ import { extractRuleViolated } from '../utils/formatUtils';
                   {title: 'Time'},
                   {title: labelMap[PersistStore.getState().dashboardCategory]["Attack type"]},
                   ...((isAgenticSecurityCategory() || isEndpointSecurityCategory()) ? [{title: 'Rule Violated'}] : []),
+                  ...((isAgenticSecurityCategory() || isEndpointSecurityCategory()) ? [{title: 'Behaviour'}] : []),
                   {title: 'Severity'},
                   {title: 'Host'},
                   {title: labelMap[PersistStore.getState().dashboardCategory]["API endpoint"]},

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/SusDataTable.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/SusDataTable.jsx
@@ -10,7 +10,7 @@ import { Badge, IndexFiltersMode, Avatar, Box, HorizontalStack, Text } from "@sh
 import dayjs from "dayjs";
 import SessionStore from "../../../../main/SessionStore";
 import { labelMap } from "../../../../main/labelHelperMap";
-import { formatActorId, extractRuleViolated } from "../utils/formatUtils";
+import { formatActorId, extractRuleViolated, extractBehaviour, getBehaviourTone } from "../utils/formatUtils";
 import threatDetectionRequests from "../api";
 import { LABELS } from "../constants";
 import { isAgenticSecurityCategory, isEndpointSecurityCategory } from "../../../../main/labelHelper";
@@ -73,6 +73,12 @@ const getHeaders = () => {
       value: "ruleViolated",
       title: "Rule Violated",
       maxWidth: "200px",
+    });
+    baseHeaders.push({
+      text: "Behaviour",
+      value: "behaviour",
+      title: "Behaviour",
+      maxWidth: "120px",
     });
   }
   baseHeaders.push(
@@ -591,7 +597,11 @@ function SusDataTable({ currDateRange, rowClicked, triggerRefresh, label = LABEL
               {isSessionBased ? 'Session' : 'Single Prompt'}
             </Badge>
           ),
-          ruleViolated: extractRuleViolated(x?.metadata)
+          ruleViolated: extractRuleViolated(x?.metadata),
+          behaviour: (() => {
+            const b = extractBehaviour(x?.metadata);
+            return b ? <Badge tone={getBehaviourTone(b)}>{func.toSentenceCase(b)}</Badge> : '-';
+          })(),
         }),
         compliance: complianceList.length > 0 ? (
           <HorizontalStack wrap={false} gap={1}>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/utils/formatUtils.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/utils/formatUtils.js
@@ -35,3 +35,17 @@ export const extractRuleViolated = (metadata) => {
     return "-";
   }
 };
+
+export const extractBehaviour = (metadata) => {
+  if (!metadata) return null;
+
+  try {
+    const metadataObj = JSON.parse(metadata);
+    return metadataObj.behaviour || null;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const getBehaviourTone = (behaviour) =>
+  behaviour === 'block' ? 'critical' : behaviour === 'warn' ? 'attention' : behaviour === 'alert' ? 'info' : undefined;

--- a/apps/guardrails-service/container/src/go.mod
+++ b/apps/guardrails-service/container/src/go.mod
@@ -3,7 +3,7 @@ module github.com/akto-api-security/guardrails-service
 go 1.24.11
 
 require (
-	github.com/akto-api-security/akto-endpoint-shield v0.0.0-20260608123556-3997aa716d14
+	github.com/akto-api-security/akto-endpoint-shield v0.0.0-20260614155929-56bc00fa9f00
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/segmentio/kafka-go v0.4.49
@@ -129,4 +129,4 @@ require (
 	modernc.org/sqlite v1.40.1 // indirect
 )
 
-replace github.com/akto-api-security/akto-endpoint-shield => github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260608123556-3997aa716d14
+replace github.com/akto-api-security/akto-endpoint-shield => github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260614155929-56bc00fa9f00

--- a/apps/guardrails-service/container/src/go.sum
+++ b/apps/guardrails-service/container/src/go.sum
@@ -29,8 +29,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/STARRY-S/zip v0.2.1 h1:pWBd4tuSGm3wtpoqRZZ2EAwOmcHK6XFf7bU9qcJXyFg=
 github.com/STARRY-S/zip v0.2.1/go.mod h1:xNvshLODWtC4EJ702g7cTYn13G53o1+X9BWnPFpcWV4=
-github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260608123556-3997aa716d14 h1:oTYFUM0WtuQezQURgmVeC8TL+H6bWlGNVTciSoCZ1Ic=
-github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260608123556-3997aa716d14/go.mod h1:tvCEIiZdk36hyCOeN/GLBqcQtFU8Hgua4UoaZYDDbkM=
+github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260614155929-56bc00fa9f00 h1:oVcnARZZi3VJDzebiJOr9gC1z2LgJczAPxcmyZCvwjo=
+github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260614155929-56bc00fa9f00/go.mod h1:tvCEIiZdk36hyCOeN/GLBqcQtFU8Hgua4UoaZYDDbkM=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/apps/guardrails-service/container/src/pkg/validator/service.go
+++ b/apps/guardrails-service/container/src/pkg/validator/service.go
@@ -493,6 +493,7 @@ func (s *Service) reportAndBlockPersonalAccount(_ context.Context, params *model
 				types.ContextSource(params.ContextSource),
 				extractHostHeader(reqHeaders),
 				sessionID,
+				"block",
 			); err != nil {
 				s.logger.Warn("Failed to report threat for personal account block", zap.String("policyName", policyName), zap.Error(err))
 			}
@@ -592,6 +593,7 @@ func (s *Service) reportAndBlockHost(params *models.ValidateRequestParams, valCt
 				types.ContextSource(params.ContextSource),
 				extractHostHeader(valCtx.RequestHeaders),
 				sessionID,
+				"block",
 			); err != nil {
 				s.logger.Warn("Failed to report threat for blocked host", zap.Error(err))
 			}

--- a/libs/utils/src/main/java/com/akto/kafka/Kafka.java
+++ b/libs/utils/src/main/java/com/akto/kafka/Kafka.java
@@ -198,8 +198,8 @@ public class Kafka {
     try {
       producer.send(record).get();
       producerReady = true;
-    } catch (Exception ignored) {
-      logger.error("Producer not ready. Cannot send message.");
+    } catch (Exception e) {
+      logger.error("Producer not ready. Cannot send message. Cause: " + e.getClass().getName() + ": " + e.getMessage());
       close();
     }
   }

--- a/protobuf/threat_detection/message/sample_request/v1/message.proto
+++ b/protobuf/threat_detection/message/sample_request/v1/message.proto
@@ -13,6 +13,7 @@ message Metadata {
   string risk_score = 5;
   string reason = 6;
   string dest_country_code = 7;
+  string behaviour = 8;
 }
 
 message SchemaConformanceError {


### PR DESCRIPTION
## Summary

- Adds `behaviour` field (block / warn / alert) to the `Metadata` proto message (`sample_request/v1/message.proto`, field 8)
- Passes `"block"` behaviour when guardrails-service reports threats for blocked hosts and personal-account blocks (`validator/service.go`)
- Extracts a shared `getBehaviourTone` helper in `formatUtils.js` (maps block→critical, warn→attention, alert→info) to eliminate the duplicated ternary chain
- Adds `extractBehaviour` utility that JSON-parses the metadata string and reads the `behaviour` key
- Displays a coloured **Behaviour** badge in `SusDataTable` (main activity table) and `ActivityLog` for Agentic and Endpoint security categories — mirrors the existing Rule Violated column placement
- Improves Kafka producer init-failure logging to include the actual exception class and message (was silently swallowed)
- Bumps `akto-endpoint-shield` pseudo-version to `20260614` in go.mod/go.sum

## Test plan

- [ ] Trigger a guardrail policy set to **block** — confirm the Behaviour column shows a red "Block" badge in the activity table
- [ ] Trigger a policy set to **warn** — confirm yellow "Warn" badge
- [ ] Trigger a policy set to **alert** — confirm blue "Alert" badge
- [ ] Confirm the column is absent for API Security category (not Agentic/Endpoint)
- [ ] Confirm `ActivityLog` widget shows the same badge for each behaviour
- [ ] Verify no regression on existing columns (Rule Violated, Detection Type, Severity, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)