### PR TITLE
Add execution status column to individual test run summary table.

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/SummaryTable.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/SummaryTable.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useEffect, useRef, useState, useMemo } from 'react'
 import transform from '../transform'
 import func from '@/util/func'
 import api from '../api'
@@ -6,10 +6,18 @@ import { IndexTable, useIndexResourceState, LegacyCard, HorizontalStack, Paginat
 import { GithubRow } from '../../../components/tables/rows/GithubRow'
 import observeFunc from "../../observe/transform"
 import { getDashboardCategory, mapLabel } from '../../../../main/labelHelper'
+import {
+    getCachedRunStatusCounts,
+    getValidRunStatusMap,
+    setCachedRunStatusCounts,
+} from '../TestRunsPage/runStatusCache'
+import { shouldFetchRunStatusSummary } from '../TestRunsPage/runStatusUtils'
 
 function SummaryTable({testingRunResultSummaries, setSummary}) {
 
     const [data, setData] = useState([])
+    const [runStatusUpdateKey, setRunStatusUpdateKey] = useState("")
+    const pendingRunStatusRequestRef = useRef(null)
 
     // Memoize headers to prevent recreation on every render
     const headers = useMemo(() => [
@@ -25,6 +33,11 @@ function SummaryTable({testingRunResultSummaries, setSummary}) {
             title: 'Vulnerabilities',
             value: 'prettifiedSeverities',
             isCustom: true
+        },
+        {
+            title: mapLabel("Test", getDashboardCategory()) + " run status",
+            value: 'run_message',
+            maxWidth: '220px',
         },
         {
             title: `Total ${mapLabel('APIs Tested', getDashboardCategory())}`,
@@ -59,8 +72,49 @@ function SummaryTable({testingRunResultSummaries, setSummary}) {
       ]};
 
     useEffect(() => {
-        setData(transform.prettifySummaryTable(testingRunResultSummaries))
-    },[testingRunResultSummaries])
+        setData(transform.prepareSummaryTableRows(testingRunResultSummaries, getValidRunStatusMap()))
+    }, [testingRunResultSummaries, runStatusUpdateKey])
+
+    useEffect(() => {
+        const summaryHexIds = [...new Set(
+            (testingRunResultSummaries || [])
+                .filter(shouldFetchRunStatusSummary)
+                .map((summary) => summary.hexId)
+                .filter((hexId) => hexId && getCachedRunStatusCounts(hexId) === undefined)
+        )];
+
+        if (summaryHexIds.length === 0) {
+            return;
+        }
+
+        const requestKey = summaryHexIds.slice().sort().join(',');
+        if (pendingRunStatusRequestRef.current === requestKey) {
+            return;
+        }
+
+        pendingRunStatusRequestRef.current = requestKey;
+        const chunkSize = 10;
+        const chunks = [];
+        for (let i = 0; i < summaryHexIds.length; i += chunkSize) {
+            chunks.push(summaryHexIds.slice(i, i + chunkSize));
+        }
+
+        Promise.all(chunks.map((chunk) =>
+            api.fetchTestRunStatusSummaries(chunk)
+                .then((statusSummaries) => {
+                    if (pendingRunStatusRequestRef.current !== requestKey) {
+                        return;
+                    }
+                    setCachedRunStatusCounts(statusSummaries);
+                    setRunStatusUpdateKey(Date.now().toString());
+                })
+                .catch(() => {})
+        )).finally(() => {
+            if (pendingRunStatusRequestRef.current === requestKey) {
+                pendingRunStatusRequestRef.current = null;
+            }
+        });
+    }, [testingRunResultSummaries])
 
     const resourceIDResolver = (data) => {
         return data.id;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/TestRunsPage.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/TestRunsPage.js
@@ -5,7 +5,7 @@ import api from "../api";
 import testingApi from "../../testing/api";
 import { useEffect, useReducer, useRef, useState } from 'react';
 import { useCollectionPageScope } from '../../../hooks/useCollectionPageScope';
-import transform, { getStatus } from "../transform";
+import transform from "../transform";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
 import func from "@/util/func"
 import { CellType } from "../../../components/tables/rows/GithubRow";
@@ -18,41 +18,13 @@ import PersistStore from "../../../../main/PersistStore";
 import TitleWithInfo from "@/apps/dashboard/components/shared/TitleWithInfo";
 import { getDashboardCategory, mapLabel } from "../../../../main/labelHelper";
 import SummaryCardComponent from "./SummaryCardComponent";
+import {
+  getCachedRunStatusCounts,
+  getValidRunStatusMap,
+  setCachedRunStatusCounts,
+} from "./runStatusCache";
+import { shouldFetchRunStatusSummary } from "./runStatusUtils";
 
-// Module-level cache for test run execution status counts. Counts for COMPLETED runs are
-// stable, so caching them here (instead of a component ref) keeps them across remounts and
-// avoids re-hitting the heavy backend status API when revisiting the page within the TTL.
-const RUN_STATUS_CACHE_TTL_MS = 5 * 60 * 1000;
-const runStatusCache = new Map(); // testingRunResultSummaryHexId -> { counts, ts }
-
-function getCachedRunStatusCounts(hexId) {
-  const entry = runStatusCache.get(hexId);
-  if (!entry) return undefined;
-  if (Date.now() - entry.ts > RUN_STATUS_CACHE_TTL_MS) {
-    runStatusCache.delete(hexId);
-    return undefined;
-  }
-  return entry.counts;
-}
-
-function getValidRunStatusMap() {
-  const result = {};
-  const now = Date.now();
-  runStatusCache.forEach((entry, hexId) => {
-    if (now - entry.ts > RUN_STATUS_CACHE_TTL_MS) {
-      runStatusCache.delete(hexId);
-    } else {
-      result[hexId] = entry.counts;
-    }
-  });
-  return result;
-}
-
-function setCachedRunStatusCounts(statusSummaries) {
-  Object.entries(statusSummaries || {}).forEach(([hexId, counts]) => {
-    runStatusCache.set(hexId, { counts, ts: Date.now() });
-  });
-}
 /*
   {
     text:"", // req. -> The text to be shown wherever the header is being shown
@@ -215,12 +187,6 @@ const [selected, setSelected] = useState(initialTabIdx)
 
 const tableCountObj = func.getTabsCount(definedTableTabs, {}, initialCount)
 const tableTabs = func.getTableTabsContent(definedTableTabs, tableCountObj, setCurrentTab, currentTab, tabsInfo)
-
-function shouldFetchRunStatusSummary(item) {
-  return getStatus(item?.testRunState) === "COMPLETED"
-    && !item?.authError
-    && !item?.tokenRateLimited;
-}
 
 const [severityMap, setSeverityMap] = useState({})
 const [subCategoryInfo, setSubCategoryInfo] = useState({})

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/runStatusCache.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/runStatusCache.js
@@ -1,0 +1,34 @@
+// Module-level cache for test run execution status counts. Counts for COMPLETED runs are
+// stable, so caching them here (instead of a component ref) keeps them across remounts and
+// avoids re-hitting the heavy backend status API when revisiting the page within the TTL.
+const RUN_STATUS_CACHE_TTL_MS = 5 * 60 * 1000;
+const runStatusCache = new Map(); // testingRunResultSummaryHexId -> { counts, ts }
+
+export function getCachedRunStatusCounts(hexId) {
+  const entry = runStatusCache.get(hexId);
+  if (!entry) return undefined;
+  if (Date.now() - entry.ts > RUN_STATUS_CACHE_TTL_MS) {
+    runStatusCache.delete(hexId);
+    return undefined;
+  }
+  return entry.counts;
+}
+
+export function getValidRunStatusMap() {
+  const result = {};
+  const now = Date.now();
+  runStatusCache.forEach((entry, hexId) => {
+    if (now - entry.ts > RUN_STATUS_CACHE_TTL_MS) {
+      runStatusCache.delete(hexId);
+    } else {
+      result[hexId] = entry.counts;
+    }
+  });
+  return result;
+}
+
+export function setCachedRunStatusCounts(statusSummaries) {
+  Object.entries(statusSummaries || {}).forEach(([hexId, counts]) => {
+    runStatusCache.set(hexId, { counts, ts: Date.now() });
+  });
+}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/runStatusUtils.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/runStatusUtils.jsx
@@ -145,6 +145,13 @@ export function getHttpStatusIssueList(statusCounts) {
   return getExecutionIssueList(statusCounts).filter((item) => statusCodeFromKey(item.key) != null);
 }
 
+export function shouldFetchRunStatusSummary(item) {
+  const state = item?.testRunState ?? item?.state;
+  const authError = item?.authError ?? item?.metadata?.error;
+  const tokenRateLimited = item?.tokenRateLimited ?? item?.metadata?.tokenRateLimited;
+  return getStatus(state) === "COMPLETED" && !authError && !tokenRateLimited;
+}
+
 function buildSummaryNodes(issues) {
   const topIssues = issues.slice(0, 2);
   const remaining = issues.length - topIssues.length;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/transform.js
@@ -873,6 +873,16 @@ const transform = {
     })
     return summaries;
   },
+  prepareSummaryTableRows: (summaries, statusSummaries = {}) => {
+    const rows = transform.prettifySummaryTable(summaries).map((row) => ({
+      ...row,
+      testRunState: row.state,
+      testingRunResultSummaryHexId: row.hexId,
+      authError: row.metadata?.error,
+      tokenRateLimited: row.metadata?.tokenRateLimited,
+    }));
+    return transform.enrichWithRunStatus(rows, statusSummaries);
+  },
 
   getInfoSectionsHeaders() {
     let moreInfoSections = [


### PR DESCRIPTION
Reuse the main test runs page status rendering and shared cache so each summary row shows the same HTTP error and execution issue breakdown.