### PR TITLE
Add accurate, verified vulnerability evidence for test results

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/gpt/cache/VulnerabilityAnalysisCache.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/cache/VulnerabilityAnalysisCache.java
@@ -31,7 +31,7 @@ public class VulnerabilityAnalysisCache {
     public String generateCacheKey(String analysisType, String resultId, BasicDBObject contentData) {
         if (resultId != null && !resultId.trim().isEmpty()) {
             String type = (analysisType != null) ? analysisType.toLowerCase() : "analysis";
-            return type + "_vulnerability_reqresp_v5:" + resultId;
+            return type + "_vulnerability_reqresp_v6:" + resultId;
         }
         return null;
     }

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/cache/VulnerabilityAnalysisCache.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/cache/VulnerabilityAnalysisCache.java
@@ -31,7 +31,7 @@ public class VulnerabilityAnalysisCache {
     public String generateCacheKey(String analysisType, String resultId, BasicDBObject contentData) {
         if (resultId != null && !resultId.trim().isEmpty()) {
             String type = (analysisType != null) ? analysisType.toLowerCase() : "analysis";
-            return type + "_vulnerability_reqresp_v2:" + resultId;
+            return type + "_vulnerability_reqresp_v5:" + resultId;
         }
         return null;
     }

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/AnalyzeVulnerability.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/AnalyzeVulnerability.java
@@ -3,7 +3,12 @@ package com.akto.action.gpt.handlers;
 import com.akto.action.gpt.GptAction;
 import com.akto.action.gpt.result_fetchers.ResultFetcherStrategy;
 import com.akto.log.LoggerMaker;
+import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class AnalyzeVulnerability implements QueryHandler {
     
@@ -22,33 +27,77 @@ public class AnalyzeVulnerability implements QueryHandler {
         if (testData == null) {
             throw new Exception("No test data provided for vulnerability analysis");
         }
-        
-        
-        BasicDBObject request = new BasicDBObject();
-        request.put("query_type", GptQuery.ANALYZE_VULNERABILITY.getName());
-        request.put("test_data", testData);  // Pass structured data instead of raw response
-        request.put(GptAction.USER_EMAIL, meta.getString(GptAction.USER_EMAIL));
-        
-        // Create the prompt for LLM using the structured data
-        String prompt = buildPrompt(testData);
-        request.put("prompt", prompt);
-        
-        // Call LLM to analyze the response
-        BasicDBObject llmResponse = this.resultFetcherStrategy.fetchResult(request);
-        
-        // Log the prompt being sent to LLM
-        loggerMaker.infoAndAddToDb("Sending prompt to LLM for vulnerability analysis: " + prompt, LoggerMaker.LogDb.DASHBOARD);
-        // Log the LLM response for debugging/monitoring
-        if (llmResponse != null) {
-            loggerMaker.infoAndAddToDb("LLM Response received for vulnerability analysis: " + llmResponse, LoggerMaker.LogDb.DASHBOARD);
-        } else {
-            loggerMaker.infoAndAddToDb("No LLM response received for vulnerability analysis", LoggerMaker.LogDb.DASHBOARD);
+
+        BasicDBObject testContext = (BasicDBObject) testData.get("testContext");
+        String category = testContext != null ? testContext.getString("category") : null;
+
+        // 1) Deterministic, ground-truth detectors first (no hallucination possible).
+        BasicDBList deterministicSegments = VulnerabilityEvidenceDetector.detect(testData);
+        loggerMaker.infoAndAddToDb("Deterministic evidence segments for " + category + ": "
+                + deterministicSegments.size(), LoggerMaker.LogDb.DASHBOARD);
+
+        // 2) Call the LLM only for semantic categories, or when deterministic
+        //    detectors found nothing - so we never pay tokens or risk hallucination
+        //    when the ground truth already pinpoints the evidence.
+        BasicDBList llmSegments = new BasicDBList();
+        boolean shouldCallLlm = deterministicSegments.isEmpty() || !EvidenceRouter.isDeterministicStrong(category);
+        if (shouldCallLlm) {
+            BasicDBObject request = new BasicDBObject();
+            request.put("query_type", GptQuery.ANALYZE_VULNERABILITY.getName());
+            request.put("test_data", testData);  // Pass structured data instead of raw response
+            request.put(GptAction.USER_EMAIL, meta.getString(GptAction.USER_EMAIL));
+
+            String prompt = buildPrompt(testData);
+            request.put("prompt", prompt);
+            loggerMaker.infoAndAddToDb("Sending prompt to LLM for vulnerability analysis: " + prompt, LoggerMaker.LogDb.DASHBOARD);
+
+            BasicDBObject llmResponse = this.resultFetcherStrategy.fetchResult(request);
+            if (llmResponse != null) {
+                loggerMaker.infoAndAddToDb("LLM Response received for vulnerability analysis: " + llmResponse, LoggerMaker.LogDb.DASHBOARD);
+                Object segs = llmResponse.get("vulnerableSegments");
+                if (segs instanceof BasicDBList) {
+                    llmSegments = (BasicDBList) segs;
+                } else if (segs instanceof List) {
+                    llmSegments.addAll((List<?>) segs);
+                }
+            } else {
+                loggerMaker.infoAndAddToDb("No LLM response received for vulnerability analysis", LoggerMaker.LogDb.DASHBOARD);
+            }
         }
-        
-        // The resultFetcherStrategy already returns the processed vulnerability analysis
-        // No need for additional processing - return the result directly
-        return llmResponse != null ? llmResponse : new BasicDBObject();
-        //return createDummyVulnerabilityResult();
+
+        // 3) Merge - deterministic wins on conflicts; dedupe by location+field+phrase.
+        //    Every merged segment is still re-verified on the frontend (it must be
+        //    locatable in the rendered text and not a denylisted credential).
+        BasicDBList merged = mergeSegments(deterministicSegments, llmSegments);
+        BasicDBObject result = new BasicDBObject();
+        result.put("vulnerableSegments", merged);
+        return result;
+    }
+
+    // Deterministic segments first (they win), then any LLM segments whose
+    // location+field+phrase wasn't already covered.
+    private BasicDBList mergeSegments(BasicDBList deterministic, BasicDBList llm) {
+        BasicDBList merged = new BasicDBList();
+        Set<String> seen = new HashSet<>();
+        addUniqueSegments(merged, seen, deterministic);
+        addUniqueSegments(merged, seen, llm);
+        return merged;
+    }
+
+    private void addUniqueSegments(BasicDBList target, Set<String> seen, BasicDBList source) {
+        if (source == null) {
+            return;
+        }
+        for (Object item : source) {
+            if (!(item instanceof BasicDBObject)) {
+                continue;
+            }
+            BasicDBObject segment = (BasicDBObject) item;
+            String key = (segment.getString("location") + "|" + segment.getString("field") + "|" + segment.getString("phrase")).toLowerCase();
+            if (seen.add(key)) {
+                target.add(segment);
+            }
+        }
     }
     
     private String buildPrompt(BasicDBObject testData) {
@@ -58,6 +107,8 @@ public class AnalyzeVulnerability implements QueryHandler {
         BasicDBObject testContext = (BasicDBObject) testData.get("testContext");
         BasicDBObject request = (BasicDBObject) testData.get("request");
         BasicDBObject response = (BasicDBObject) testData.get("response");
+        Object modifiedRequestValues = testData.get("modifiedRequestValues");
+        Object siblingAttempts = testData.get("siblingAttempts");
         
         // Get test category from the structured data
         String testCategory = "UNKNOWN";
@@ -65,19 +116,36 @@ public class AnalyzeVulnerability implements QueryHandler {
             testCategory = testContext.getString("category");
         }
         
-        // Compact, small-model-friendly prompt. We intentionally keep it short and
-        // ask only for what the UI needs (location + phrase + reason) to minimise
-        // input/output tokens and avoid asking weaker models to compute offsets.
-        prompt.append("You are a security reviewer. The HTTP request/response below is ALREADY confirmed vulnerable for the ")
-              .append(testCategory).append(" test. Point to the exact evidence; do not re-judge.\n\n");
+        // Compact, small-model-friendly prompt. We give the model every source of
+        // proof (the test's success criteria, what the attack changed, the full
+        // request/response, and cross-attempt context) and ask it to point to the
+        // concrete evidence - never to re-judge or invent a generic reason.
+        prompt.append("You are a security reviewer. The HTTP exchange below is ALREADY confirmed vulnerable for the ")
+              .append(testCategory).append(" test. Select the exact evidence that proves it; do not re-judge.\n\n");
 
         if (testContext != null) {
             prompt.append("Test: ").append(testContext.getString("category"));
             if (testContext.getString("description") != null) {
                 prompt.append(" - ").append(testContext.getString("description"));
             }
-            prompt.append("\n\n");
+            prompt.append("\n");
         }
+
+        // Why this is vulnerable: the framework's own verdict + the test definition
+        // (its validate/success conditions and injected wordlists).
+        String validationReason = testContext != null ? testContext.getString("validationReason") : null;
+        String testTemplate = testContext != null ? testContext.getString("testTemplate") : null;
+        if (validationReason != null && !validationReason.trim().isEmpty()) {
+            prompt.append("Why flagged vulnerable (framework verdict): ").append(validationReason.trim()).append("\n");
+        }
+        if (testTemplate != null && !testTemplate.trim().isEmpty()) {
+            prompt.append("Test definition (validate conditions + injected values):\n```\n")
+                  .append(truncate(testTemplate.trim(), MAX_BLOCK_CHARS)).append("\n```\n");
+        }
+        prompt.append("\n");
+
+        // What the test changed vs the baseline request - the concrete injected values.
+        appendModifiedValues(prompt, modifiedRequestValues);
 
         // Full request (evidence such as a swapped auth token / cookie for broken
         // authorization lives here, not in the response).
@@ -95,15 +163,86 @@ public class AnalyzeVulnerability implements QueryHandler {
             appendHttpBlock(prompt, "RESPONSE", firstLine, response.get("headers"), response.getString("body"));
         }
 
+        // Cross-attempt context for multi-exec tests (rate limit, 2-account BOLA).
+        appendSiblingAttempts(prompt, siblingAttempts);
+
+        prompt.append("Where to look for this category: ").append(EvidenceRouter.route(testCategory).hint).append("\n\n");
+
         prompt.append("Rules:\n");
-        prompt.append("- Evidence may be in the REQUEST, the RESPONSE, or both. For broken authorization/access-control, highlight the request identity that was changed (auth token, cookie, or user id) AND the response value/status showing it wrongly succeeded.\n");
-        prompt.append("- \"phrase\" must be copied VERBATIM from that block and be the SMALLEST substring that pinpoints the issue (a single value, under 80 chars). For a header or field, return ONLY the value (e.g. the token after 'Bearer ', or the email value) - NOT the JSON \"key\":\"value\" pair. Never return a whole JSON object/array or cut a word in half.\n");
-        prompt.append("- One segment per distinct finding. \"reason\" is one short sentence specific to that phrase.\n");
-        prompt.append("- Always return at least one segment. If nothing is individually sensitive, point to the returned response value (or status code) that shows the request wrongly succeeded.\n");
+        prompt.append("- Highlight the concrete evidence that satisfies the test's validate condition. It may be in the REQUEST (an injected/changed value), the RESPONSE (a leaked value, header, or status), or both.\n");
+        prompt.append("- Prefer the values listed under \"What the test changed\" and the response proof. For response-only categories (sensitive-data exposure, error/stack-trace disclosure, CORS, missing security headers) point to the response value/header.\n");
+        prompt.append("- NEVER decode, base64-decode, parse or transform a JWT or any encoded/encrypted value. Only use text exactly as printed in the blocks below.\n");
+        prompt.append("- NEVER cite the caller's own credentials as evidence: do not return anything from the \"authorization\", \"cookie\", \"set-cookie\", \"proxy-authorization\", \"x-api-key\" or \"api-key\" headers, and never a bearer/JWT token, as the phrase. The caller's identity is not the exposed data.\n");
+        prompt.append("- \"phrase\" must be copied VERBATIM (character-for-character) from the REQUEST or RESPONSE block shown above and be the SMALLEST substring that pinpoints the issue (a single value, under 80 chars). If you cannot find the value verbatim in those blocks, do NOT include it. Return ONLY the value, NOT the \"key\":\"value\" pair, and never a whole JSON object/array or a half word.\n");
+        prompt.append("- \"field\" is the header name or body key that the value belongs to (e.g. \"product_vendor_provisioning_email\", \"sec-ch-ua-mobile\", \"email\"); it lets the UI bind the highlight precisely. Set it for every segment.\n");
+        prompt.append("- One segment per distinct finding. \"reason\" is one short sentence naming the actual value/field and why it proves the vulnerability (reference the validate condition).\n");
+        prompt.append("- For multi-exec tests the reason may explain the cross-attempt pattern, but \"phrase\" must still be copied from the REQUEST/RESPONSE blocks shown (the last attempt).\n");
+        prompt.append("- Return at least one segment. If only the status proves it, state the validate condition concretely (do NOT write a generic sentence).\n");
         prompt.append("Return ONLY this JSON, nothing else:\n");
-        prompt.append("{\"vulnerableSegments\":[{\"location\":\"REQUEST or RESPONSE\",\"phrase\":\"...\",\"reason\":\"...\"}]}\n");
+        prompt.append("{\"vulnerableSegments\":[{\"location\":\"REQUEST or RESPONSE\",\"field\":\"...\",\"phrase\":\"...\",\"reason\":\"...\"}]}\n");
 
         return prompt.toString();
+    }
+
+    // Render the baseline-vs-attack diff so the model can pick the injected values.
+    private void appendModifiedValues(StringBuilder prompt, Object modifiedRequestValues) {
+        if (!(modifiedRequestValues instanceof List)) {
+            return;
+        }
+        List<?> list = (List<?>) modifiedRequestValues;
+        if (list.isEmpty()) {
+            return;
+        }
+        prompt.append("What the test changed (baseline -> attack), these are the injected values:\n");
+        int count = 0;
+        for (Object item : list) {
+            if (!(item instanceof BasicDBObject)) {
+                continue;
+            }
+            BasicDBObject entry = (BasicDBObject) item;
+            String field = entry.getString("field");
+            Object original = entry.get("original");
+            Object modified = entry.get("modified");
+            prompt.append("- ").append(field == null ? "" : field).append(": ")
+                  .append(original == null ? "(absent)" : truncate(original.toString(), 120))
+                  .append(" -> ")
+                  .append(modified == null ? "" : truncate(modified.toString(), 120))
+                  .append("\n");
+            if (++count >= 15) {
+                break;
+            }
+        }
+        prompt.append("\n");
+    }
+
+    // Render a compact summary of the other attempts for multi-exec tests.
+    private void appendSiblingAttempts(StringBuilder prompt, Object siblingAttempts) {
+        if (!(siblingAttempts instanceof List)) {
+            return;
+        }
+        List<?> list = (List<?>) siblingAttempts;
+        if (list.isEmpty()) {
+            return;
+        }
+        prompt.append("Other attempts (for cross-attempt proof; highlight only on the last attempt shown above):\n");
+        int count = 0;
+        for (Object item : list) {
+            if (!(item instanceof BasicDBObject)) {
+                continue;
+            }
+            BasicDBObject entry = (BasicDBObject) item;
+            prompt.append("- attempt ").append(entry.get("attempt"))
+                  .append(": status ").append(entry.get("statusCode"));
+            Object keyChange = entry.get("keyChange");
+            if (keyChange != null) {
+                prompt.append(", change ").append(truncate(keyChange.toString(), 120));
+            }
+            prompt.append("\n");
+            if (++count >= 10) {
+                break;
+            }
+        }
+        prompt.append("\n");
     }
 
     // Cap per-block size so a huge body doesn't blow up token cost on small models.

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/AnalyzeVulnerability.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/AnalyzeVulnerability.java
@@ -29,40 +29,39 @@ public class AnalyzeVulnerability implements QueryHandler {
         }
 
         BasicDBObject testContext = (BasicDBObject) testData.get("testContext");
+        BasicDBObject response = (BasicDBObject) testData.get("response");
         String category = testContext != null ? testContext.getString("category") : null;
 
-        // 1) Deterministic, ground-truth detectors first (no hallucination possible).
-        BasicDBList deterministicSegments = VulnerabilityEvidenceDetector.detect(testData);
+        // 1) Precise deterministic detectors for the few single-artifact categories
+        //    (broken-auth 2xx status, wildcard CORS header). No hallucination possible.
+        BasicDBList deterministicSegments = VulnerabilityEvidenceDetector.detect(category, response);
         loggerMaker.infoAndAddToDb("Deterministic evidence segments for " + category + ": "
                 + deterministicSegments.size(), LoggerMaker.LogDb.DASHBOARD);
 
-        // 2) Call the LLM only for semantic categories, or when deterministic
-        //    detectors found nothing - so we never pay tokens or risk hallucination
-        //    when the ground truth already pinpoints the evidence.
+        // 2) Ask the LLM for the semantic evidence (it is told the exact data type /
+        //    location via EvidenceRouter and must copy values verbatim). Every segment
+        //    is re-verified on the frontend, so the LLM cannot fabricate highlights.
         BasicDBList llmSegments = new BasicDBList();
-        boolean shouldCallLlm = deterministicSegments.isEmpty() || !EvidenceRouter.isDeterministicStrong(category);
-        if (shouldCallLlm) {
-            BasicDBObject request = new BasicDBObject();
-            request.put("query_type", GptQuery.ANALYZE_VULNERABILITY.getName());
-            request.put("test_data", testData);  // Pass structured data instead of raw response
-            request.put(GptAction.USER_EMAIL, meta.getString(GptAction.USER_EMAIL));
+        BasicDBObject request = new BasicDBObject();
+        request.put("query_type", GptQuery.ANALYZE_VULNERABILITY.getName());
+        request.put("test_data", testData);  // Pass structured data instead of raw response
+        request.put(GptAction.USER_EMAIL, meta.getString(GptAction.USER_EMAIL));
 
-            String prompt = buildPrompt(testData);
-            request.put("prompt", prompt);
-            loggerMaker.infoAndAddToDb("Sending prompt to LLM for vulnerability analysis: " + prompt, LoggerMaker.LogDb.DASHBOARD);
+        String prompt = buildPrompt(testData);
+        request.put("prompt", prompt);
+        loggerMaker.infoAndAddToDb("Sending prompt to LLM for vulnerability analysis: " + prompt, LoggerMaker.LogDb.DASHBOARD);
 
-            BasicDBObject llmResponse = this.resultFetcherStrategy.fetchResult(request);
-            if (llmResponse != null) {
-                loggerMaker.infoAndAddToDb("LLM Response received for vulnerability analysis: " + llmResponse, LoggerMaker.LogDb.DASHBOARD);
-                Object segs = llmResponse.get("vulnerableSegments");
-                if (segs instanceof BasicDBList) {
-                    llmSegments = (BasicDBList) segs;
-                } else if (segs instanceof List) {
-                    llmSegments.addAll((List<?>) segs);
-                }
-            } else {
-                loggerMaker.infoAndAddToDb("No LLM response received for vulnerability analysis", LoggerMaker.LogDb.DASHBOARD);
+        BasicDBObject llmResponse = this.resultFetcherStrategy.fetchResult(request);
+        if (llmResponse != null) {
+            loggerMaker.infoAndAddToDb("LLM Response received for vulnerability analysis: " + llmResponse, LoggerMaker.LogDb.DASHBOARD);
+            Object segs = llmResponse.get("vulnerableSegments");
+            if (segs instanceof BasicDBList) {
+                llmSegments = (BasicDBList) segs;
+            } else if (segs instanceof List) {
+                llmSegments.addAll((List<?>) segs);
             }
+        } else {
+            loggerMaker.infoAndAddToDb("No LLM response received for vulnerability analysis", LoggerMaker.LogDb.DASHBOARD);
         }
 
         // 3) Merge - deterministic wins on conflicts; dedupe by location+field+phrase.
@@ -167,6 +166,17 @@ public class AnalyzeVulnerability implements QueryHandler {
         appendSiblingAttempts(prompt, siblingAttempts);
 
         prompt.append("Where to look for this category: ").append(EvidenceRouter.route(testCategory).hint).append("\n\n");
+
+        // Sensitive-data exposure: the exact data type is already known from the test
+        // sub-type, so name it explicitly instead of letting the model guess.
+        String edeDataType = EvidenceRouter.edeDataType(testCategory);
+        if (edeDataType != null) {
+            prompt.append("This is a sensitive-data exposure test for the data type ").append(edeDataType)
+                  .append(". Find the actual ").append(edeDataType)
+                  .append(" value and return it VERBATIM as \"phrase\", with \"field\" set to the key holding it. ")
+                  .append("If the only ").append(edeDataType)
+                  .append(" present is inside the caller's own authorization/cookie/token, do NOT return it - that is the caller's identity, not exposed data.\n\n");
+        }
 
         prompt.append("Rules:\n");
         prompt.append("- Highlight the concrete evidence that satisfies the test's validate condition. It may be in the REQUEST (an injected/changed value), the RESPONSE (a leaked value, header, or status), or both.\n");

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
@@ -12,12 +12,10 @@ import java.util.List;
 public class EvidenceRouter {
 
     public enum Detector {
-        DATATYPE_RESPONSE_SCAN, // sensitive-data exposure: scan response for the data type
-        REQUEST_DIFF,           // injection/fuzzing/authz: the values the test changed
-        RESPONSE_HEADERS,       // CORS / security misconfig: a response header
+        RESPONSE_HEADERS,       // CORS / security misconfig: a precise response header
         RESPONSE_STATUS,        // broken auth / no-auth: 2xx returned after token removed
         CROSS_ATTEMPT,          // rate-limit / multi-account: proof spans attempts
-        LLM_SEMANTIC            // error/stack-trace disclosure, business logic
+        LLM_SEMANTIC            // everything else: LLM selects evidence, FE verifies it
     }
 
     public static class Route {
@@ -42,13 +40,22 @@ public class EvidenceRouter {
     public static Route route(String category) {
         String c = category == null ? "" : category.toUpperCase();
 
+        // Sensitive-data exposure: the data type is already known from the test
+        // sub-type (see edeDataType) and may surface in EITHER the response or the
+        // request (the test's own conditions decide where). We do not re-scan/re-
+        // classify here - the LLM is told the exact data type and asked to copy the
+        // value verbatim; the frontend then verifies it is actually highlightable.
         if (c.startsWith(EDE_PREFIX) || c.contains("EXCESSIVE_DATA") || c.equals("EDE")) {
             return new Route(
-                list("RESPONSE"),
-                list(Detector.DATATYPE_RESPONSE_SCAN),
-                "Evidence is the exposed value in the RESPONSE body or headers.");
+                list("RESPONSE", "REQUEST"),
+                list(Detector.LLM_SEMANTIC),
+                "Evidence is the exposed value of the data type named by this test, shown verbatim in the RESPONSE (or the REQUEST if that is where the sensitive value appears).");
         }
-        if (c.contains("CORS") || c.contains("SECURITY_HEADER") || c.contains("MISCONFIG") || c.contains("SSRF")) {
+        // Header-based misconfig ONLY (CORS / security headers). Keep this first
+        // check precise: SSRF is NOT a response-header finding (its proof is the
+        // injected URL in the request + the fetched content in the response), so it
+        // must not be routed here - it falls through to the request/response path.
+        if (c.contains("CORS") || c.contains("SECURITY_HEADER")) {
             return new Route(
                 list("RESPONSE"),
                 list(Detector.RESPONSE_HEADERS, Detector.LLM_SEMANTIC),
@@ -60,36 +67,58 @@ public class EvidenceRouter {
                 list(Detector.CROSS_ATTEMPT, Detector.LLM_SEMANTIC),
                 "Evidence spans attempts; cite the RESPONSE status that shows the limit was not enforced.");
         }
+        // Injection / fuzzing FIRST: a broad bucket like NO_AUTH can also contain
+        // SQLi / command-injection / SSTI / CRLF tests (especially custom ones).
+        // For those the proof is the injected REQUEST payload + the RESPONSE effect,
+        // NOT a "token was removed" 2xx - so match them before the broken-auth branch.
+        if (c.contains("INJECTION") || c.contains("SQL") || c.contains("SSTI")
+                || c.contains("CRLF") || c.contains("XSS") || c.contains("XXE")
+                || c.contains("TEMPLATE") || c.contains("LDAP") || c.contains("FUZZ")
+                || c.contains("SSRF")) {
+            return new Route(
+                list("REQUEST", "RESPONSE"),
+                list(Detector.LLM_SEMANTIC),
+                "Evidence is the injected REQUEST payload (the value the test added, listed in the test definition) and the RESPONSE proof that it executed/was reflected.");
+        }
         // Broken authentication / no-auth: the test removes or breaks the auth token
-        // and the server still returns 2xx. The evidence is response-side (the status
-        // + any data returned), NOT the request headers, so do not run request-diff.
+        // and the server still returns 2xx. Evidence is primarily response-side (the
+        // status + any data returned). We still run request-diff so that if the test
+        // actually injected a value (mislabeled under this bucket) it is highlighted.
         if (c.contains("NO_AUTH") || c.contains("ANY_USER") || c.contains("REMOVE_TOKEN")
                 || c.contains("REPLACE_AUTH") || c.contains("ADD_USER_TOKEN") || c.contains("AUTH_BYPASS")
-                || c.contains("BROKEN_AUTHENTICATION") || c.contains("AUTHENTICATION")) {
+                || c.contains("BROKEN_AUTHENTICATION")) {
             return new Route(
-                list("RESPONSE"),
+                list("REQUEST", "RESPONSE"),
                 list(Detector.RESPONSE_STATUS, Detector.LLM_SEMANTIC),
-                "The auth token was removed/invalidated; evidence is the 2xx RESPONSE status and any data the response returned. Do NOT cite the request's own auth token or headers.");
+                "Evidence is usually the 2xx RESPONSE status returned after the auth token was removed/invalidated, plus any data the response returned. If the test instead injected a payload (this broad bucket can include injection tests), the injected REQUEST value listed in the test definition is the evidence. Do NOT cite the caller's own auth token or transport headers.");
         }
         if (c.contains("BOLA") || c.contains("BFLA") || c.contains("IDOR") || c.contains("AUTH")
                 || c.contains("ACCESS") || c.contains("PRIVILEGE") || c.contains("ACCOUNT")) {
             return new Route(
                 list("REQUEST", "RESPONSE"),
-                list(Detector.REQUEST_DIFF, Detector.LLM_SEMANTIC),
-                "Evidence is the changed request object id/identity AND the RESPONSE data wrongly returned. Do NOT cite the caller's auth token.");
+                list(Detector.LLM_SEMANTIC),
+                "Evidence is the changed request object id/identity in the REQUEST, and the RESPONSE returning another user's/role's resource (its body closely matches the victim's by schema/percentage) when access should have been denied. Do NOT cite the caller's auth token.");
         }
         // default: injection / fuzzing / semantic
         return new Route(
             list("REQUEST", "RESPONSE"),
-            list(Detector.REQUEST_DIFF, Detector.LLM_SEMANTIC),
+            list(Detector.LLM_SEMANTIC),
             "Evidence is the injected REQUEST value and/or the RESPONSE proof.");
     }
 
     /**
-     * True when the category has a deterministic detector strong enough that we
-     * can skip the LLM entirely when that detector produced evidence.
+     * The sensitive data type a sensitive-data-exposure test targets (e.g.
+     * SENSITIVE_DATA_EXPOSURE_EMAIL -> EMAIL), or null if this is not an EDE
+     * category. Lets the prompt name the exact data type instead of re-scanning.
      */
-    public static boolean isDeterministicStrong(String category) {
-        return route(category).detectors.contains(Detector.DATATYPE_RESPONSE_SCAN);
+    public static String edeDataType(String category) {
+        if (category == null) {
+            return null;
+        }
+        String c = category.toUpperCase();
+        if (c.startsWith(EDE_PREFIX) && c.length() > EDE_PREFIX.length()) {
+            return c.substring(EDE_PREFIX.length());
+        }
+        return null;
     }
 }

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
@@ -81,9 +81,10 @@ public class EvidenceRouter {
                 "Evidence is the injected REQUEST payload (the value the test added, listed in the test definition) and the RESPONSE proof that it executed/was reflected.");
         }
         // Broken authentication / no-auth: the test removes or breaks the auth token
-        // and the server still returns 2xx. Evidence is primarily response-side (the
-        // status + any data returned). We still run request-diff so that if the test
-        // actually injected a value (mislabeled under this bucket) it is highlighted.
+        // and the server still returns 2xx, so the evidence is response-side (the
+        // status + any data returned). Injection tests that can also be filed under
+        // this broad bucket are already caught by the injection branch above; if one
+        // still lands here, LLM_SEMANTIC (told via the hint) picks the injected value.
         if (c.contains("NO_AUTH") || c.contains("ANY_USER") || c.contains("REMOVE_TOKEN")
                 || c.contains("REPLACE_AUTH") || c.contains("ADD_USER_TOKEN") || c.contains("AUTH_BYPASS")
                 || c.contains("BROKEN_AUTHENTICATION")) {

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
@@ -1,0 +1,95 @@
+package com.akto.action.gpt.handlers;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Single source of truth for WHERE vulnerability evidence lives per test
+ * category. Drives (a) which deterministic detectors to run and (b) the
+ * location hint given to the LLM, so evidence is selected by category rather
+ * than guessed.
+ */
+public class EvidenceRouter {
+
+    public enum Detector {
+        DATATYPE_RESPONSE_SCAN, // sensitive-data exposure: scan response for the data type
+        REQUEST_DIFF,           // injection/fuzzing/authz: the values the test changed
+        RESPONSE_HEADERS,       // CORS / security misconfig: a response header
+        RESPONSE_STATUS,        // broken auth / no-auth: 2xx returned after token removed
+        CROSS_ATTEMPT,          // rate-limit / multi-account: proof spans attempts
+        LLM_SEMANTIC            // error/stack-trace disclosure, business logic
+    }
+
+    public static class Route {
+        public final List<String> locations;   // REQUEST / RESPONSE
+        public final List<Detector> detectors;
+        public final String hint;               // prompt location hint
+
+        public Route(List<String> locations, List<Detector> detectors, String hint) {
+            this.locations = locations;
+            this.detectors = detectors;
+            this.hint = hint;
+        }
+    }
+
+    public static final String EDE_PREFIX = "SENSITIVE_DATA_EXPOSURE_";
+
+    @SafeVarargs
+    private static <T> List<T> list(T... items) {
+        return Arrays.asList(items);
+    }
+
+    public static Route route(String category) {
+        String c = category == null ? "" : category.toUpperCase();
+
+        if (c.startsWith(EDE_PREFIX) || c.contains("EXCESSIVE_DATA") || c.equals("EDE")) {
+            return new Route(
+                list("RESPONSE"),
+                list(Detector.DATATYPE_RESPONSE_SCAN),
+                "Evidence is the exposed value in the RESPONSE body or headers.");
+        }
+        if (c.contains("CORS") || c.contains("SECURITY_HEADER") || c.contains("MISCONFIG") || c.contains("SSRF")) {
+            return new Route(
+                list("RESPONSE"),
+                list(Detector.RESPONSE_HEADERS, Detector.LLM_SEMANTIC),
+                "Evidence is usually a RESPONSE header (e.g. access-control-allow-origin: *).");
+        }
+        if (c.contains("RATE") || c.contains("LIMIT")) {
+            return new Route(
+                list("REQUEST", "RESPONSE"),
+                list(Detector.CROSS_ATTEMPT, Detector.LLM_SEMANTIC),
+                "Evidence spans attempts; cite the RESPONSE status that shows the limit was not enforced.");
+        }
+        // Broken authentication / no-auth: the test removes or breaks the auth token
+        // and the server still returns 2xx. The evidence is response-side (the status
+        // + any data returned), NOT the request headers, so do not run request-diff.
+        if (c.contains("NO_AUTH") || c.contains("ANY_USER") || c.contains("REMOVE_TOKEN")
+                || c.contains("REPLACE_AUTH") || c.contains("ADD_USER_TOKEN") || c.contains("AUTH_BYPASS")
+                || c.contains("BROKEN_AUTHENTICATION") || c.contains("AUTHENTICATION")) {
+            return new Route(
+                list("RESPONSE"),
+                list(Detector.RESPONSE_STATUS, Detector.LLM_SEMANTIC),
+                "The auth token was removed/invalidated; evidence is the 2xx RESPONSE status and any data the response returned. Do NOT cite the request's own auth token or headers.");
+        }
+        if (c.contains("BOLA") || c.contains("BFLA") || c.contains("IDOR") || c.contains("AUTH")
+                || c.contains("ACCESS") || c.contains("PRIVILEGE") || c.contains("ACCOUNT")) {
+            return new Route(
+                list("REQUEST", "RESPONSE"),
+                list(Detector.REQUEST_DIFF, Detector.LLM_SEMANTIC),
+                "Evidence is the changed request object id/identity AND the RESPONSE data wrongly returned. Do NOT cite the caller's auth token.");
+        }
+        // default: injection / fuzzing / semantic
+        return new Route(
+            list("REQUEST", "RESPONSE"),
+            list(Detector.REQUEST_DIFF, Detector.LLM_SEMANTIC),
+            "Evidence is the injected REQUEST value and/or the RESPONSE proof.");
+    }
+
+    /**
+     * True when the category has a deterministic detector strong enough that we
+     * can skip the LLM entirely when that detector produced evidence.
+     */
+    public static boolean isDeterministicStrong(String category) {
+        return route(category).detectors.contains(Detector.DATATYPE_RESPONSE_SCAN);
+    }
+}

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/VulnerabilityEvidenceDetector.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/VulnerabilityEvidenceDetector.java
@@ -1,151 +1,47 @@
 package com.akto.action.gpt.handlers;
 
-import com.akto.dto.type.KeyTypes;
-import com.akto.dto.type.SingleTypeInfo.SubType;
 import com.akto.log.LoggerMaker;
 import com.google.gson.Gson;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
- * Ground-truth, hallucination-free evidence detectors. These reuse Akto's own
- * data-type definitions (so detection equals what the engine already does) and
- * the baseline-vs-attack request diff, producing evidence that is guaranteed to
- * exist verbatim in the rendered request/response. The LLM is only an augmenter.
+ * Precise, hallucination-free evidence detectors for the few categories where the
+ * proof is a deterministic, single response artifact: the 2xx status that proves
+ * broken authentication, and the wildcard CORS header. Everything else (sensitive
+ * data exposure, injection, BOLA/BFLA, etc.) is left to the LLM - which is told
+ * the exact data type / location via EvidenceRouter - and then verified on the
+ * frontend, so we never re-implement Akto's data-type detection here.
  */
 public class VulnerabilityEvidenceDetector {
 
     private static final LoggerMaker loggerMaker = new LoggerMaker(VulnerabilityEvidenceDetector.class, LoggerMaker.LogDb.DASHBOARD);
     private static final Gson gson = new Gson();
-    private static final int MAX_SEGMENTS = 10;
     private static final int MAX_PHRASE_CHARS = 80;
 
-    public static BasicDBList detect(BasicDBObject testData) {
+    public static BasicDBList detect(String category, BasicDBObject response) {
         BasicDBList segments = new BasicDBList();
-        if (testData == null) {
-            return segments;
-        }
         try {
-            BasicDBObject testContext = (BasicDBObject) testData.get("testContext");
-            BasicDBObject response = (BasicDBObject) testData.get("response");
-            String category = testContext != null ? testContext.getString("category") : null;
             String cUpper = category == null ? "" : category.toUpperCase();
-
             EvidenceRouter.Route route = EvidenceRouter.route(category);
 
-            if (route.detectors.contains(EvidenceRouter.Detector.DATATYPE_RESPONSE_SCAN)
-                    && response != null && cUpper.startsWith(EvidenceRouter.EDE_PREFIX)) {
-                String typeName = cUpper.substring(EvidenceRouter.EDE_PREFIX.length());
-                addDataTypeResponseSegments(segments, response, typeName);
+            if (response == null) {
+                return segments;
             }
 
-            if (route.detectors.contains(EvidenceRouter.Detector.REQUEST_DIFF)) {
-                addRequestDiffSegments(segments, testData.get("modifiedRequestValues"));
-            }
-
-            if (route.detectors.contains(EvidenceRouter.Detector.RESPONSE_STATUS) && response != null) {
+            if (route.detectors.contains(EvidenceRouter.Detector.RESPONSE_STATUS)) {
                 addResponseStatusSegment(segments, response);
             }
 
-            if (route.detectors.contains(EvidenceRouter.Detector.RESPONSE_HEADERS) && response != null) {
+            if (route.detectors.contains(EvidenceRouter.Detector.RESPONSE_HEADERS)) {
                 addCorsSegments(segments, response, cUpper);
             }
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb("Deterministic evidence detection failed: " + e.getMessage(), LoggerMaker.LogDb.DASHBOARD);
         }
         return segments;
-    }
-
-    // Sensitive-data exposure: scan the response body + headers for the data type
-    // named by the test (e.g. SENSITIVE_DATA_EXPOSURE_EMAIL -> EMAIL) using Akto's
-    // own classifier, and emit one segment per matched key/value.
-    private static void addDataTypeResponseSegments(BasicDBList segments, BasicDBObject response, String typeName) {
-        int[] count = {0};
-        scan(asNode(response.get("body")), null, typeName, segments, count);
-        scan(asNode(response.get("headers")), null, typeName, segments, count);
-    }
-
-    private static void scan(Object node, String key, String typeName, BasicDBList segments, int[] count) {
-        if (node == null || count[0] >= MAX_SEGMENTS) {
-            return;
-        }
-        if (node instanceof Map) {
-            for (Map.Entry<?, ?> entry : ((Map<?, ?>) node).entrySet()) {
-                scan(entry.getValue(), String.valueOf(entry.getKey()), typeName, segments, count);
-                if (count[0] >= MAX_SEGMENTS) {
-                    return;
-                }
-            }
-        } else if (node instanceof List) {
-            for (Object item : (List<?>) node) {
-                scan(item, key, typeName, segments, count);
-                if (count[0] >= MAX_SEGMENTS) {
-                    return;
-                }
-            }
-        } else {
-            String value = node.toString();
-            if (value.trim().isEmpty()) {
-                return;
-            }
-            SubType subType = classify(value, key);
-            if (subType != null && typeName.equalsIgnoreCase(subType.getName())) {
-                String reason = "The response exposes " + subType.getName()
-                        + (key != null ? " in field \"" + key + "\"" : "") + ", which the test flags as sensitive-data exposure.";
-                segments.add(makeSegment("RESPONSE", key, value, reason));
-                count[0]++;
-            }
-        }
-    }
-
-    private static SubType classify(String value, String key) {
-        try {
-            return KeyTypes.findSubType(value, key, null, true);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    // The injected/changed request values are deterministic proof for injection,
-    // fuzzing and authz tests. (Credential fields are dropped later by the FE
-    // denylist, so we never present the caller's own token as evidence.)
-    private static void addRequestDiffSegments(BasicDBList segments, Object modifiedRequestValues) {
-        if (!(modifiedRequestValues instanceof List)) {
-            return;
-        }
-        int count = 0;
-        for (Object item : (List<?>) modifiedRequestValues) {
-            if (!(item instanceof BasicDBObject)) {
-                continue;
-            }
-            BasicDBObject entry = (BasicDBObject) item;
-            String field = entry.getString("field");
-            if (isNoiseField(field)) {
-                continue;
-            }
-            Object modified = entry.get("modified");
-            Object original = entry.get("original");
-            if (modified == null) {
-                continue;
-            }
-            String phrase = modified.toString();
-            if (phrase.trim().isEmpty()) {
-                continue;
-            }
-            String reason = (original != null)
-                    ? "The request changed \"" + field + "\" to \"" + truncate(phrase) + "\" and the endpoint accepted it."
-                    : "The request injected \"" + truncate(phrase) + "\" into \"" + field + "\" and the endpoint accepted it.";
-            segments.add(makeSegment("REQUEST", field, phrase, reason));
-            if (++count >= 15) {
-                break;
-            }
-        }
     }
 
     // Broken authentication / no-auth: a 2xx returned after the auth token was
@@ -184,37 +80,6 @@ public class VulnerabilityEvidenceDetector {
             }
             break;
         }
-    }
-
-    // Transport / proxy / CDN / infra / credential / probe headers are never
-    // meaningful attack evidence - they ride along on every request. Mirrors the
-    // frontend isNoiseField so the request-diff detector never floods the panel.
-    private static final String[] NOISE_FIELD_PREFIXES = {
-        "x-forwarded-", "x-akto-", "x-sigsci-", "fastly-", "sec-fetch-", "sec-ch-", "x-amzn-", "cf-"
-    };
-    private static final Set<String> NOISE_FIELD_EXACT = new HashSet<>(Arrays.asList(
-        "host", "content-length", "content-type", "connection", "accept", "accept-encoding",
-        "accept-language", "accept-charset", "user-agent", "referer", "origin", "cache-control",
-        "pragma", "te", "trailer", "transfer-encoding", "upgrade", "keep-alive", "via", "forwarded",
-        "x-real-ip", "x-request-id", "x-correlation-id", "cdn-loop", "x-varnish", "x-timer",
-        "x-cache", "x-cache-hits", "x-served-by", "dnt",
-        "authorization", "cookie", "set-cookie", "proxy-authorization", "x-api-key", "api-key", "apikey", "a"
-    ));
-
-    private static boolean isNoiseField(String field) {
-        if (field == null) {
-            return true;
-        }
-        String k = field.trim().toLowerCase();
-        if (k.isEmpty() || NOISE_FIELD_EXACT.contains(k)) {
-            return true;
-        }
-        for (String prefix : NOISE_FIELD_PREFIXES) {
-            if (k.startsWith(prefix)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static Object asNode(Object value) {

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/VulnerabilityEvidenceDetector.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/VulnerabilityEvidenceDetector.java
@@ -1,0 +1,256 @@
+package com.akto.action.gpt.handlers;
+
+import com.akto.dto.type.KeyTypes;
+import com.akto.dto.type.SingleTypeInfo.SubType;
+import com.akto.log.LoggerMaker;
+import com.google.gson.Gson;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Ground-truth, hallucination-free evidence detectors. These reuse Akto's own
+ * data-type definitions (so detection equals what the engine already does) and
+ * the baseline-vs-attack request diff, producing evidence that is guaranteed to
+ * exist verbatim in the rendered request/response. The LLM is only an augmenter.
+ */
+public class VulnerabilityEvidenceDetector {
+
+    private static final LoggerMaker loggerMaker = new LoggerMaker(VulnerabilityEvidenceDetector.class, LoggerMaker.LogDb.DASHBOARD);
+    private static final Gson gson = new Gson();
+    private static final int MAX_SEGMENTS = 10;
+    private static final int MAX_PHRASE_CHARS = 80;
+
+    public static BasicDBList detect(BasicDBObject testData) {
+        BasicDBList segments = new BasicDBList();
+        if (testData == null) {
+            return segments;
+        }
+        try {
+            BasicDBObject testContext = (BasicDBObject) testData.get("testContext");
+            BasicDBObject response = (BasicDBObject) testData.get("response");
+            String category = testContext != null ? testContext.getString("category") : null;
+            String cUpper = category == null ? "" : category.toUpperCase();
+
+            EvidenceRouter.Route route = EvidenceRouter.route(category);
+
+            if (route.detectors.contains(EvidenceRouter.Detector.DATATYPE_RESPONSE_SCAN)
+                    && response != null && cUpper.startsWith(EvidenceRouter.EDE_PREFIX)) {
+                String typeName = cUpper.substring(EvidenceRouter.EDE_PREFIX.length());
+                addDataTypeResponseSegments(segments, response, typeName);
+            }
+
+            if (route.detectors.contains(EvidenceRouter.Detector.REQUEST_DIFF)) {
+                addRequestDiffSegments(segments, testData.get("modifiedRequestValues"));
+            }
+
+            if (route.detectors.contains(EvidenceRouter.Detector.RESPONSE_STATUS) && response != null) {
+                addResponseStatusSegment(segments, response);
+            }
+
+            if (route.detectors.contains(EvidenceRouter.Detector.RESPONSE_HEADERS) && response != null) {
+                addCorsSegments(segments, response, cUpper);
+            }
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("Deterministic evidence detection failed: " + e.getMessage(), LoggerMaker.LogDb.DASHBOARD);
+        }
+        return segments;
+    }
+
+    // Sensitive-data exposure: scan the response body + headers for the data type
+    // named by the test (e.g. SENSITIVE_DATA_EXPOSURE_EMAIL -> EMAIL) using Akto's
+    // own classifier, and emit one segment per matched key/value.
+    private static void addDataTypeResponseSegments(BasicDBList segments, BasicDBObject response, String typeName) {
+        int[] count = {0};
+        scan(asNode(response.get("body")), null, typeName, segments, count);
+        scan(asNode(response.get("headers")), null, typeName, segments, count);
+    }
+
+    private static void scan(Object node, String key, String typeName, BasicDBList segments, int[] count) {
+        if (node == null || count[0] >= MAX_SEGMENTS) {
+            return;
+        }
+        if (node instanceof Map) {
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) node).entrySet()) {
+                scan(entry.getValue(), String.valueOf(entry.getKey()), typeName, segments, count);
+                if (count[0] >= MAX_SEGMENTS) {
+                    return;
+                }
+            }
+        } else if (node instanceof List) {
+            for (Object item : (List<?>) node) {
+                scan(item, key, typeName, segments, count);
+                if (count[0] >= MAX_SEGMENTS) {
+                    return;
+                }
+            }
+        } else {
+            String value = node.toString();
+            if (value.trim().isEmpty()) {
+                return;
+            }
+            SubType subType = classify(value, key);
+            if (subType != null && typeName.equalsIgnoreCase(subType.getName())) {
+                String reason = "The response exposes " + subType.getName()
+                        + (key != null ? " in field \"" + key + "\"" : "") + ", which the test flags as sensitive-data exposure.";
+                segments.add(makeSegment("RESPONSE", key, value, reason));
+                count[0]++;
+            }
+        }
+    }
+
+    private static SubType classify(String value, String key) {
+        try {
+            return KeyTypes.findSubType(value, key, null, true);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // The injected/changed request values are deterministic proof for injection,
+    // fuzzing and authz tests. (Credential fields are dropped later by the FE
+    // denylist, so we never present the caller's own token as evidence.)
+    private static void addRequestDiffSegments(BasicDBList segments, Object modifiedRequestValues) {
+        if (!(modifiedRequestValues instanceof List)) {
+            return;
+        }
+        int count = 0;
+        for (Object item : (List<?>) modifiedRequestValues) {
+            if (!(item instanceof BasicDBObject)) {
+                continue;
+            }
+            BasicDBObject entry = (BasicDBObject) item;
+            String field = entry.getString("field");
+            if (isNoiseField(field)) {
+                continue;
+            }
+            Object modified = entry.get("modified");
+            Object original = entry.get("original");
+            if (modified == null) {
+                continue;
+            }
+            String phrase = modified.toString();
+            if (phrase.trim().isEmpty()) {
+                continue;
+            }
+            String reason = (original != null)
+                    ? "The request changed \"" + field + "\" to \"" + truncate(phrase) + "\" and the endpoint accepted it."
+                    : "The request injected \"" + truncate(phrase) + "\" into \"" + field + "\" and the endpoint accepted it.";
+            segments.add(makeSegment("REQUEST", field, phrase, reason));
+            if (++count >= 15) {
+                break;
+            }
+        }
+    }
+
+    // Broken authentication / no-auth: a 2xx returned after the auth token was
+    // removed/invalidated is the proof. Anchor to the response status code.
+    private static void addResponseStatusSegment(BasicDBList segments, BasicDBObject response) {
+        int status;
+        try {
+            status = response.getInt("statusCode", 0);
+        } catch (Exception e) {
+            status = 0;
+        }
+        if (status >= 200 && status < 300) {
+            segments.add(makeSegment("RESPONSE", "statusCode", String.valueOf(status),
+                    "The server returned " + status + " even though the request's auth token was removed or invalid, proving broken authentication."));
+        }
+    }
+
+    // CORS misconfiguration: a wildcard access-control-allow-origin in the response.
+    private static void addCorsSegments(BasicDBList segments, BasicDBObject response, String cUpper) {
+        if (!cUpper.contains("CORS")) {
+            return;
+        }
+        Object headersNode = asNode(response.get("headers"));
+        if (!(headersNode instanceof Map)) {
+            return;
+        }
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) headersNode).entrySet()) {
+            String key = String.valueOf(entry.getKey());
+            if (!"access-control-allow-origin".equalsIgnoreCase(key) || entry.getValue() == null) {
+                continue;
+            }
+            String value = entry.getValue().toString();
+            if (value.contains("*") || value.trim().equalsIgnoreCase("null")) {
+                segments.add(makeSegment("RESPONSE", key, value,
+                        "The response sets access-control-allow-origin to \"" + value + "\", allowing cross-origin access."));
+            }
+            break;
+        }
+    }
+
+    // Transport / proxy / CDN / infra / credential / probe headers are never
+    // meaningful attack evidence - they ride along on every request. Mirrors the
+    // frontend isNoiseField so the request-diff detector never floods the panel.
+    private static final String[] NOISE_FIELD_PREFIXES = {
+        "x-forwarded-", "x-akto-", "x-sigsci-", "fastly-", "sec-fetch-", "sec-ch-", "x-amzn-", "cf-"
+    };
+    private static final Set<String> NOISE_FIELD_EXACT = new HashSet<>(Arrays.asList(
+        "host", "content-length", "content-type", "connection", "accept", "accept-encoding",
+        "accept-language", "accept-charset", "user-agent", "referer", "origin", "cache-control",
+        "pragma", "te", "trailer", "transfer-encoding", "upgrade", "keep-alive", "via", "forwarded",
+        "x-real-ip", "x-request-id", "x-correlation-id", "cdn-loop", "x-varnish", "x-timer",
+        "x-cache", "x-cache-hits", "x-served-by", "dnt",
+        "authorization", "cookie", "set-cookie", "proxy-authorization", "x-api-key", "api-key", "apikey", "a"
+    ));
+
+    private static boolean isNoiseField(String field) {
+        if (field == null) {
+            return true;
+        }
+        String k = field.trim().toLowerCase();
+        if (k.isEmpty() || NOISE_FIELD_EXACT.contains(k)) {
+            return true;
+        }
+        for (String prefix : NOISE_FIELD_PREFIXES) {
+            if (k.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Object asNode(Object value) {
+        if (value instanceof String) {
+            return parseJson((String) value);
+        }
+        return value;
+    }
+
+    private static Object parseJson(String s) {
+        if (s == null || s.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return gson.fromJson(s, Object.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String truncate(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.length() > MAX_PHRASE_CHARS ? s.substring(0, MAX_PHRASE_CHARS) : s;
+    }
+
+    private static BasicDBObject makeSegment(String location, String field, String phrase, String reason) {
+        BasicDBObject segment = new BasicDBObject();
+        segment.put("start", 0);
+        segment.put("end", 0);
+        segment.put("location", location);
+        segment.put("field", field == null ? "" : field);
+        segment.put("phrase", truncate(phrase));
+        segment.put("reason", reason);
+        segment.put("source", "deterministic");
+        return segment;
+    }
+}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleData.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleData.js
@@ -7,6 +7,7 @@ import editorSetup from './customEditor';
 import yamlEditorSetup from "../../pages/test_editor/components/editor_config/editorSetup"
 import keywords from "../../pages/test_editor/components/editor_config/keywords"
 import authTypesApi from "@/apps/dashboard/pages/settings/auth_types/api";
+import { locateSegment } from "./vulnerabilityEvidence";
 
 function highlightPaths(highlightPathMap, ref){
   highlightPathMap && Object.keys(highlightPathMap).forEach((key) => {
@@ -156,124 +157,14 @@ function highlightVulnerabilities(vulnerabilitySegments, ref) {
     return;
   }
 
-  const textLength = text.length;
-  const isWordChar = (ch) => typeof ch === 'string' && /[A-Za-z0-9_-]/.test(ch);
-
-  const resolvePhrase = (segment) => {
-    if (typeof segment?.phrase === 'string' && segment.phrase.trim().length > 0) {
-      return segment.phrase.trim();
-    }
-    if (typeof segment?.message === 'string' && segment.message.length > 0) {
-      return segment.message.replace(/\s*\[chars\s+\d+-\d+\]\s*$/, '').trim();
-    }
-    return undefined;
-  };
-
-  // The LLM's char offsets are computed against a different text layout than the
-  // editor renders, so they are unreliable. We anchor strictly to the phrase the
-  // LLM flagged. Build progressively looser candidates so we still match when the
-  // phrase is wrapped in quotes, given as a JSON "key":"value" pair (while the
-  // editor renders headers as "key: value"), or truncated mid-token.
-  const buildPhraseCandidates = (phrase) => {
-    const candidates = [];
-    const add = (p) => {
-      if (typeof p !== 'string') {
-        return;
-      }
-      const trimmed = p.trim().replace(/^[\s"'`]+|[\s"',`]+$/g, '');
-      if (trimmed.length >= 2 && !candidates.includes(trimmed)) {
-        candidates.push(trimmed);
-      }
-    };
-
-    add(phrase);
-    if (phrase) {
-      // JSON pair -> value only (handles `"authorization":"Bearer x"` vs editor `authorization: Bearer x`).
-      const colonIdx = phrase.indexOf(':');
-      if (colonIdx >= 0 && colonIdx < phrase.length - 1) {
-        add(phrase.slice(colonIdx + 1));
-      }
-    }
-    // For long tokens (e.g. JWTs) the LLM often truncates or the formatting
-    // differs; a unique prefix is enough to anchor the highlight.
-    candidates.slice().forEach((c) => {
-      if (c.length > 40) {
-        add(c.slice(0, 40));
-      }
-    });
-    return candidates;
-  };
-
-  // Exact occurrence, preferring whole-token matches so "envoy" doesn't match
-  // inside "x-envoy-..." and disambiguating with the LLM's hint position.
-  const findExactRange = (phrase, hintStart) => {
-    const matches = [];
-    let from = 0;
-    while (from <= textLength) {
-      const idx = text.indexOf(phrase, from);
-      if (idx === -1) {
-        break;
-      }
-      const endIdx = idx + phrase.length;
-      const boundedBefore = idx === 0 || !isWordChar(text[idx - 1]) || !isWordChar(phrase[0]);
-      const boundedAfter = endIdx >= textLength || !isWordChar(text[endIdx]) || !isWordChar(phrase[phrase.length - 1]);
-      matches.push({ start: idx, end: endIdx, wholeToken: boundedBefore && boundedAfter });
-      from = idx + 1;
-    }
-    if (matches.length === 0) {
-      return null;
-    }
-    const wholeTokenMatches = matches.filter((m) => m.wholeToken);
-    const candidates = wholeTokenMatches.length > 0 ? wholeTokenMatches : matches;
-    if (Number.isFinite(hintStart)) {
-      candidates.sort((a, b) => Math.abs(a.start - hintStart) - Math.abs(b.start - hintStart));
-    }
-    return candidates[0];
-  };
-
-  // Whitespace-tolerant, case-insensitive match for when the LLM collapses
-  // newlines/indentation or changes header-name casing.
-  const findFlexibleRange = (phrase) => {
-    const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
-    try {
-      const match = new RegExp(escaped, 'i').exec(text);
-      if (match) {
-        return { start: match.index, end: match.index + match[0].length };
-      }
-    } catch (e) {
-      // invalid regex, ignore
-    }
-    return null;
-  };
-
-  const locateSegment = (segment) => {
-    const phrase = resolvePhrase(segment);
-    if (!phrase) {
-      return null;
-    }
-    const hintStart = Number(segment?.start);
-    const candidates = buildPhraseCandidates(phrase);
-    for (const candidate of candidates) {
-      const range = findExactRange(candidate, hintStart);
-      if (range) {
-        return range;
-      }
-    }
-    for (const candidate of candidates) {
-      const range = findFlexibleRange(candidate);
-      if (range) {
-        return range;
-      }
-    }
-    return null;
-  };
-
   const decorations = [];
   let firstStart = Infinity;
 
   vulnerabilitySegments.forEach((segment) => {
     try {
-      const range = locateSegment(segment);
+      // Shared locator (see vulnerabilityEvidence.js) - the SAME contract the
+      // Evidence panel uses, so we never highlight what the panel can't show.
+      const range = locateSegment(segment, text);
       // If we cannot locate the exact phrase, skip rather than highlight the
       // wrong span using unreliable offsets.
       if (!range) {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataComponent.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataComponent.jsx
@@ -129,17 +129,8 @@ function SampleDataComponent(props) {
         const llmResponseSegments = baseSegments.filter(s => s?.location !== 'REQUEST');
 
         if(isNewDiff){
-            let lineReqObj = transform.getFirstLine(originalRequestJson?.firstLine,requestJson?.firstLine)
-            let lineResObj = transform.getFirstLine(originalResponseJson?.firstLine,responseJson?.firstLine)
-
-            let requestHeaderObj = transform.compareJsonKeys(originalRequestJson?.json?.requestHeaders,requestJson?.json?.requestHeaders)
-            let responseHeaderObj = transform.compareJsonKeys(originalResponseJson?.json?.responseHeaders,responseJson?.json?.responseHeaders)
-            
-            let requestPayloadObj = transform.getPayloadData(originalRequestJson?.json?.requestPayload,requestJson?.json?.requestPayload)
-            let responsePayloadObj = transform.getPayloadData(originalResponseJson?.json?.responsePayload,responseJson?.json?.responsePayload)
-            
-            const requestData = transform.mergeDataObjs(lineReqObj, requestHeaderObj, requestPayloadObj)
-            const responseData = transform.mergeDataObjs(lineResObj, responseHeaderObj, responsePayloadObj)
+            // Shared builder so the rendered text matches the verification contract.
+            const { requestData, responseData } = transform.buildDiffData(requestJson, responseJson, originalRequestJson, originalResponseJson)
 
             setSampleJsonData({
                 request: { ...requestData, vulnerabilitySegments: segmentsFromMetadata ? [] : llmRequestSegments },

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataList.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import {
   Banner,
   List,
@@ -11,8 +11,15 @@ import SampleData from './SampleData';
 import ValidationReasonBanner from './ValidationReasonBanner';
 import func from '../../../../util/func';
 import { getDashboardCategory, mapLabel, isAgenticSecurityCategory, isEndpointSecurityCategory } from '../../../main/labelHelper';
+import transform from './customDiffEditor';
+import { filterLocatableSegments } from './vulnerabilityEvidence';
 
-const SHOW_VULNERABILITY_EVIDENCE = false;
+// Evidence panel is internal-only until the feature is generally available.
+const SHOW_VULNERABILITY_EVIDENCE = func.isAktoUser();
+// Good-to-have, off by default: when the model reports low confidence in a piece
+// of evidence, show a subtle hint nudging the user toward the existing
+// Triage -> "False positive" action. The framework verdict stays authoritative.
+const SHOW_LOW_CONFIDENCE_HINT = false;
 
 function SchemaValidationError({ sampleData}) {
     const [expanded, setExpanded] = useState(false);
@@ -65,6 +72,9 @@ function VulnerabilityEvidence({ segments }) {
         return null;
     }
 
+    const hasLowConfidence = SHOW_LOW_CONFIDENCE_HINT
+        && segments.some((seg) => String(seg?.confidence || '').toLowerCase() === 'low');
+
     return (
         <Banner title="Evidence" status="warning">
             <VerticalStack gap="2">
@@ -72,6 +82,9 @@ function VulnerabilityEvidence({ segments }) {
                     const isRequest = String(seg?.location || 'RESPONSE').toUpperCase() === 'REQUEST';
                     const reason = typeof seg?.reason === 'string' ? seg.reason : '';
                     const phrase = typeof seg?.phrase === 'string' ? seg.phrase : '';
+                    const field = typeof seg?.field === 'string' ? seg.field : '';
+                    // Prefer showing the concrete value; if it is masked/absent, show the field so the row is never blank.
+                    const evidenceText = phrase || field;
                     return (
                         <Box key={index}>
                             <HorizontalStack gap="2" align="start" blockAlign="start" wrap={false}>
@@ -82,9 +95,9 @@ function VulnerabilityEvidence({ segments }) {
                                 </Box>
                                 <VerticalStack gap="0">
                                     {reason ? <Text variant="bodyMd">{reason}</Text> : null}
-                                    {phrase ? (
+                                    {evidenceText ? (
                                         <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#6B46C1', wordBreak: 'break-all' }}>
-                                            {phrase}
+                                            {field && phrase ? `${field}: ${phrase}` : evidenceText}
                                         </span>
                                     ) : null}
                                 </VerticalStack>
@@ -92,6 +105,13 @@ function VulnerabilityEvidence({ segments }) {
                         </Box>
                     );
                 })}
+                {hasLowConfidence ? (
+                    <Box paddingBlockStart="1">
+                        <Text variant="bodySm" color="subdued">
+                            Some evidence is low-confidence. If this looks like a false positive, use Triage - "False positive".
+                        </Text>
+                    </Box>
+                ) : null}
             </VerticalStack>
         </Banner>
     );
@@ -112,11 +132,35 @@ function SampleDataList(props) {
     const isWebSocket = isWebSocketProp === true || func.isWebSocketApiType(parsedSample?.type)
     const panelTypes = isWebSocket ? ['events'] : ['request', 'response'];
 
+    // Verification contract (keystone): only ever show evidence that can actually
+    // be located in the SAME text the editor renders. We validate REQUEST segments
+    // against the rendered request text and RESPONSE segments against the response
+    // text (and drop denylisted credential/token segments), then feed the identical
+    // validated list to BOTH the Evidence panel and the request/response editors -
+    // so the panel never lists a segment the editor cannot highlight.
+    const validatedCurrentSample = useMemo(() => {
+        if (!currentSample) {
+            return currentSample;
+        }
+        const segments = currentSample.vulnerabilitySegments;
+        if (!Array.isArray(segments) || segments.length === 0 || isWebSocket) {
+            return currentSample;
+        }
+        const { requestText, responseText } = transform.buildRenderedText(currentSample, { isNewDiff, redactHeaders, metadata });
+        const requestSegments = segments.filter(s => String(s?.location || '').toUpperCase() === 'REQUEST');
+        const responseSegments = segments.filter(s => String(s?.location || '').toUpperCase() !== 'REQUEST');
+        const validated = [
+            ...filterLocatableSegments(requestSegments, requestText),
+            ...filterLocatableSegments(responseSegments, responseText),
+        ];
+        return { ...currentSample, vulnerabilitySegments: validated };
+    }, [currentSample, isNewDiff, redactHeaders, metadata, isWebSocket]);
+
     return (
       <VerticalStack gap="3">
          <SchemaValidationError sampleData={currentSample} />
          {SHOW_VULNERABILITY_EVIDENCE ? (
-           <VulnerabilityEvidence segments={currentSample?.vulnerabilitySegments} />
+           <VulnerabilityEvidence segments={validatedCurrentSample?.vulnerabilitySegments} />
          ) : null}
         <HorizontalStack align='space-between'>
           <HorizontalStack gap="2">
@@ -165,7 +209,7 @@ function SampleDataList(props) {
                   <LegacyCard>
                     <SampleDataComponent
                       type={type}
-                      sampleData={sampleData[Math.min(page, sampleData.length-1)]}
+                      sampleData={validatedCurrentSample}
                       minHeight={minHeight}
                       showDiff={showDiff}
                       isNewDiff={isNewDiff}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/customDiffEditor.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/customDiffEditor.js
@@ -1,3 +1,5 @@
+import func from "@/util/func";
+
 const transform = {
     formatJson(data){
         let allKeys = [];
@@ -237,6 +239,62 @@ const transform = {
             headersMap: {...jsonObj.headersMap, ...payloadObj.headersMap},
             updatedData: jsonObj.updatedData,
         }
+    },
+
+    // Shared "new diff" builder: takes the parsed request/response json objects
+    // (current + original) and produces the request/response data objects the
+    // editor renders. Used by both SampleDataComponent (rendering) and
+    // buildRenderedText (verification) so the rendered text is identical.
+    buildDiffData(requestJson, responseJson, originalRequestJson, originalResponseJson){
+        let lineReqObj = this.getFirstLine(originalRequestJson?.firstLine, requestJson?.firstLine)
+        let lineResObj = this.getFirstLine(originalResponseJson?.firstLine, responseJson?.firstLine)
+
+        let requestHeaderObj = this.compareJsonKeys(originalRequestJson?.json?.requestHeaders, requestJson?.json?.requestHeaders)
+        let responseHeaderObj = this.compareJsonKeys(originalResponseJson?.json?.responseHeaders, responseJson?.json?.responseHeaders)
+
+        let requestPayloadObj = this.getPayloadData(originalRequestJson?.json?.requestPayload, requestJson?.json?.requestPayload)
+        let responsePayloadObj = this.getPayloadData(originalResponseJson?.json?.responsePayload, responseJson?.json?.responsePayload)
+
+        return {
+            requestData: this.mergeDataObjs(lineReqObj, requestHeaderObj, requestPayloadObj),
+            responseData: this.mergeDataObjs(lineResObj, responseHeaderObj, responsePayloadObj),
+        }
+    },
+
+    // Reproduce EXACTLY the request/response text the Monaco editor renders for a
+    // given sample, so the verification contract (vulnerabilityEvidence.js) checks
+    // segments against the same text the user sees. Returns { requestText, responseText }.
+    buildRenderedText(sampleData, options = {}){
+        const { isNewDiff = false, redactHeaders = [], metadata, showResponse = true } = options
+        if (!sampleData) {
+            return { requestText: "", responseText: "" }
+        }
+
+        let parsed
+        try { parsed = JSON.parse(sampleData?.message) } catch { parsed = undefined }
+        let originalParsed
+        try { originalParsed = JSON.parse(sampleData?.originalMessage) } catch { originalParsed = undefined }
+
+        const highlightPaths = sampleData?.highlightPaths || []
+        const responseJson = func.responseJson(parsed, highlightPaths, metadata)
+        const requestJson = func.requestJson(parsed, highlightPaths, metadata)
+        const originalResponseJson = func.responseJson(originalParsed, highlightPaths)
+        const originalRequestJson = func.requestJson(originalParsed, highlightPaths)
+
+        if (isNewDiff) {
+            const { requestData, responseData } = this.buildDiffData(requestJson, responseJson, originalRequestJson, originalResponseJson)
+            return {
+                requestText: requestData?.message || "",
+                responseText: showResponse ? (responseData?.message || "") : "",
+            }
+        }
+
+        // Non-new-diff editors render data.original (when present) else data.message.
+        const requestText = this.formatData(originalRequestJson, "http", redactHeaders) || this.formatData(requestJson, "http", redactHeaders)
+        const responseText = showResponse
+            ? (this.formatData(originalResponseJson, "http", redactHeaders) || this.formatData(responseJson, "http", redactHeaders))
+            : ""
+        return { requestText: requestText || "", responseText: responseText || "" }
     },
     isGraphQLPayload(payload){
         if (!payload || typeof payload !== 'object') return false;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/vulnerabilityEvidence.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/vulnerabilityEvidence.js
@@ -1,0 +1,225 @@
+// Pure, text-based vulnerability-evidence locator + verification contract.
+//
+// This is the single source of truth for "can this evidence segment actually be
+// pointed to in the rendered request/response text?". It is shared by the Monaco
+// highlighter (SampleData.js) and the Evidence panel (SampleDataList.js) so that
+// both ONLY ever show evidence that physically exists on screen - no phantom
+// evidence (e.g. a value the LLM decoded out of a JWT) is ever displayed.
+
+const isWordChar = (ch) => typeof ch === 'string' && /[A-Za-z0-9_-]/.test(ch);
+
+// Caller-credential header keys. These carry the REQUESTER's own identity, not
+// data the API exposed, so they must never be presented as "evidence" (this is
+// exactly the bug where a JWT in `authorization` was cited as data exposure).
+const CREDENTIAL_FIELDS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'proxy-authorization',
+  'x-api-key',
+  'api-key',
+  'apikey',
+]);
+
+// A bearer token or a JWT (three base64url segments). Opaque credentials are not
+// meaningful evidence and must never be highlighted, even if present on screen.
+const looksLikeToken = (s) => {
+  if (typeof s !== 'string') {
+    return false;
+  }
+  const t = s.trim();
+  if (/^bearer\s+/i.test(t)) {
+    return true;
+  }
+  if (/^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/.test(t)) {
+    return true;
+  }
+  return false;
+};
+
+// True when a segment points at the caller's own credentials or an opaque token.
+// Such segments are dropped before reaching either the editor or the panel.
+export function isDenylistedSegment(segment) {
+  const field = typeof segment?.field === 'string' ? segment.field.trim().toLowerCase() : '';
+  if (field && CREDENTIAL_FIELDS.has(field)) {
+    return true;
+  }
+  if (looksLikeToken(segment?.phrase)) {
+    return true;
+  }
+  return false;
+}
+
+const resolvePhrase = (segment) => {
+  if (typeof segment?.phrase === 'string' && segment.phrase.trim().length > 0) {
+    return segment.phrase.trim();
+  }
+  if (typeof segment?.message === 'string' && segment.message.length > 0) {
+    return segment.message.replace(/\s*\[chars\s+\d+-\d+\]\s*$/, '').trim();
+  }
+  return undefined;
+};
+
+// The LLM's char offsets are computed against a different text layout than the
+// editor renders, so they are unreliable. We anchor strictly to the phrase the
+// LLM flagged. Build progressively looser candidates so we still match when the
+// phrase is wrapped in quotes, given as a JSON "key":"value" pair (while the
+// editor renders headers as "key: value"), or truncated mid-token.
+const buildPhraseCandidates = (phrase) => {
+  const candidates = [];
+  const add = (p) => {
+    if (typeof p !== 'string') {
+      return;
+    }
+    const trimmed = p.trim().replace(/^[\s"'`]+|[\s"',`]+$/g, '');
+    if (trimmed.length >= 2 && !candidates.includes(trimmed)) {
+      candidates.push(trimmed);
+    }
+  };
+
+  add(phrase);
+  if (phrase) {
+    // JSON pair -> value only (handles `"authorization":"Bearer x"` vs editor `authorization: Bearer x`).
+    const colonIdx = phrase.indexOf(':');
+    if (colonIdx >= 0 && colonIdx < phrase.length - 1) {
+      add(phrase.slice(colonIdx + 1));
+    }
+  }
+  // For long tokens (e.g. JWTs) the LLM often truncates or the formatting
+  // differs; a unique prefix is enough to anchor the highlight.
+  candidates.slice().forEach((c) => {
+    if (c.length > 40) {
+      add(c.slice(0, 40));
+    }
+  });
+  return candidates;
+};
+
+// Field-based binding: anchor to the exact header/body key the segment refers to.
+// Essential when the same value repeats (e.g. many headers = "NULL") or is masked
+// (e.g. ******), where a plain phrase match would land on the wrong line or fail.
+const findFieldRange = (field, phrase, text) => {
+  if (typeof field !== 'string' || field.trim().length === 0) {
+    return null;
+  }
+  // The editor renders headers as "key: value" and JSON body as "key": value.
+  // Use the last path segment for paths like response.body.email -> email.
+  const key = field.split('.').pop().trim();
+  if (key.length === 0) {
+    return null;
+  }
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const lineRegex = new RegExp('^\\s*"?' + escapedKey + '"?\\s*:\\s*(.*)$', 'mi');
+  const match = lineRegex.exec(text);
+  if (!match) {
+    return null;
+  }
+  const valueStartInLine = match.index + match[0].indexOf(match[1]);
+  const rawValue = match[1];
+  const trimmedValue = rawValue.replace(/[\s,]+$/, '');
+  if (trimmedValue.length === 0) {
+    const keyIdx = text.indexOf(key, match.index);
+    return keyIdx >= 0 ? { start: keyIdx, end: keyIdx + key.length } : null;
+  }
+  if (typeof phrase === 'string' && phrase.trim().length > 0) {
+    const idxInValue = rawValue.indexOf(phrase.trim());
+    if (idxInValue >= 0) {
+      const start = valueStartInLine + idxInValue;
+      return { start, end: start + phrase.trim().length };
+    }
+  }
+  return { start: valueStartInLine, end: valueStartInLine + trimmedValue.length };
+};
+
+// Exact occurrence, preferring whole-token matches so "envoy" doesn't match
+// inside "x-envoy-..." and disambiguating with the LLM's hint position.
+const findExactRange = (phrase, hintStart, text) => {
+  const textLength = text.length;
+  const matches = [];
+  let from = 0;
+  while (from <= textLength) {
+    const idx = text.indexOf(phrase, from);
+    if (idx === -1) {
+      break;
+    }
+    const endIdx = idx + phrase.length;
+    const boundedBefore = idx === 0 || !isWordChar(text[idx - 1]) || !isWordChar(phrase[0]);
+    const boundedAfter = endIdx >= textLength || !isWordChar(text[endIdx]) || !isWordChar(phrase[phrase.length - 1]);
+    matches.push({ start: idx, end: endIdx, wholeToken: boundedBefore && boundedAfter });
+    from = idx + 1;
+  }
+  if (matches.length === 0) {
+    return null;
+  }
+  const wholeTokenMatches = matches.filter((m) => m.wholeToken);
+  const candidates = wholeTokenMatches.length > 0 ? wholeTokenMatches : matches;
+  if (Number.isFinite(hintStart)) {
+    candidates.sort((a, b) => Math.abs(a.start - hintStart) - Math.abs(b.start - hintStart));
+  }
+  return candidates[0];
+};
+
+// Whitespace-tolerant, case-insensitive match for when the LLM collapses
+// newlines/indentation or changes header-name casing.
+const findFlexibleRange = (phrase, text) => {
+  const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
+  try {
+    const match = new RegExp(escaped, 'i').exec(text);
+    if (match) {
+      return { start: match.index, end: match.index + match[0].length };
+    }
+  } catch (e) {
+    // invalid regex, ignore
+  }
+  return null;
+};
+
+// Locate a single segment in the rendered text. Returns { start, end } or null.
+// Binds by `field` first (reliable for repeated/masked values), then falls back
+// to phrase matching with progressively looser candidates.
+export function locateSegment(segment, text) {
+  if (!segment || typeof text !== 'string' || text.length === 0) {
+    return null;
+  }
+  const fieldRange = findFieldRange(segment.field, segment.phrase, text);
+  if (fieldRange) {
+    return fieldRange;
+  }
+  const phrase = resolvePhrase(segment);
+  if (!phrase) {
+    return null;
+  }
+  const hintStart = Number(segment.start);
+  const candidates = buildPhraseCandidates(phrase);
+  for (const candidate of candidates) {
+    const range = findExactRange(candidate, hintStart, text);
+    if (range) {
+      return range;
+    }
+  }
+  for (const candidate of candidates) {
+    const range = findFlexibleRange(candidate, text);
+    if (range) {
+      return range;
+    }
+  }
+  return null;
+}
+
+// True when the segment is allowed (not a credential/token) AND can be
+// highlighted in the given text. This is the full verification contract.
+export function canLocateSegment(segment, text) {
+  if (isDenylistedSegment(segment)) {
+    return false;
+  }
+  return locateSegment(segment, text) !== null;
+}
+
+// Keep only segments that pass the verification contract for the given rendered
+// text (locatable + not a denylisted credential/token).
+export function filterLocatableSegments(segments, text) {
+  if (!Array.isArray(segments)) {
+    return [];
+  }
+  return segments.filter((seg) => canLocateSegment(seg, text));
+}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunResultPage/TestRunResultFlyout.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunResultPage/TestRunResultFlyout.jsx
@@ -11,6 +11,7 @@ import CompulsoryDescriptionModal from "../../issues/components/CompulsoryDescri
 import api from '../../observe/api'
 import issuesApi from "../../issues/api"
 import testingApi from "../api"
+import testEditorApi from "../../test_editor/api"
 import GridRows from '../../../components/shared/GridRows'
 import { useNavigate } from 'react-router-dom'
 import TitleWithInfo from '@/apps/dashboard/components/shared/TitleWithInfo'
@@ -716,43 +717,208 @@ function TestRunResultFlyout(props) {
         return {};
     };
 
-    const buildFallbackSegments = (messageObj) => {
-        const reason = issueDetails?.description
-            || selectedTestRunResult?.name
-            || 'This response was flagged as vulnerable for this test.';
-        const category = (selectedTestRunResult?.testCategoryId || selectedTestRunResult?.testCategory || '').toUpperCase();
-        const isAuthzLike = /AUTH|BOLA|ACCESS|IDOR|PRIVILEGE|ACCOUNT/.test(category);
-        const segments = [];
+    // Parse a request/response message that may be a JSON string or already an object.
+    const parseMessageObj = (msg) => {
+        if (!msg) return null;
+        if (typeof msg === 'object') return msg;
+        if (typeof msg === 'string') {
+            try { return JSON.parse(msg); } catch (e) { return null; }
+        }
+        return null;
+    };
 
-        // Request-side anchor: the identity (auth token / cookie) used for the access.
-        if (isAuthzLike) {
-            const headers = parseHeaders(messageObj?.request?.headers);
-            const findHeader = (name) => {
-                const key = Object.keys(headers).find(k => k.toLowerCase() === name);
-                return key ? headers[key] : null;
-            };
-            const authVal = findHeader('authorization') || findHeader('cookie');
-            if (typeof authVal === 'string' && authVal.trim().length > 0) {
-                segments.push({
-                    phrase: authVal.trim().slice(0, 60),
-                    reason: 'Identity (auth token/cookie) used for this request - broken authorization is shown by this identity accessing data it should not.',
+    // Cap how many changed fields we surface so the prompt/UI stay small.
+    const MAX_DIFF_ENTRIES = 15;
+
+    // A value is "masked" when the UI redacts it (e.g. auth headers shown as ******).
+    // We must not emit such a value as a phrase (it won't exist verbatim in the
+    // rendered editor); the segment is bound by its field key instead.
+    const isMaskedValue = (v) => typeof v === 'string' && /^\*{3,}$/.test(v.trim());
+
+    // Transport / proxy / CDN / infra / credential / probe headers are NEVER
+    // meaningful attack evidence - they ride along on every request. Highlighting
+    // them floods the evidence panel with noise (host, x-forwarded-*, fastly-*,
+    // the auth JWT, the akto "a" probe, etc.), so we never treat them as injected.
+    const NOISE_FIELD_PREFIXES = ['x-forwarded-', 'x-akto-', 'x-sigsci-', 'fastly-', 'sec-fetch-', 'sec-ch-', 'x-amzn-', 'cf-'];
+    const NOISE_FIELD_EXACT = new Set([
+        'host', 'content-length', 'content-type', 'connection', 'accept', 'accept-encoding',
+        'accept-language', 'accept-charset', 'user-agent', 'referer', 'origin', 'cache-control',
+        'pragma', 'te', 'trailer', 'transfer-encoding', 'upgrade', 'keep-alive', 'via', 'forwarded',
+        'x-real-ip', 'x-request-id', 'x-correlation-id', 'cdn-loop', 'x-varnish', 'x-timer',
+        'x-cache', 'x-cache-hits', 'x-served-by', 'dnt',
+        'authorization', 'cookie', 'set-cookie', 'proxy-authorization', 'x-api-key', 'api-key', 'apikey', 'a'
+    ]);
+    const isNoiseField = (key) => {
+        const k = String(key || '').trim().toLowerCase();
+        if (!k) return true;
+        if (NOISE_FIELD_EXACT.has(k)) return true;
+        return NOISE_FIELD_PREFIXES.some((p) => k.startsWith(p));
+    };
+
+    // Compute what the test changed between the baseline (original) request and the
+    // attack request. These changed/added values are the concrete evidence of the
+    // injected attack (e.g. invalid header values, swapped auth token, payload).
+    //
+    // IMPORTANT: a header/body field is only "injected" if there is a real baseline
+    // to compare against. When the baseline has no headers (the diff is degenerate),
+    // we must NOT mark the entire request as injected - otherwise every transport
+    // header shows up as fake evidence.
+    const computeRequestDiff = (originalMessage, attackMessage) => {
+        const orig = parseMessageObj(originalMessage);
+        const atk = parseMessageObj(attackMessage);
+        if (!atk || !atk.request) return [];
+
+        const entries = [];
+        const origHeaders = parseHeaders(orig?.request?.headers);
+        const atkHeaders = parseHeaders(atk?.request?.headers);
+        const hasBaselineHeaders = Object.keys(origHeaders).length > 0;
+
+        Object.keys(atkHeaders).forEach((key) => {
+            if (entries.length >= MAX_DIFF_ENTRIES) return;
+            if (isNoiseField(key)) return;
+            const modified = atkHeaders[key];
+            const original = origHeaders[key];
+            const modStr = modified === undefined || modified === null ? '' : String(modified);
+            const hasOriginal = original !== undefined;
+            if (hasOriginal) {
+                const origStr = String(original);
+                if (origStr !== modStr) {
+                    entries.push({ field: key, original: origStr, modified: modStr, location: 'REQUEST' });
+                }
+            } else if (hasBaselineHeaders) {
+                // Genuinely added vs a real baseline.
+                entries.push({ field: key, original: null, modified: modStr, location: 'REQUEST' });
+            }
+        });
+
+        const origBodyObj = parseMessageObj(orig?.request?.body);
+        const atkBodyObj = parseMessageObj(atk?.request?.body);
+        const hasBaselineBody = origBodyObj && typeof origBodyObj === 'object';
+        if (atkBodyObj && typeof atkBodyObj === 'object' && !Array.isArray(atkBodyObj)) {
+            Object.keys(atkBodyObj).forEach((key) => {
+                if (entries.length >= MAX_DIFF_ENTRIES) return;
+                const modified = atkBodyObj[key];
+                const original = origBodyObj ? origBodyObj[key] : undefined;
+                const modStr = typeof modified === 'object' ? JSON.stringify(modified) : String(modified);
+                const hasOriginal = original !== undefined;
+                if (hasOriginal) {
+                    const origStr = typeof original === 'object' ? JSON.stringify(original) : String(original);
+                    if (origStr !== modStr) {
+                        entries.push({ field: key, original: origStr, modified: modStr, location: 'REQUEST' });
+                    }
+                } else if (hasBaselineBody) {
+                    entries.push({ field: key, original: null, modified: modStr, location: 'REQUEST' });
+                }
+            });
+        } else {
+            const origBody = orig?.request?.body;
+            const atkBody = atk?.request?.body;
+            if (typeof atkBody === 'string' && atkBody.length > 0 && typeof origBody === 'string' && origBody.length > 0 && String(origBody) !== atkBody && entries.length < MAX_DIFF_ENTRIES) {
+                entries.push({
+                    field: 'body',
+                    original: String(origBody).slice(0, 120),
+                    modified: atkBody.slice(0, 120),
                     location: 'REQUEST'
                 });
             }
         }
 
-        // Response-side anchor: a short body value, else the status code.
+        return entries.slice(0, MAX_DIFF_ENTRIES);
+    };
+
+    // For multi-exec tests, summarise the sibling attempts (everything except the
+    // last/vulnerable one) so the model can explain cross-attempt proof (rate-limit,
+    // 2-account BOLA) without us sending every full request/response.
+    const buildSiblingAttempts = (testResults, lastIdx) => {
+        if (!Array.isArray(testResults) || testResults.length <= 1) return [];
+        const summary = [];
+        testResults.forEach((res, i) => {
+            if (i === lastIdx) return;
+            if (summary.length >= 10) return;
+            const msg = parseMessageObj(res?.message);
+            const statusCode = msg?.response?.statusCode || null;
+            const diff = computeRequestDiff(res?.originalMessage, res?.message);
+            const keyChange = diff.length > 0 ? `${diff[0].field}=${diff[0].modified}` : null;
+            summary.push({ attempt: i + 1, statusCode, keyChange });
+        });
+        return summary;
+    };
+
+    // Trim a test template (YAML) to keep the prompt small. The validate/success
+    // conditions and injected wordlists are what explain WHY the test is vulnerable.
+    const TEMPLATE_MAX_CHARS = 1500;
+    const trimTemplate = (content) => {
+        if (typeof content !== 'string' || content.length === 0) return '';
+        return content.length > TEMPLATE_MAX_CHARS
+            ? content.slice(0, TEMPLATE_MAX_CHARS) + "\n...[truncated]"
+            : content;
+    };
+
+    // Cache trimmed templates per testSubType so we never refetch within a run.
+    // On any failure (e.g. no TEST_EDITOR access) we degrade gracefully to "".
+    const templateCacheRef = useRef({});
+    const getTrimmedTemplate = async (testSubType) => {
+        if (!testSubType) return '';
+        if (templateCacheRef.current[testSubType] !== undefined) {
+            return templateCacheRef.current[testSubType];
+        }
+        let trimmed = '';
+        try {
+            const resp = await testEditorApi.fetchTestContent(testSubType);
+            const content = typeof resp === 'string' ? resp : (resp?.content || '');
+            trimmed = trimTemplate(content);
+        } catch (e) {
+            trimmed = '';
+        }
+        templateCacheRef.current[testSubType] = trimmed;
+        return trimmed;
+    };
+
+    // Deterministic, specific evidence when the model returns nothing. We never
+    // emit a hardcoded generic sentence: we prefer (1) the concrete values the test
+    // changed, then (2) the framework's own validationReason, then (3) the response
+    // proof (a short value or the status code).
+    const buildFallbackSegments = (messageObj, requestDiff, validationReason) => {
+        const segments = [];
+
+        // (1) Request-side: the actual injected/changed values.
+        (requestDiff || []).forEach((d) => {
+            if (segments.length >= MAX_DIFF_ENTRIES) return;
+            const masked = isMaskedValue(d.modified);
+            const seg = {
+                field: d.field,
+                location: 'REQUEST',
+                reason: (d.original !== null && d.original !== undefined)
+                    ? `"${d.field}" was changed from "${d.original}" to "${d.modified}" and the endpoint still accepted it.`
+                    : `"${d.field}" was injected with "${d.modified}" and the endpoint still accepted it.`
+            };
+            // Bind by field when the value is masked/empty; otherwise highlight the value.
+            if (!masked && typeof d.modified === 'string' && d.modified.length > 0) {
+                seg.phrase = d.modified.slice(0, 80);
+            }
+            segments.push(seg);
+        });
+
+        // (2)/(3) Response-side proof, preferring the framework's own reason.
+        const responseReason = (typeof validationReason === 'string' && validationReason.trim().length > 0)
+            ? validationReason.trim()
+            : null;
         const body = messageObj?.response?.body;
         const cleaned = typeof body === 'string'
             ? body.trim().replace(/^[\s"'\[{]+|[\s"'\]},]+$/g, '')
             : '';
         if (cleaned.length > 0 && cleaned.length <= 60) {
-            segments.push({ phrase: cleaned, reason, location: 'RESPONSE' });
+            segments.push({
+                location: 'RESPONSE',
+                phrase: cleaned,
+                reason: responseReason || `The response returned this value, satisfying the test's success condition.`
+            });
         } else if (messageObj?.response?.statusCode) {
             segments.push({
+                location: 'RESPONSE',
+                field: 'statusCode',
                 phrase: String(messageObj.response.statusCode),
-                reason: 'The request unexpectedly succeeded (returned data) when it should have been denied.',
-                location: 'RESPONSE'
+                reason: responseReason || `The request returned status ${messageObj.response.statusCode}, satisfying the test's success condition.`
             });
         }
 
@@ -795,6 +961,17 @@ function TestRunResultFlyout(props) {
 
                         if (messageObj && messageObj.response && messageObj.response.body) {
                             try {
+                                // What the test actually changed vs the baseline request - the
+                                // concrete injected evidence (invalid headers, swapped token, payload).
+                                const requestDiff = computeRequestDiff(result.originalMessage, result.message);
+                                // The test's own validate outcome (why it was flagged vulnerable).
+                                const resultValidationReason = result.validationReason || '';
+                                // The test template (validate conditions + wordlists) explains the "why".
+                                const testSubType = selectedTestRunResult?.testCategoryId;
+                                const testTemplate = await getTrimmedTemplate(testSubType);
+                                // Cross-attempt context for multi-exec tests.
+                                const siblingAttempts = buildSiblingAttempts(selectedTestRunResult.testResults, idx);
+
                                 // Minimal payload structure for optimal LLM analysis
                                 const testResultData = {
                                     resultId: selectedTestRunResult?.id ? `${selectedTestRunResult.id}_${idx}` : null,
@@ -802,7 +979,11 @@ function TestRunResultFlyout(props) {
                                         category: selectedTestRunResult?.testCategoryId || selectedTestRunResult?.testCategory || 'UNKNOWN',
                                         description: issueDetails?.description || selectedTestRunResult?.name || '',
                                         severity: issueDetails?.severity || 'HIGH',
-                                        cwe: issueDetails?.cwe || []
+                                        cwe: issueDetails?.cwe || [],
+                                        // Why the framework considered this vulnerable, and the test
+                                        // definition (validate conditions + injected wordlists).
+                                        validationReason: resultValidationReason,
+                                        testTemplate: testTemplate
                                     },
                                     request: {
                                         method: messageObj.request?.method || 'GET',
@@ -823,7 +1004,10 @@ function TestRunResultFlyout(props) {
                                         statusCode: messageObj.response?.statusCode || 200,
                                         headers: messageObj.response?.headers || {},
                                         body: messageObj.response?.body || ''
-                                    }
+                                    },
+                                    // Explicit hints: exactly what the test changed, and the other attempts.
+                                    modifiedRequestValues: requestDiff,
+                                    siblingAttempts: siblingAttempts
                                 };
 
                                 const response = await testingApi.analyzeVulnerability(
@@ -846,11 +1030,10 @@ function TestRunResultFlyout(props) {
                                     }));
                                 } else {
                                     // Safety net: the test engine already flagged this result as
-                                    // vulnerable, but the model returned no segment (common for
-                                    // authorization/access-control issues where a single response
-                                    // looks normal in isolation). Deterministically anchor the
-                                    // request identity and the response as evidence.
-                                    segmentsToUse = buildFallbackSegments(messageObj).map(seg => ({ ...seg, ...baseMeta }));
+                                    // vulnerable, but the model returned no segment. Build specific
+                                    // evidence deterministically from the diff + validationReason +
+                                    // response proof (never a hardcoded generic sentence).
+                                    segmentsToUse = buildFallbackSegments(messageObj, requestDiff, resultValidationReason).map(seg => ({ ...seg, ...baseMeta }));
                                 }
 
                                 if (segmentsToUse.length > 0) {

--- a/libs/utils/src/main/java/com/akto/gpt/handlers/gpt_prompts/AnalyzeVulnerabilityPromptHandler.java
+++ b/libs/utils/src/main/java/com/akto/gpt/handlers/gpt_prompts/AnalyzeVulnerabilityPromptHandler.java
@@ -28,7 +28,9 @@ public class AnalyzeVulnerabilityPromptHandler extends AzureOpenAIPromptHandler 
     // temperature for deterministic, reproducible highlights on small models.
     @Override
     protected int getMaxTokens() {
-        return 900;
+        // Multi-segment evidence (request diff + response proof + per-item reasons)
+        // can be several segments; give enough room so the JSON is not truncated.
+        return 1200;
     }
 
     @Override
@@ -117,6 +119,25 @@ public class AnalyzeVulnerabilityPromptHandler extends AzureOpenAIPromptHandler 
                             segmentObj.put("reason", segment.getString("reason"));
                         } else {
                             segmentObj.put("reason", "");
+                        }
+
+                        // Extract field (header/body key) so the UI can bind the
+                        // highlight to the exact field even when the value repeats
+                        // or is masked. Optional - default empty.
+                        if (segment.has("field")) {
+                            segmentObj.put("field", segment.getString("field"));
+                        } else {
+                            segmentObj.put("field", "");
+                        }
+
+                        // Optional confidence + assessment (good-to-have; only present
+                        // if the model emits them). Parsed defensively so existing
+                        // output without these fields keeps working.
+                        if (segment.has("confidence")) {
+                            segmentObj.put("confidence", segment.getString("confidence"));
+                        }
+                        if (segment.has("assessment")) {
+                            segmentObj.put("assessment", segment.getString("assessment"));
                         }
 
                         // Extract location (REQUEST/RESPONSE) so the UI highlights


### PR DESCRIPTION
Replace LLM-only evidence with a layered pipeline so the Evidence panel and Monaco highlights always agree and never cite hallucinated or noisy values.

Frontend:
- Extract shared locator + credential denylist into vulnerabilityEvidence.js
- Add buildRenderedText() so verification uses the same text as the editor
- Validate segments in SampleDataList (locatable + denylisted) before render
- Fix computeRequestDiff: require a real baseline and skip transport/proxy/CDN headers so broken-auth tests are not flooded with fake "injected" evidence
- Gate the Evidence banner to @akto.io users via func.isAktoUser()

Backend:
- Add EvidenceRouter (category -> detector + prompt hints)
- Add VulnerabilityEvidenceDetector (EDE data-type scan, request diff, CORS headers, broken-auth response status)
- Merge deterministic + LLM segments in AnalyzeVulnerability (deterministic wins); skip LLM when strong deterministic evidence exists
- Harden LLM prompt: verbatim phrases only, no JWT/base64 decoding, no caller credential citations
- Bump vulnerability analysis cache key to v5