### PR TITLE
Make RAG detection robust to reduce false positives

### DIFF
--- a/libs/utils/src/main/java/com/akto/rag/RagDetector.java
+++ b/libs/utils/src/main/java/com/akto/rag/RagDetector.java
@@ -3,7 +3,10 @@ package com.akto.rag;
 import com.akto.dto.HttpResponseParams;
 import com.akto.log.LoggerMaker;
 import com.akto.log.LoggerMaker.LogDb;
+import com.akto.util.Constants;
+import com.akto.util.HttpRequestResponseUtils;
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -12,72 +15,122 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static com.akto.util.Constants.AKTO_RAG_DATABASE_TAG;
-
 /**
- * RAG (Retrieval-Augmented Generation) detection system.
- * Optimized detector that identifies vector database and RAG-related traffic.
- * Parses JSON and checks if RAG keywords exist as keys.
+ * RAG (Retrieval-Augmented Generation) detection.
+ *
+ * Identifies vector-database / RAG traffic using an ordered, corroboration-based model so that
+ * generic endpoints are NOT mis-tagged as RAG (e.g. GET /graphql/query/GetTierGroupV2/tierGroup,
+ * or paginated APIs whose body carries a "limit" field).
+ *
+ * Core principle: an ambiguous URL signal (one that reuses generic words such as "query" or
+ * "collections") never flags on its own - it must be corroborated by vector evidence in the body.
+ * Only signals that are essentially unique to vector search flag immediately.
+ *
+ * Evaluation order (returns at the first decision):
+ *   1. strong vendor Host        -> RAG          (checked first: Weaviate runs vector search over GraphQL)
+ *   2. GraphQL path              -> not RAG      (excludes the /graphql/... false-positive class)
+ *   3. strong anchored path      -> RAG          (e.g. /points/search, /embeddings)
+ *   4. strong body key           -> RAG          (e.g. query_vector, anns_field)
+ *   5. ambiguous path + body key -> RAG          (e.g. Pinecone /query, Chroma /collections/{id}/query)
+ *   6. >= 2 weak body keys       -> RAG
+ *   7. otherwise                 -> not RAG
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RagDetector {
 
     private static final LoggerMaker logger = new LoggerMaker(RagDetector.class, LogDb.RUNTIME);
 
-    // ==================== URL PATTERNS ====================
-    private static final List<Pattern> RAG_URL_PATTERNS = Arrays.asList(
-        // Vector database patterns
-        Pattern.compile(".*/collections?.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*/vectors?.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*/query.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*/embeddings?.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*pinecone\\.io.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*/chroma.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*weaviate.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*qdrant.*", Pattern.CASE_INSENSITIVE),
-        Pattern.compile(".*milvus.*", Pattern.CASE_INSENSITIVE)
+    /** Bound JSON traversal so a deeply nested / hostile payload cannot blow up. */
+    private static final int MAX_JSON_DEPTH = 6;
+    private static final int MAX_KEYS_SCANNED = 2000;
+
+    // ==================== STEP 1: STRONG VENDOR HOST ====================
+    // Managed vector-DB vendors, matched against the Host header. Vendor names sourced from
+    // com.akto.dto.tracing.TracingConstants. "chroma" is intentionally restricted to chromadb /
+    // trychroma because the bare word collides with chroma-key / colour / video hosts.
+    private static final List<Pattern> VENDOR_HOST_PATTERNS = Arrays.asList(
+        Pattern.compile("pinecone\\.io", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("\\bweaviate\\b", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("\\bqdrant\\b", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("\\bmilvus\\b", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("\\b(chromadb|trychroma)\\b", Pattern.CASE_INSENSITIVE)
     );
 
-    // ==================== DETECTION KEYWORDS ====================
-    private static final Set<String> RAG_KEYWORDS = new HashSet<>(Arrays.asList(
-        "embedding", "embeddings", "vector", "vectors", "query_embedding",
-        "query_vector", "similarity", "distance", "cosine", "euclidean",
-        "nearest", "neighbors", "knn", "ann", "top_k", "n_results",
-        "collection", "collections", "collection_name", "index", "indices",
-        "anns_field", "search_params", "metric_type", "limit",
-        "namespace", "output_fields", "with_payload", "include_metadata"
+    // ==================== STEP 3: STRONG ANCHORED PATHS ====================
+    // Anchored on vendor-specific segments with no generic words; safe to flag on their own.
+    // Qdrant's /points/* is required to sit under /collections/<name>/ so a generic /points/search
+    // (loyalty points, map points, ...) does not match.
+    private static final List<Pattern> STRONG_PATH_PATTERNS = Arrays.asList(
+        Pattern.compile("/vectors?/(search|upsert|delete|fetch)(?:[/?]|$)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("/collections?/[^/]+/points/(search|recommend|scroll|query)(?:[/?]|$)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("/vector[_-]?search(?:[/?]|$)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("/embeddings?(?:[/?]|$)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("/(knn|ann)[_-]?search(?:[/?]|$)", Pattern.CASE_INSENSITIVE)
+    );
+
+    // ==================== STEP 5: AMBIGUOUS PATHS (need body corroboration) ====================
+    // These reuse generic words ("query"/"collections") so they only flag when the body explicitly
+    // carries a vector/embedding key. Covers Pinecone's bare POST /query and Chroma's
+    // /collections/{id}/query.
+    private static final List<Pattern> AMBIGUOUS_PATH_PATTERNS = Arrays.asList(
+        Pattern.compile("/query(?:[/?]|$)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("/collections?/[^/]+/(query|search)(?:[/?]|$)", Pattern.CASE_INSENSITIVE)
+    );
+
+    // ==================== STEP 4: STRONG BODY KEYS ====================
+    // Phrases that essentially never occur outside vector search. A single match flags RAG.
+    private static final Set<String> STRONG_BODY_KEYS = new HashSet<>(Arrays.asList(
+        "query_vector", "query_vectors", "query_embedding", "query_embeddings", "anns_field"
+    ));
+
+    // ==================== BODY SIGNAL CATEGORIES (steps 5-6) ====================
+    // VECTOR_PRESENCE - explicit "what": the request actually carries a vector/embedding.
+    private static final Set<String> VECTOR_PRESENCE_KEYS = new HashSet<>(Arrays.asList(
+        "vector", "vectors", "embedding", "embeddings"
+    ));
+    // SEARCH_INTENT - high-precision "how": retrieval parameters used by real vector DBs. Generic
+    // concept words (similarity, cosine, euclidean, metric_type, nearest, neighbors, knn, ann) are
+    // deliberately excluded - they collide with analytics / geo / graph / maths APIs.
+    private static final Set<String> SEARCH_INTENT_KEYS = new HashSet<>(Arrays.asList(
+        "top_k", "topk", "n_results", "with_payload", "output_fields",
+        "search_params", "include_metadata", "includemetadata"
     ));
 
     /**
-     * Check if the request is a RAG operation.
-     * Returns true if RAG detected, false otherwise.
+     * Check if the request is a RAG operation. Returns true if RAG detected, false otherwise.
      */
     public static boolean isRagRequest(HttpResponseParams responseParams) {
-        if (responseParams == null) {
+        if (responseParams == null || responseParams.getRequestParams() == null) {
             return false;
         }
 
         try {
             String url = responseParams.getRequestParams().getURL();
-            String requestBody = responseParams.getRequestParams().getPayload();
-
-            if (url == null) {
+            if (StringUtils.isBlank(url)) {
                 return false;
             }
 
-            // Check URL patterns
-            if (checkUrlPatterns(url)) {
-                logger.info("Detected RAG operation from URL: " + url);
+            // Step 1: strong vendor host (before GraphQL exclusion - Weaviate searches over GraphQL)
+            String host = HttpRequestResponseUtils.getHeaderValue(
+                responseParams.getRequestParams().getHeaders(), Constants.HOST_HEADER);
+            if (matchesAny(VENDOR_HOST_PATTERNS, host)) {
+                logger.info("Detected RAG operation from vendor host: " + host);
                 return true;
             }
 
-            // Check body patterns
-            if (checkBodyPatterns(requestBody)) {
-                logger.info("Detected RAG operation from body content");
+            // Step 2: GraphQL is never RAG - kills the /graphql/query/... false-positive class
+            if (url.toLowerCase().contains("graphql")) {
+                return false;
+            }
+
+            // Step 3: strong anchored path
+            if (matchesAny(STRONG_PATH_PATTERNS, url)) {
+                logger.info("Detected RAG operation from vector path: " + url);
                 return true;
             }
 
-            return false;
+            // Steps 4-6: body-based detection (with ambiguous-path corroboration)
+            return checkBody(responseParams.getRequestParams().getPayload(), url);
 
         } catch (Exception e) {
             logger.error("Error detecting RAG operation: " + e.getMessage(), e);
@@ -86,11 +139,73 @@ public final class RagDetector {
     }
 
     /**
-     * Check if URL matches RAG patterns
+     * Body analysis (all conditions require parsed JSON keys):
+     *   step 4 - a strong, vector-exclusive key flags immediately;
+     *   step 5 - an ambiguous path ({@code /query}, {@code /collections/<name>/query}) corroborated
+     *            by an explicit vector/embedding key;
+     *   step 6 - body alone needs BOTH an explicit vector/embedding key AND a high-precision
+     *            retrieval term (AND of categories) - neither category alone is enough.
      */
-    private static boolean checkUrlPatterns(String url) {
-        for (Pattern pattern : RAG_URL_PATTERNS) {
-            if (pattern.matcher(url).find()) {
+    private static boolean checkBody(String requestBody, String url) {
+        if (StringUtils.isBlank(requestBody)) {
+            return false;
+        }
+
+        Object parsed;
+        try {
+            parsed = JSON.parse(requestBody);
+        } catch (Exception e) {
+            // Not JSON - we don't keyword-scan raw text to avoid substring false positives.
+            return false;
+        }
+        if (parsed == null) {
+            return false;
+        }
+
+        Set<String> keys = new HashSet<>();
+        collectKeys(parsed, keys, 0, new int[]{0});
+
+        // Step 4: strong body key
+        for (String strong : STRONG_BODY_KEYS) {
+            if (keys.contains(strong)) {
+                logger.info("Detected RAG operation from strong body key: " + strong);
+                return true;
+            }
+        }
+
+        boolean hasVectorPresence = containsAny(keys, VECTOR_PRESENCE_KEYS);
+        boolean hasSearchIntent = containsAny(keys, SEARCH_INTENT_KEYS);
+
+        // Step 5: ambiguous path corroborated by an explicit vector/embedding key
+        if (hasVectorPresence && matchesAny(AMBIGUOUS_PATH_PATTERNS, url)) {
+            logger.info("Detected RAG operation from ambiguous path " + url + " corroborated by a vector key");
+            return true;
+        }
+
+        // Step 6: body alone - vector/embedding key AND a retrieval term must co-occur
+        if (hasVectorPresence && hasSearchIntent) {
+            logger.info("Detected RAG operation from vector + retrieval body signals on URL: " + url);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static boolean containsAny(Set<String> keys, Set<String> candidates) {
+        for (String candidate : candidates) {
+            if (keys.contains(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matchesAny(List<Pattern> patterns, String value) {
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+        for (Pattern p : patterns) {
+            if (p.matcher(value).find()) {
                 return true;
             }
         }
@@ -98,50 +213,28 @@ public final class RagDetector {
     }
 
     /**
-     * Check request/response body for RAG keywords
+     * Recursively collect all object keys (lower-cased) from a parsed JSON value, bounded by depth
+     * and total keys scanned to stay safe on large / hostile payloads.
      */
-    private static boolean checkBodyPatterns(String requestBody) {
-        try {
-            // Check request body
-            if (StringUtils.isNotBlank(requestBody)) {
-                if (containsRagKeys(requestBody)) {
-                    logger.info("Detected RAG operation from request body");
-                    return true;
+    private static void collectKeys(Object node, Set<String> out, int depth, int[] scanned) {
+        if (node == null || depth > MAX_JSON_DEPTH || scanned[0] >= MAX_KEYS_SCANNED) {
+            return;
+        }
+        if (node instanceof JSONObject) {
+            for (Map.Entry<String, Object> entry : ((JSONObject) node).entrySet()) {
+                if (scanned[0]++ >= MAX_KEYS_SCANNED) {
+                    return;
                 }
+                out.add(entry.getKey().toLowerCase());
+                collectKeys(entry.getValue(), out, depth + 1, scanned);
             }
-
-        } catch (Exception e) {
-            logger.debug("Error checking body patterns: " + e.getMessage());
-        }
-
-        return false;
-    }
-
-    /**
-     * Parse JSON and check if any RAG keyword exists as a key.
-     * Iterates through RAG_KEYWORDS and checks if they exist in parsed JSON.
-     */
-    private static boolean containsRagKeys(String jsonString) {
-        if (jsonString == null || jsonString.isEmpty()) {
-            return false;
-        }
-
-        try {
-            // Parse JSON with fastjson2
-            JSONObject json = JSON.parseObject(jsonString);
-
-            // Check each keyword from RAG_KEYWORDS
-            for (String keyword : RAG_KEYWORDS) {
-                if (json.containsKey(keyword)) {
-                    return true;  // Found RAG keyword as key
+        } else if (node instanceof JSONArray) {
+            for (Object item : (JSONArray) node) {
+                if (scanned[0] >= MAX_KEYS_SCANNED) {
+                    return;
                 }
+                collectKeys(item, out, depth + 1, scanned);
             }
-
-        } catch (Exception e) {
-            // Not valid JSON or parsing error
-            return false;
         }
-
-        return false;
     }
 }

--- a/libs/utils/src/test/java/com/akto/rag/RagDetectorTest.java
+++ b/libs/utils/src/test/java/com/akto/rag/RagDetectorTest.java
@@ -1,0 +1,189 @@
+package com.akto.rag;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.akto.dto.HttpRequestParams;
+import com.akto.dto.HttpResponseParams;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RagDetectorTest {
+
+    private HttpResponseParams params(String url, String payload, Map<String, List<String>> headers) {
+        HttpRequestParams reqParams = new HttpRequestParams();
+        reqParams.setUrl(url);
+        reqParams.setPayload(payload);
+        reqParams.setHeaders(headers == null ? new HashMap<>() : headers);
+        reqParams.setApiCollectionId(123456789);
+
+        HttpResponseParams responseParams = new HttpResponseParams();
+        responseParams.setRequestParams(reqParams);
+        responseParams.statusCode = 200;
+        return responseParams;
+    }
+
+    private HttpResponseParams params(String url, String payload) {
+        return params(url, payload, null);
+    }
+
+    private Map<String, List<String>> hostHeader(String host) {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Host", Collections.singletonList(host));
+        return headers;
+    }
+
+    // ==================== FALSE POSITIVES ====================
+
+    @Test
+    public void testGraphQLQueryPathIsNotRag() {
+        // The reported regression: GraphQL endpoint must never be tagged RAG.
+        assertFalse(isRag("/graphql/query/GetTierGroupV2/tierGroup", null));
+    }
+
+    @Test
+    public void testPaginatedLimitBodyIsNotRag() {
+        assertFalse(isRag("/api/users", "{\"limit\":10,\"offset\":0}"));
+    }
+
+    @Test
+    public void testSingleWeakKeyIsNotRag() {
+        // One weak key, no corroborating path or second key.
+        assertFalse(isRag("/api/items", "{\"vector\":[0.1,0.2,0.3]}"));
+    }
+
+    @Test
+    public void testAmbiguousCollectionsQueryWithGraphQLBodyIsNotRag() {
+        String body = "{\"query\":\"query { tierGroup { id } }\",\"operationName\":\"q\",\"variables\":{}}";
+        assertFalse(isRag("/collections/users/query", body));
+    }
+
+    @Test
+    public void testAmbiguousQueryPathWithNonVectorBodyIsNotRag() {
+        assertFalse(isRag("/query", "{\"name\":\"x\"}"));
+    }
+
+    @Test
+    public void testGenericCollectionsPathIsNotRag() {
+        assertFalse(isRag("/api/v1/collections", "{\"name\":\"my-collection\"}"));
+    }
+
+    @Test
+    public void testQueryPathWithRetrievalTermButNoVectorIsNotRag() {
+        // analytics-style "top K" query - retrieval term but no vector/embedding key.
+        assertFalse(isRag("/query", "{\"top_k\":5,\"metric\":\"count\"}"));
+    }
+
+    @Test
+    public void testAnalyticsMetricTypeIsNotRag() {
+        // monitoring/analytics body - metric_type is no longer a signal at all.
+        assertFalse(isRag("/api/query", "{\"metric_type\":\"gauge\",\"similarity\":0.9}"));
+    }
+
+    @Test
+    public void testGeoNearestNeighborsIsNotRag() {
+        // geo/graph body - "nearest"/"neighbors" no longer count as signals.
+        assertFalse(isRag("/api/locations/query", "{\"nearest\":true,\"neighbors\":[1,2]}"));
+    }
+
+    @Test
+    public void testGraphicsVectorWithoutRetrievalIsNotRag() {
+        // 3D/physics API uses "vector"/"vectors" heavily but has no retrieval intent.
+        assertFalse(isRag("/api/render", "{\"vector\":[1,2,3],\"vectors\":[[4,5,6]]}"));
+    }
+
+    @Test
+    public void testGenericPointsSearchIsNotRag() {
+        // loyalty/map "points" search - not under /collections/<name>/points.
+        assertFalse(isRag("/api/points/search", "{\"q\":\"x\"}"));
+    }
+
+    // ==================== TRUE POSITIVES ====================
+
+    @Test
+    public void testPineconeVendorHostIsRag() {
+        assertTrue(isRag("/query", null, hostHeader("my-index-abc.svc.us-east1.pinecone.io")));
+    }
+
+    @Test
+    public void testWeaviateVendorHostOverGraphQLIsRag() {
+        // Weaviate runs vector search over GraphQL - host wins before the GraphQL exclusion.
+        assertTrue(isRag("/v1/graphql", "{\"query\":\"{ Get { Doc } }\"}", hostHeader("my-cluster.weaviate.network")));
+    }
+
+    @Test
+    public void testPineconeQueryPathCorroboratedByBodyIsRag() {
+        assertTrue(isRag("/query", "{\"vector\":[0.1,0.2],\"topK\":10,\"includeMetadata\":true}"));
+    }
+
+    @Test
+    public void testChromaCollectionsQueryIsRag() {
+        // query_embeddings is a strong key; also a corroborated ambiguous path.
+        assertTrue(isRag("/api/v1/collections/docs/query", "{\"query_embeddings\":[[0.1,0.2]],\"n_results\":10}"));
+    }
+
+    @Test
+    public void testQdrantPointsSearchPathIsRag() {
+        assertTrue(isRag("/collections/docs/points/search", "{\"vector\":[0.1,0.2],\"limit\":5}"));
+    }
+
+    @Test
+    public void testEmbeddingsPathIsRag() {
+        assertTrue(isRag("/v1/embeddings", "{\"input\":\"hello\",\"model\":\"text-embedding-3-small\"}"));
+    }
+
+    @Test
+    public void testStrongBodyKeyIsRag() {
+        assertTrue(isRag("/api/search", "{\"query_vector\":[0.1,0.2,0.3]}"));
+    }
+
+    @Test
+    public void testTwoWeakKeysIsRag() {
+        assertTrue(isRag("/api/search", "{\"vector\":[0.1,0.2],\"top_k\":5}"));
+    }
+
+    @Test
+    public void testNestedVectorBodyIsRag() {
+        // Qdrant-style nested payload - keys collected recursively.
+        assertTrue(isRag("/api/search", "{\"params\":{\"vector\":[0.1],\"top_k\":3}}"));
+    }
+
+    // ==================== EDGE CASES ====================
+
+    @Test
+    public void testNullRequestParamsIsNotRag() {
+        HttpResponseParams rp = new HttpResponseParams();
+        assertFalse(RagDetector.isRagRequest(rp));
+    }
+
+    @Test
+    public void testNullResponseParamsIsNotRag() {
+        assertFalse(RagDetector.isRagRequest(null));
+    }
+
+    @Test
+    public void testBlankUrlIsNotRag() {
+        assertFalse(isRag("", "{\"query_vector\":[0.1]}"));
+    }
+
+    @Test
+    public void testNonJsonBodyIsNotRag() {
+        // Raw text containing keywords must not be keyword-scanned.
+        assertFalse(isRag("/api/search", "this is a vector embedding similarity top_k blob"));
+    }
+
+    // ==================== helpers ====================
+
+    private boolean isRag(String url, String payload) {
+        return RagDetector.isRagRequest(params(url, payload));
+    }
+
+    private boolean isRag(String url, String payload, Map<String, List<String>> headers) {
+        return RagDetector.isRagRequest(params(url, payload, headers));
+    }
+}


### PR DESCRIPTION
Rewrote RagDetector with an ordered, corroboration-based model so generic endpoints are no longer mis-tagged as RAG (e.g. GET /graphql/query/... and paginated APIs with a "limit" field).

- Read host from the Host header (URL only holds the path), matching managed vendors (pinecone/weaviate/qdrant/milvus/chromadb,trychroma)
- Exclude GraphQL paths (after the vendor-host check, since Weaviate uses GraphQL)
- Flag on anchored vector paths and vector-exclusive body keys
- Ambiguous paths (/query, /collections/<name>/query) require an explicit vector/embedding body key to corroborate
- Body-alone detection requires BOTH a vector word AND a retrieval term
- Removed over-generic signals (limit, index, namespace, collection, distance, metric_type, nearest, neighbors, similarity, ...)
- Added RagDetectorTest (24 cases) covering the FP regressions and positives