### PR TITLE
fix: include Akto default topics and fix contentFiltering key in play…

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
@@ -987,12 +987,17 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
             blockedMessage: blockedMessage || "",
             applyToResponses: applyToResponses,
             behaviour: b,
-            contentFilters: {
+            contentFiltering: {
                 harmfulCategories: enableHarmfulCategories ? harmfulCategoriesSettings : null,
                 promptAttacks: enablePromptAttacks ? { level: promptAttackLevel.toUpperCase() } : null,
                 code: enableCodeFilter ? { level: codeFilterLevel.toUpperCase() } : null
             },
-            deniedTopics: deniedTopics,
+            deniedTopics: enableDeniedTopics
+                ? [
+                    ...GENERAL_BLOCKS.filter(b => selectedDefaultBlockKeys.has(b.key)).map(toDeniedTopic),
+                    ...deniedTopics
+                  ]
+                : [],
             wordFilters: wordFilters,
             piiFilters: piiTypes,
             regexPatterns: regexPatterns


### PR DESCRIPTION
…ground

- buildPlaygroundPolicyData now merges selectedDefaultBlockKeys (Akto default blocks like Illegal Drugs) with custom deniedTopics, matching the save-policy path
- Renamed contentFilters -> contentFiltering so Jackson maps the field correctly to GuardrailPolicies DTO; previously content filtering was silently dropped in playground requests