### PR TITLE
Refactor ApiEndpoints.jsx to use includes() for URL checks instead of…

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiEndpoints.jsx
@@ -321,14 +321,14 @@ function ApiEndpoints(props) {
     const hasAccessToDiscoveryAgent = func.checkForFeatureSaas('STATIC_DISCOVERY_AI_AGENTS');
 
 
-    const isSkillCollection = (apiInfoList || []).some(info => info?.id?.url?.startsWith('/skills/'))
+    const isSkillCollection = (apiInfoList || []).some(info => info?.id?.url?.includes('/skills/'))
 
     // the values used here are defined at the server.
     const baseTableTabs = apiCollectionId === 111111999 ? ['All', 'New', 'High risk', 'No auth', 'Shadow'] : ( apiCollectionId === 111111120 ? ['All', 'New', 'Sensitive', 'High risk', 'Shadow'] : ['All', 'New', 'Sensitive', 'High risk', 'No auth', 'Shadow', 'Zombie'] )
     const definedTableTabs = isSkillCollection ? [...baseTableTabs, 'Blocked Skills'] : baseTableTabs
 
     const { tabsInfo } = useTable()
-    const blockedSkillsCount = (apiInfoList || []).filter(info => info?.id?.url?.startsWith('/skills/') && info.isSkillBlocked).length
+    const blockedSkillsCount = (apiInfoList || []).filter(info => info?.id?.url?.includes('/skills/') && info.isSkillBlocked).length
     const tableCountObj = { ...func.getTabsCount(definedTableTabs, endpointData), ...(isSkillCollection ? { blocked_skills: blockedSkillsCount } : {}) }
     const tableTabs = func.getTableTabsContent(definedTableTabs, tableCountObj, setSelectedTab, selectedTab, tabsInfo)
 
@@ -424,6 +424,7 @@ function ApiEndpoints(props) {
 
         apiEndpointsInCollection.forEach(apiEndpoint => {
             const key = apiEndpoint.method + " " + apiEndpoint.url + " " + apiEndpoint.apiCollectionId;
+            console.log("jey", key)
             const allSensitive = new Set(), sensitiveInResp = [], sensitiveInReq = [];
 
             sensitiveParamsMap[key]?.forEach(({ name, position }) => {
@@ -446,9 +447,9 @@ function ApiEndpoints(props) {
         // Scope to config-only or skills-only endpoints when navigated from the agent tree.
         // Config and skill endpoints live in the same collection; this keeps the two views distinct.
         if (agenticView === 'config') {
-            allEndpoints = allEndpoints.filter(e => e?.endpoint?.startsWith('/claude/config/'))
+            allEndpoints = allEndpoints.filter(e => e?.endpoint?.includes('/claude/config/'))
         } else if (agenticView === 'skills') {
-            allEndpoints = allEndpoints.filter(e => e?.endpoint?.startsWith('/skills/'))
+            allEndpoints = allEndpoints.filter(e => e?.endpoint?.includes('/skills/'))
         }
 
         // handle code analysis endpoints
@@ -1562,12 +1563,12 @@ function ApiEndpoints(props) {
         if (isSkillCollection) {
             const selectedSkillEndpoints = selectedResources.map(id =>
                 (endpointData["all"] || []).find(e => e.id === id)
-            ).filter(e => e?.endpoint?.startsWith('/skills/'))
+            ).filter(e => e?.endpoint?.includes('/skills/'))
 
             if (selectedSkillEndpoints.length > 0) {
                 const blockedUrlsSet = new Set(
                     (apiInfoList || [])
-                        .filter(i => i?.id?.url?.startsWith('/skills/') && i.isSkillBlocked)
+                        .filter(i => i?.id?.url?.includes('/skills/') && i.isSkillBlocked)
                         .map(i => i.id.url)
                 )
                 const hasUnblocked = selectedSkillEndpoints.some(e => !blockedUrlsSet.has(e.endpoint))
@@ -1601,7 +1602,7 @@ function ApiEndpoints(props) {
     async function handleBulkSkillBlock(selectedResources, block) {
         const selectedSkillEndpoints = selectedResources.map(id =>
             (endpointData["all"] || []).find(e => e.id === id)
-        ).filter(e => e?.endpoint?.startsWith('/skills/'))
+        ).filter(e => e?.endpoint?.includes('/skills/'))
 
         if (selectedSkillEndpoints.length === 0) return
 
@@ -1857,7 +1858,7 @@ function ApiEndpoints(props) {
     const blockedSkillsData = useMemo(() => {
         const blockedUrls = new Set(
             (apiInfoList || [])
-                .filter(info => info?.id?.url?.startsWith('/skills/') && info.isSkillBlocked)
+                .filter(info => info?.id?.url?.includes('/skills/') && info.isSkillBlocked)
                 .map(info => info.id.url)
         )
         return (endpointData['all'] || []).filter(e => blockedUrls.has(e.endpoint))

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/transform.js
@@ -840,6 +840,8 @@ const transform = {
     let resp = {}
     if(!isEndpointSecurityCategory()){
       resp = await this.getAllSubcategoriesData(false, type, setTestsLoaded)
+    }else{
+      return;
     }
     let subCategoryMap = {};
     resp?.subCategories.forEach((x) => {


### PR DESCRIPTION
… startsWith(). This change improves the flexibility of URL matching for skills and config endpoints. Additionally, added a guard clause in transform.js to prevent fetching subcategory data when the endpoint security category is active.