### PR TITLE
feat(guardrails): add malicious skill detection overview & remediation

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/constants/guardrailRuleDefinitions.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/constants/guardrailRuleDefinitions.js
@@ -13,7 +13,72 @@
  *   // info.heading, info.overview (array of { heading, body, items? }), info.remediation (markdown)
  */
 
+/**
+ * Pull the skill name out of a skill rule_violated value.
+ * Producer emits "skill:<skillName>"; the filterId form is
+ * "malicious_skill_detected~<agent>~skill:<skillName>". Handles both.
+ */
+function extractSkillName(ruleViolated) {
+    if (!ruleViolated || typeof ruleViolated !== 'string') return null;
+    const v = ruleViolated.trim();
+    const marker = 'skill:';
+    const idx = v.toLowerCase().lastIndexOf(marker);
+    if (idx === -1) return null; // no "skill:<name>" — e.g. the bare "malicious_skill_detected" form
+    const name = v.slice(idx + marker.length).trim();
+    return name.length > 0 ? name : null;
+}
+
+/** Skill-specific remediation. Concrete, scoped to the offending skill - not generic advice. */
+function buildSkillRemediation(skill) {
+    return `## What to do about \`${skill}\`
+
+### Right now
+1. **Disable \`${skill}\`** - remove or quarantine the skill file from the agent/device so it cannot be loaded again. This block stopped this run; deleting the file stops the next one.
+2. **Read why it fired** - open the Values tab and check the \`reason\` field. It tells you which pattern \`${skill}\` matched (remote-code download, credential exfiltration, or prompt injection) and what to clean up.
+3. **Find where it came from** - check who added \`${skill}\` and from what source (a copied gist, an untrusted registry, a teammate). If the source is compromised, every skill from it is suspect.
+
+### If \`${skill}\` could read secrets or run commands
+- Treat the host as compromised. **Rotate every credential, API key and token reachable from that machine** - assume they were read.
+- Review the agent's recent actions and outbound network calls for anything \`${skill}\` may have already triggered before it was blocked.
+
+### Stop it recurring
+- **Allowlist skills** for this agent/device so only reviewed skills load - reject anything not on the list.
+- **Review skill contents before enabling**: reject \`curl|bash\`-style download-and-run, any read of credential/secret files combined with a network call, and any text instructing the agent to ignore its own rules.
+- If \`${skill}\` is a known-good skill that was flagged by mistake, confirm its contents are clean, then add it to the allowlist so it is trusted explicitly rather than re-flagged each scan.`;
+}
+
 const GUARDRAIL_RULE_DEFINITIONS = [
+    // ─── Malicious Skill Detection ─────────────────────────────────────────────
+    // NOTE: rule_violated for skill events is "skill:<skillName>" (skillName is freeform).
+    // This entry MUST stay first so the "skill:" prefix is matched before broad
+    // substring prefixes below (e.g. a skill named "my-code-helper" would otherwise
+    // hit the BanCode "code" prefix via the matcher's includes() check).
+    {
+        prefixes: ["skill:", "malicious_skill_detected", "MaliciousSkill", "malicious_skill", "SkillDetection"],
+        heading: "Malicious Skill Detected",
+        // The skill name comes from the rule_violated value ("skill:<skillName>"), so the
+        // heading / overview / remediation are built per-event via customize(). See
+        // extractSkillName() and getGuardrailRuleInfo() below.
+        customize: (ruleViolated) => {
+            const skill = extractSkillName(ruleViolated) || "the skill";
+            const isNamed = skill !== "the skill";
+            return {
+                heading: isNamed ? `Malicious Skill Detected: ${skill}` : "Malicious Skill Detected",
+                overview: [
+                    {
+                        heading: "What was flagged?",
+                        body: `The skill **${skill}** was scanned and classified as malicious before the agent could use it. Skill detection only fires on three high-confidence attack patterns, so this is not a heuristic guess: (1) a download piped straight into a shell interpreter (\`curl ... | bash\`), (2) reading local credential/secret files **and** sending that data to an external URL, or (3) prompt injection - the skill explicitly telling the agent to ignore or override its own safety instructions. Open the Values tab and read the \`reason\` field to see exactly which one **${skill}** matched.`
+                    },
+                    {
+                        heading: "Why it matters",
+                        body: `Skills run with the agent's full privileges on the host that loaded them. If **${skill}** is left active it can execute remote code on that machine, exfiltrate API keys and secrets it can read, or quietly steer the agent off its guardrails - and because skills are shared across a device, the same file affects every agent and user on it.`
+                    }
+                ],
+                remediation: buildSkillRemediation(skill)
+            };
+        }
+    },
+
     // ─── Prompt Injection ──────────────────────────────────────────────────────
     {
         prefixes: ["PromptInjection", "prompt_injection"],
@@ -587,7 +652,9 @@ Identify the specific rule from the \`ruleViolated\` field:
 /**
  * Returns the rule definition entry matching the given ruleViolated or templateId.
  * Tries ruleViolated first (prefix/includes match), then templateId.
- * Returns null if no match found.
+ * If the matched entry defines customize(ruleViolated), its returned fields
+ * (heading / overview / remediation) override the static ones - this is how
+ * skill events render the actual skill name. Returns null if no match found.
  */
 export function getGuardrailRuleInfo(ruleViolated, templateId) {
     const matches = (value, prefixes) => {
@@ -599,14 +666,17 @@ export function getGuardrailRuleInfo(ruleViolated, templateId) {
         });
     };
 
+    const resolve = (def, ruleViolatedValue) =>
+        typeof def.customize === 'function' ? { ...def, ...def.customize(ruleViolatedValue) } : def;
+
     if (ruleViolated && ruleViolated !== '-') {
         for (const def of GUARDRAIL_RULE_DEFINITIONS) {
-            if (matches(ruleViolated, def.prefixes)) return def;
+            if (matches(ruleViolated, def.prefixes)) return resolve(def, ruleViolated);
         }
     }
     if (templateId) {
         for (const def of GUARDRAIL_RULE_DEFINITIONS) {
-            if (def.templateIdPrefixes && matches(templateId, def.templateIdPrefixes)) return def;
+            if (def.templateIdPrefixes && matches(templateId, def.templateIdPrefixes)) return resolve(def, ruleViolated);
         }
     }
     return null;


### PR DESCRIPTION
Skill-detection events (rule_violated = "skill:<skillName>") had no entry in GUARDRAIL_RULE_DEFINITIONS, so the Overview and Remediation tabs rendered empty.

- Add a Malicious Skill Detected definition, placed first so the "skill:" prefix matches before broad substring prefixes (e.g. a skill named "my-code-helper" would otherwise hit the BanCode "code" prefix).
- Render the actual skill name via a customize(ruleViolated) hook resolved in getGuardrailRuleInfo; extractSkillName() handles both "skill:<name>" and the "malicious_skill_detected~<agent>~skill:<name>" filterId form.
- Skill-specific, actionable remediation scoped to the offending skill instead of generic advice.