### PR TITLE
Add deterministic missing-header evidence for MHH test results

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/gpt/cache/VulnerabilityAnalysisCache.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/cache/VulnerabilityAnalysisCache.java
@@ -31,7 +31,7 @@ public class VulnerabilityAnalysisCache {
     public String generateCacheKey(String analysisType, String resultId, BasicDBObject contentData) {
         if (resultId != null && !resultId.trim().isEmpty()) {
             String type = (analysisType != null) ? analysisType.toLowerCase() : "analysis";
-            return type + "_vulnerability_reqresp_v6:" + resultId;
+            return type + "_vulnerability_reqresp_v7:" + resultId;
         }
         return null;
     }

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/AnalyzeVulnerability.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/AnalyzeVulnerability.java
@@ -30,7 +30,26 @@ public class AnalyzeVulnerability implements QueryHandler {
 
         BasicDBObject testContext = (BasicDBObject) testData.get("testContext");
         BasicDBObject response = (BasicDBObject) testData.get("response");
+        BasicDBObject testRequest = (BasicDBObject) testData.get("request");
         String category = testContext != null ? testContext.getString("category") : null;
+
+        // 0) Header-presence (MHH) fast path. For "missing/unwanted header" tests the
+        //    evidence is fully deterministic (the test's validate header list vs the
+        //    headers actually present), so we compute it and SKIP the LLM entirely.
+        //    The category check is only a cheap pre-filter; the authoritative gate is
+        //    whether the detector actually found header conditions (non-empty result).
+        //    If it finds nothing (no header conditions / template missing) we fall
+        //    through to the normal path so we never produce empty evidence.
+        if (EvidenceRouter.isHeaderCategory(category)) {
+            BasicDBList headerSegments = HeaderEvidenceDetector.detect(category, response, testRequest);
+            if (headerSegments != null && !headerSegments.isEmpty()) {
+                loggerMaker.infoAndAddToDb("Header evidence segments for " + category + ": "
+                        + headerSegments.size() + " (skipping LLM)", LoggerMaker.LogDb.DASHBOARD);
+                BasicDBObject headerResult = new BasicDBObject();
+                headerResult.put("vulnerableSegments", headerSegments);
+                return headerResult;
+            }
+        }
 
         // 1) Precise deterministic detectors for the few single-artifact categories
         //    (broken-auth 2xx status, wildcard CORS header). No hallucination possible.

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/EvidenceRouter.java
@@ -108,6 +108,22 @@ public class EvidenceRouter {
     }
 
     /**
+     * Cheap pre-filter for header-presence (MHH) tests. This ONLY decides whether
+     * it is worth loading + parsing the test template to look for header key
+     * conditions; it does NOT by itself decide to skip the LLM. The authoritative
+     * gate is whether HeaderEvidenceDetector actually extracts header conditions.
+     */
+    public static boolean isHeaderCategory(String category) {
+        if (category == null) {
+            return false;
+        }
+        String c = category.toUpperCase();
+        return c.contains("HEADER") || c.contains("MHH") || c.contains("CORS")
+                || c.contains("HSTS") || c.contains("CSP") || c.contains("X_FRAME")
+                || c.contains("CONTENT_TYPE");
+    }
+
+    /**
      * The sensitive data type a sensitive-data-exposure test targets (e.g.
      * SENSITIVE_DATA_EXPOSURE_EMAIL -> EMAIL), or null if this is not an EDE
      * category. Lets the prompt name the exact data type instead of re-scanning.

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/HeaderEvidenceDetector.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/HeaderEvidenceDetector.java
@@ -1,0 +1,225 @@
+package com.akto.action.gpt.handlers;
+
+import com.akto.dao.test_editor.TestConfigYamlParser;
+import com.akto.dao.test_editor.YamlTemplateDao;
+import com.akto.dto.test_editor.FilterNode;
+import com.akto.dto.test_editor.TestConfig;
+import com.akto.dto.test_editor.YamlTemplate;
+import com.akto.log.LoggerMaker;
+import com.akto.util.Constants;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Deterministic, hallucination-free evidence for "missing / unwanted HTTP header"
+ * tests (Akto MHH category). The truth is in the test's validate block, e.g.
+ *   response_headers -> for_one -> key -> not_contains_either: [Cross-Origin-..., ...]
+ * which fires when those security headers are ABSENT. Since an absent header has
+ * nothing to highlight in the rendered response, we:
+ *  - load the untruncated template from the DB and parse its validate conditions,
+ *  - diff the expected/unwanted header names against the headers actually present,
+ *  - emit a grouped "informational" segment for the genuinely-missing headers and
+ *    a normal (highlightable) segment for any unwanted header that IS present.
+ * When the validate has no header key-presence conditions (or the template can't be
+ * loaded) this returns nothing, so the caller falls back to the LLM path.
+ */
+public class HeaderEvidenceDetector {
+
+    private static final LoggerMaker loggerMaker = new LoggerMaker(HeaderEvidenceDetector.class, LoggerMaker.LogDb.DASHBOARD);
+
+    // Operands on a header KEY. "missing" semantics flag absence (the header must
+    // be present); "unwanted" semantics flag presence (the header must be absent).
+    private static final Set<String> MISSING_OPERANDS = new HashSet<>(Arrays.asList("not_contains", "not_contains_either", "neq"));
+    private static final Set<String> UNWANTED_OPERANDS = new HashSet<>(Arrays.asList("contains", "contains_either", "eq"));
+
+    private static class HeaderCondition {
+        String location;       // REQUEST or RESPONSE
+        boolean missingCheck;  // true = expected header (flag if absent)
+        List<String> headers;
+    }
+
+    public static BasicDBList detect(String category, BasicDBObject response, BasicDBObject request) {
+        BasicDBList segments = new BasicDBList();
+        try {
+            FilterNode root = loadValidateRoot(category);
+            if (root == null) {
+                return segments;
+            }
+
+            List<HeaderCondition> conditions = new ArrayList<>();
+            collect(root, null, null, conditions);
+            if (conditions.isEmpty()) {
+                return segments;
+            }
+
+            Map<String, String> responseHeaders = headerKeyMap(response);
+            Map<String, String> requestHeaders = headerKeyMap(request);
+
+            LinkedHashSet<String> missingResponse = new LinkedHashSet<>();
+            LinkedHashSet<String> missingRequest = new LinkedHashSet<>();
+
+            for (HeaderCondition hc : conditions) {
+                Map<String, String> present = "REQUEST".equals(hc.location) ? requestHeaders : responseHeaders;
+                for (String header : hc.headers) {
+                    String presentKey = findPresent(present, header);
+                    if (hc.missingCheck) {
+                        if (presentKey == null) {
+                            if ("REQUEST".equals(hc.location)) {
+                                missingRequest.add(header);
+                            } else {
+                                missingResponse.add(header);
+                            }
+                        }
+                    } else if (presentKey != null) {
+                        // Unwanted header is present -> highlightable evidence.
+                        String where = "REQUEST".equals(hc.location) ? "request" : "response";
+                        segments.add(makeSegment(hc.location, presentKey, presentKey,
+                                "The " + where + " contains the unwanted header \"" + presentKey + "\", which the test flags.", false));
+                    }
+                }
+            }
+
+            if (!missingResponse.isEmpty()) {
+                segments.add(makeSegment("RESPONSE", "", String.join(", ", missingResponse),
+                        "The response is missing required security headers that the test expects.", true));
+            }
+            if (!missingRequest.isEmpty()) {
+                segments.add(makeSegment("REQUEST", "", String.join(", ", missingRequest),
+                        "The request is missing required headers that the test expects.", true));
+            }
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("Header evidence detection failed: " + e.getMessage(), LoggerMaker.LogDb.DASHBOARD);
+        }
+        return segments;
+    }
+
+    private static FilterNode loadValidateRoot(String category) throws Exception {
+        if (category == null || category.trim().isEmpty()) {
+            return null;
+        }
+        YamlTemplate template = YamlTemplateDao.instance.findOne(
+                Filters.eq(Constants.ID, category), Projections.include(YamlTemplate.CONTENT));
+        if (template == null || template.getContent() == null) {
+            return null;
+        }
+        TestConfig cfg = TestConfigYamlParser.parseTemplate(template.getContent());
+        if (cfg == null || cfg.getValidation() == null) {
+            return null;
+        }
+        return cfg.getValidation().getNode();
+    }
+
+    // Recursively collect header key-presence conditions, carrying the nearest
+    // concernedProperty/subConcernedProperty down to leaf operand nodes.
+    private static void collect(FilterNode node, String inheritedConcerned, String inheritedSub, List<HeaderCondition> out) {
+        if (node == null) {
+            return;
+        }
+        String concerned = node.getConcernedProperty() != null ? node.getConcernedProperty() : inheritedConcerned;
+        String sub = node.getSubConcernedProperty() != null ? node.getSubConcernedProperty() : inheritedSub;
+        String operand = node.getOperand() != null ? node.getOperand().toLowerCase().trim() : null;
+
+        if (operand != null && isHeaderProp(concerned) && "key".equalsIgnoreCase(sub)) {
+            boolean missing = MISSING_OPERANDS.contains(operand);
+            boolean unwanted = UNWANTED_OPERANDS.contains(operand);
+            if (missing || unwanted) {
+                List<String> headers = toStringList(node.getValues());
+                if (!headers.isEmpty()) {
+                    HeaderCondition hc = new HeaderCondition();
+                    hc.location = concerned.toLowerCase().startsWith("request") ? "REQUEST" : "RESPONSE";
+                    hc.missingCheck = missing;
+                    hc.headers = headers;
+                    out.add(hc);
+                }
+            }
+        }
+
+        if (node.getChildNodes() != null) {
+            for (FilterNode child : node.getChildNodes()) {
+                collect(child, concerned, sub, out);
+            }
+        }
+    }
+
+    private static boolean isHeaderProp(String p) {
+        if (p == null) {
+            return false;
+        }
+        String s = p.toLowerCase();
+        return s.equals("response_headers") || s.equals("request_headers");
+    }
+
+    private static List<String> toStringList(Object values) {
+        List<String> out = new ArrayList<>();
+        if (values instanceof List) {
+            for (Object o : (List<?>) values) {
+                if (o != null) {
+                    String s = o.toString().trim();
+                    if (!s.isEmpty()) {
+                        out.add(s);
+                    }
+                }
+            }
+        } else if (values instanceof String) {
+            String s = ((String) values).trim();
+            if (!s.isEmpty()) {
+                out.add(s);
+            }
+        }
+        return out;
+    }
+
+    private static Map<String, String> headerKeyMap(BasicDBObject httpObj) {
+        Map<String, String> map = new HashMap<>();
+        if (httpObj == null) {
+            return map;
+        }
+        Object node = VulnerabilityEvidenceDetector.asNode(httpObj.get("headers"));
+        if (node instanceof Map) {
+            for (Map.Entry<?, ?> e : ((Map<?, ?>) node).entrySet()) {
+                String key = String.valueOf(e.getKey());
+                map.put(key.toLowerCase().trim(), key);
+            }
+        }
+        return map;
+    }
+
+    // Mirrors the framework's case-insensitive substring matching on header names.
+    private static String findPresent(Map<String, String> present, String headerName) {
+        String h = headerName.toLowerCase().trim();
+        String exact = present.get(h);
+        if (exact != null) {
+            return exact;
+        }
+        for (Map.Entry<String, String> e : present.entrySet()) {
+            if (e.getKey().contains(h)) {
+                return e.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static BasicDBObject makeSegment(String location, String field, String phrase, String reason, boolean informational) {
+        BasicDBObject segment = new BasicDBObject();
+        segment.put("start", 0);
+        segment.put("end", 0);
+        segment.put("location", location);
+        segment.put("field", field == null ? "" : field);
+        segment.put("phrase", phrase == null ? "" : phrase);
+        segment.put("reason", reason);
+        segment.put("source", "deterministic");
+        segment.put("informational", informational);
+        return segment;
+    }
+}

--- a/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/VulnerabilityEvidenceDetector.java
+++ b/apps/dashboard/src/main/java/com/akto/action/gpt/handlers/VulnerabilityEvidenceDetector.java
@@ -82,7 +82,9 @@ public class VulnerabilityEvidenceDetector {
         }
     }
 
-    private static Object asNode(Object value) {
+    // Package-private so sibling detectors (e.g. HeaderEvidenceDetector) reuse the
+    // same lenient "string-or-object -> object" coercion instead of duplicating it.
+    static Object asNode(Object value) {
         if (value instanceof String) {
             return parseJson((String) value);
         }
@@ -116,6 +118,7 @@ public class VulnerabilityEvidenceDetector {
         segment.put("phrase", truncate(phrase));
         segment.put("reason", reason);
         segment.put("source", "deterministic");
+        segment.put("informational", false);
         return segment;
     }
 }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleData.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleData.js
@@ -174,6 +174,11 @@ function highlightVulnerabilities(vulnerabilitySegments, ref) {
 
   vulnerabilitySegments.forEach((segment) => {
     try {
+      // Informational evidence (e.g. missing headers) describes something ABSENT,
+      // so there is nothing in the editor text to highlight - it is panel-only.
+      if (segment?.informational === true) {
+        return;
+      }
       // Shared locator (see vulnerabilityEvidence.js) - the SAME contract the
       // Evidence panel uses, so we never highlight what the panel can't show.
       const range = locateSegment(segment, text);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataComponent.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataComponent.jsx
@@ -125,8 +125,11 @@ function SampleDataComponent(props) {
 
         // LLM analysis segments carry a location of REQUEST/RESPONSE so we can
         // highlight the evidence in the correct editor (default to RESPONSE).
-        const llmRequestSegments = baseSegments.filter(s => s?.location === 'REQUEST');
-        const llmResponseSegments = baseSegments.filter(s => s?.location !== 'REQUEST');
+        // Informational segments (e.g. missing headers) are panel-only - they
+        // describe something absent, so they never go to the editors.
+        const highlightableSegments = baseSegments.filter(s => s?.informational !== true);
+        const llmRequestSegments = highlightableSegments.filter(s => s?.location === 'REQUEST');
+        const llmResponseSegments = highlightableSegments.filter(s => s?.location !== 'REQUEST');
 
         if(isNewDiff){
             // Shared builder so the rendered text matches the verification contract.

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataList.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/shared/SampleDataList.js
@@ -83,6 +83,7 @@ function VulnerabilityEvidence({ segments }) {
                     const reason = typeof seg?.reason === 'string' ? seg.reason : '';
                     const phrase = typeof seg?.phrase === 'string' ? seg.phrase : '';
                     const field = typeof seg?.field === 'string' ? seg.field : '';
+                    const isInformational = seg?.informational === true;
                     // Prefer showing the concrete value; if it is masked/absent, show the field so the row is never blank.
                     const evidenceText = phrase || field;
                     return (
@@ -95,7 +96,15 @@ function VulnerabilityEvidence({ segments }) {
                                 </Box>
                                 <VerticalStack gap="0">
                                     {reason ? <Text variant="bodyMd">{reason}</Text> : null}
-                                    {evidenceText ? (
+                                    {/* Informational evidence (e.g. missing headers) describes something absent,
+                                        so render the header list verbatim without the locatable "field: phrase" form. */}
+                                    {isInformational ? (
+                                        phrase ? (
+                                            <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#6B46C1', wordBreak: 'break-all' }}>
+                                                {phrase}
+                                            </span>
+                                        ) : null
+                                    ) : evidenceText ? (
                                         <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#6B46C1', wordBreak: 'break-all' }}>
                                             {field && phrase ? `${field}: ${phrase}` : evidenceText}
                                         </span>
@@ -147,9 +156,15 @@ function SampleDataList(props) {
             return currentSample;
         }
         const { requestText, responseText } = transform.buildRenderedText(currentSample, { isNewDiff, redactHeaders, metadata });
-        const requestSegments = segments.filter(s => String(s?.location || '').toUpperCase() === 'REQUEST');
-        const responseSegments = segments.filter(s => String(s?.location || '').toUpperCase() !== 'REQUEST');
+        // Informational segments (e.g. missing-header evidence) describe something
+        // ABSENT, so there is nothing to locate/highlight - they bypass the
+        // locatability filter and are panel-only. Everything else must be locatable.
+        const informationalSegments = segments.filter(s => s?.informational === true);
+        const locatableInput = segments.filter(s => s?.informational !== true);
+        const requestSegments = locatableInput.filter(s => String(s?.location || '').toUpperCase() === 'REQUEST');
+        const responseSegments = locatableInput.filter(s => String(s?.location || '').toUpperCase() !== 'REQUEST');
         const validated = [
+            ...informationalSegments,
             ...filterLocatableSegments(requestSegments, requestText),
             ...filterLocatableSegments(responseSegments, responseText),
         ];


### PR DESCRIPTION
Header-presence tests are vulnerable because expected security headers are absent, so LLM evidence was nonsensical (e.g. citing unrelated present headers). Derive evidence from the test validate block instead.

- HeaderEvidenceDetector: load template from DB, parse validate FilterNode tree, diff expected/unwanted header keys against actual request/response headers; emit grouped informational segments for missing headers and highlightable segments for unwanted-present headers
- EvidenceRouter.isHeaderCategory pre-filter; AnalyzeVulnerability skips LLM when header detector produces evidence
- Frontend: informational segments bypass locatability filter, panel-only rendering without editor highlights
- Bump vulnerability analysis cache key v6 -> v7