### PR TITLE
parse cookies before subtype finding

### DIFF
--- a/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
+++ b/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
@@ -94,7 +94,7 @@ public class RedactSampleData {
         return finalUrl;
     }
 
-    private static void handleCookies(List<String> cookieList, Map<String, List<String>> responseHeaders) {
+   private static void handleCookies(List<String> cookieList, Map<String, List<String>> responseHeaders) {
         Map<String, String> cookieMap = AuthPolicy.parseCookie(cookieList);
         StringBuilder newCookie = new StringBuilder();
         for (Map.Entry<String, String> entry : cookieMap.entrySet()) {
@@ -148,7 +148,7 @@ public class RedactSampleData {
                 }
             }
         }
-    }
+    } 
 
     // never use this function directly. This alters the httpResponseParams
     public static String redact(HttpResponseParams httpResponseParams, final boolean redactAll) throws Exception {
@@ -190,7 +190,7 @@ public class RedactSampleData {
                 loggerMaker.errorAndAddToDb("Error in redacting original payloads for xml content type: " +e.getMessage());
             }
 
-
+            
         }
 
         handleHeaders(responseHeaders, redactAll);
@@ -259,7 +259,7 @@ public class RedactSampleData {
         }
         
 
-    }
+    }    
 
     public static void change(String parentName, JsonNode parent, boolean redactAll, boolean isGraphqlModified) {
         if (parent == null) return;
@@ -334,16 +334,16 @@ public class RedactSampleData {
         if (xmlString == null || xmlString.isEmpty()) {
             return xmlString;
         }
-
+        
         // Pattern to match XML tags and their content: <tagName>content</tagName>
         Pattern pattern = Pattern.compile("<([^>/]+)>([^<>]*)</\\1>");
         Matcher matcher = pattern.matcher(xmlString);
         StringBuffer result = new StringBuffer();
-
+        
         while (matcher.find()) {
             String tagName = matcher.group(1);
             String tagContent = matcher.group(2);
-
+            
             // Apply redaction based on conditions
             if (redactAll) {
                 // Redact all content
@@ -359,15 +359,15 @@ public class RedactSampleData {
                 }
             }
         }
-
+        
         matcher.appendTail(result);
-
+        
         // Process attributes if needed (simplified version)
         // Pattern to match attributes: tagName attribute="value"
         Pattern attrPattern = Pattern.compile("(\\w+)\\s*=\\s*\"([^\"]*)\"");
         matcher = attrPattern.matcher(result.toString());
         StringBuffer finalResult = new StringBuffer();
-
+        
         while (matcher.find()) {
             String attrName = matcher.group(1);
             String attrValue = matcher.group(2);
@@ -383,12 +383,12 @@ public class RedactSampleData {
                 }
             }
         }
-
+        
         if (finalResult.length() > 0) {
             matcher.appendTail(finalResult);
             return finalResult.toString();
         }
-
+        
         return result.toString();
     }
 

--- a/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
+++ b/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
@@ -94,10 +94,28 @@ public class RedactSampleData {
         return finalUrl;
     }
 
+    private static void handleCookies(List<String> cookieList, Map<String, List<String>> responseHeaders) {
+        Map<String, String> cookieMap = AuthPolicy.parseCookie(cookieList);
+        StringBuilder newCookie = new StringBuilder();
+        for (Map.Entry<String, String> entry : cookieMap.entrySet()) {
+            String cookieName = entry.getKey();
+            String cookieValue = entry.getValue();
+            SingleTypeInfo.SubType subType = KeyTypes.findSubType(cookieValue, cookieName, null);
+            newCookie.append(cookieName).append("=");
+            if (SingleTypeInfo.isRedacted(subType.getName())) {
+                newCookie.append(redact(cookieValue));
+            } else {
+                newCookie.append(cookieValue);
+            }
+            newCookie.append(";");
+        }
+        responseHeaders.put(AuthPolicy.COOKIE_NAME, Collections.singletonList(newCookie.toString()));
+    }
+
     private static void handleHeaders(Map<String, List<String>> responseHeaders, boolean redactAll) {
-        if(redactAll){
+        if (redactAll) {
             for (String header : responseHeaders.keySet()) {
-                if(header.equals(HOST)){
+                if (header.equals(HOST)) {
                     continue;
                 }
                 if (header.equalsIgnoreCase(AuthPolicy.COOKIE_NAME)) {
@@ -117,17 +135,18 @@ public class RedactSampleData {
         for(Map.Entry<String, List<String>> entry : entries){
             String key = entry.getKey();
             List<String> values = entry.getValue();
-            SingleTypeInfo.SubType subType = KeyTypes.findSubType(values.get(0), key, null);
-            if(SingleTypeInfo.isRedacted(subType.getName())){
-                if(key.equals(HOST)){
-                    continue;
+
+            if (key.equals(AuthPolicy.COOKIE_NAME)) {
+                handleCookies(values, responseHeaders);
+            } else {
+                SingleTypeInfo.SubType subType = KeyTypes.findSubType(values.get(0), key, null);
+                if (SingleTypeInfo.isRedacted(subType.getName())) {
+                    if (key.equals(HOST)) {
+                        continue;
+                    }
+                    responseHeaders.put(key, Collections.singletonList(redact(values.get(0))));
                 }
-                if (key.equalsIgnoreCase(AuthPolicy.COOKIE_NAME)) {
-                    String cookie = redactCookie(responseHeaders, key);
-                    responseHeaders.put(key, Collections.singletonList(cookie));
-                    continue;
-                }
-                responseHeaders.put(key, Collections.singletonList(redact(values.get(0))));
+
             }
         }
     }
@@ -172,7 +191,7 @@ public class RedactSampleData {
                 loggerMaker.errorAndAddToDb("Error in redacting original payloads for xml content type: " +e.getMessage());
             }
 
-            
+
         }
 
         handleHeaders(responseHeaders, redactAll);
@@ -241,7 +260,7 @@ public class RedactSampleData {
         }
         
 
-    }    
+    }
 
     public static void change(String parentName, JsonNode parent, boolean redactAll, boolean isGraphqlModified) {
         if (parent == null) return;
@@ -316,16 +335,16 @@ public class RedactSampleData {
         if (xmlString == null || xmlString.isEmpty()) {
             return xmlString;
         }
-        
+
         // Pattern to match XML tags and their content: <tagName>content</tagName>
         Pattern pattern = Pattern.compile("<([^>/]+)>([^<>]*)</\\1>");
         Matcher matcher = pattern.matcher(xmlString);
         StringBuffer result = new StringBuffer();
-        
+
         while (matcher.find()) {
             String tagName = matcher.group(1);
             String tagContent = matcher.group(2);
-            
+
             // Apply redaction based on conditions
             if (redactAll) {
                 // Redact all content
@@ -341,15 +360,15 @@ public class RedactSampleData {
                 }
             }
         }
-        
+
         matcher.appendTail(result);
-        
+
         // Process attributes if needed (simplified version)
         // Pattern to match attributes: tagName attribute="value"
         Pattern attrPattern = Pattern.compile("(\\w+)\\s*=\\s*\"([^\"]*)\"");
         matcher = attrPattern.matcher(result.toString());
         StringBuffer finalResult = new StringBuffer();
-        
+
         while (matcher.find()) {
             String attrName = matcher.group(1);
             String attrValue = matcher.group(2);
@@ -365,12 +384,12 @@ public class RedactSampleData {
                 }
             }
         }
-        
+
         if (finalResult.length() > 0) {
             matcher.appendTail(finalResult);
             return finalResult.toString();
         }
-        
+
         return result.toString();
     }
 

--- a/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
+++ b/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
@@ -96,18 +96,13 @@ public class RedactSampleData {
 
    private static void handleCookies(List<String> cookieList, Map<String, List<String>> responseHeaders) {
         Map<String, String> cookieMap = AuthPolicy.parseCookie(cookieList);
-        StringBuilder newCookie = new StringBuilder();
+        StringJoiner newCookie = new StringJoiner(";");
         for (Map.Entry<String, String> entry : cookieMap.entrySet()) {
             String cookieName = entry.getKey();
             String cookieValue = entry.getValue();
             SingleTypeInfo.SubType subType = KeyTypes.findSubType(cookieValue, cookieName, null);
-            newCookie.append(cookieName).append("=");
-            if (SingleTypeInfo.isRedacted(subType.getName())) {
-                newCookie.append(redact(cookieValue));
-            } else {
-                newCookie.append(cookieValue);
-            }
-            newCookie.append(";");
+            String value = SingleTypeInfo.isRedacted(subType.getName()) ? redact(cookieValue) : cookieValue;
+            newCookie.add(cookieName + "=" + value);
         }
         responseHeaders.put(AuthPolicy.COOKIE_NAME, Collections.singletonList(newCookie.toString()));
     }

--- a/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
+++ b/apps/mini-runtime/src/main/java/com/akto/utils/RedactSampleData.java
@@ -113,9 +113,9 @@ public class RedactSampleData {
     }
 
     private static void handleHeaders(Map<String, List<String>> responseHeaders, boolean redactAll) {
-        if (redactAll) {
+        if(redactAll){
             for (String header : responseHeaders.keySet()) {
-                if (header.equals(HOST)) {
+                if(header.equals(HOST)){
                     continue;
                 }
                 if (header.equalsIgnoreCase(AuthPolicy.COOKIE_NAME)) {
@@ -146,7 +146,6 @@ public class RedactSampleData {
                     }
                     responseHeaders.put(key, Collections.singletonList(redact(values.get(0))));
                 }
-
             }
         }
     }


### PR DESCRIPTION
## Summary

- Previously, cookie redaction in the non-`redactAll` path was calling `redactCookie()` which redacted **all** cookie values unconditionally, regardless of their subtype
- Added `handleCookies()` which parses the cookie header, checks each cookie's subtype individually, and only redacts cookies whose subtype is flagged as sensitive
- Replaced the old cookie-handling logic in `handleHeaders()` with a call to `handleCookies()` for selective, per-cookie redaction

## Test plan

- [x] Verify that cookies with sensitive subtypes (e.g. auth tokens) are redacted
- [x] Verify that non-sensitive cookies are preserved as-is
- [x] Verify that the `redactAll=true` path still redacts all cookies via `redactCookie()`