### PR TITLE
fix: make cascade backpressure self-healing + serve cache before back…

### DIFF
--- a/apps/agent-guard/python-service/worker-py/src/cascade_backpressure.py
+++ b/apps/agent-guard/python-service/worker-py/src/cascade_backpressure.py
@@ -1,25 +1,44 @@
 """Adaptive backpressure for LLM cascade scans when Vertex latency is elevated.
 
-Recent cascade latencies are averaged over a rolling window. When that average
-meets or exceeds AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS (env override), new
-cascade scans fail-open (is_valid=True) so guardrails traffic is not blocked.
+Recent cascade latencies are averaged over a rolling, *time-bounded* window. When
+that average meets or exceeds AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS (env
+override), new cascade scans fail-open (is_valid=True) so guardrails traffic is
+not blocked.
+
+Recovery: samples older than AGW_CASCADE_BACKPRESSURE_TTL_SECONDS are evicted on
+every read/write, *independently of new traffic*. This is what makes backpressure
+self-healing. While skipping, no cascade runs, so no new latencies are recorded —
+a purely count-based window would therefore stay full of stale high latencies and
+latch ON forever. With time eviction the stale samples age out; once fewer than
+min_samples remain, should_skip_cascade() returns False, the next cascade runs as
+a natural probe, and fresh latencies decide whether to re-trip. So a transient
+Vertex slowdown self-clears within ~TTL instead of requiring a process restart.
 """
 
 from __future__ import annotations
 
 import os
 import threading
+import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Deque, Dict, Optional
+from typing import Deque, Dict, Optional, Tuple
 
 _DEFAULT_WINDOW = 50
 _DEFAULT_MIN_SAMPLES = 5
 _DEFAULT_AVG_LATENCY_MS = 8000.0
+_DEFAULT_TTL_SECONDS = 30.0
 _DEFAULT_ENABLED = True
 
 _lock = threading.Lock()
-_latencies_ms: Deque[float] = deque(maxlen=_DEFAULT_WINDOW)
+# Each entry is (monotonic_timestamp_seconds, latency_ms). maxlen bounds memory
+# under bursts; the TTL bounds staleness so backpressure can recover.
+_samples: Deque[Tuple[float, float]] = deque(maxlen=_DEFAULT_WINDOW)
+
+
+def _now() -> float:
+    """Monotonic clock (seconds). Indirected so tests can control time."""
+    return time.monotonic()
 
 
 @dataclass(frozen=True)
@@ -28,6 +47,7 @@ class BackpressureConfig:
     min_samples: int = _DEFAULT_MIN_SAMPLES
     threshold_ms: float = _DEFAULT_AVG_LATENCY_MS
     window: int = _DEFAULT_WINDOW
+    ttl_seconds: float = _DEFAULT_TTL_SECONDS
 
 
 _config = BackpressureConfig()
@@ -65,51 +85,68 @@ def get_config() -> BackpressureConfig:
 
 
 def configure_from_env() -> None:
-    """Load threshold/window from env; resize the rolling latency window."""
-    global _config, _latencies_ms
+    """Load threshold/window/ttl from env; resize the rolling latency window."""
+    global _config, _samples
     window = _env_int("AGW_CASCADE_BACKPRESSURE_WINDOW", _DEFAULT_WINDOW)
     _config = BackpressureConfig(
         enabled=_env_bool("AGW_CASCADE_BACKPRESSURE_ENABLED", _DEFAULT_ENABLED),
         min_samples=_env_int("AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES", _DEFAULT_MIN_SAMPLES),
         threshold_ms=_env_float("AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS", _DEFAULT_AVG_LATENCY_MS),
         window=window,
+        ttl_seconds=_env_float("AGW_CASCADE_BACKPRESSURE_TTL_SECONDS", _DEFAULT_TTL_SECONDS),
     )
     with _lock:
-        if window != _latencies_ms.maxlen:
-            _latencies_ms = deque(list(_latencies_ms)[-window:], maxlen=window)
+        if window != _samples.maxlen:
+            _samples = deque(list(_samples)[-window:], maxlen=window)
+
+
+def _prune_locked(now: float) -> None:
+    """Drop samples older than the TTL. Caller must hold _lock."""
+    ttl = _config.ttl_seconds
+    if ttl <= 0:
+        return
+    cutoff = now - ttl
+    while _samples and _samples[0][0] < cutoff:
+        _samples.popleft()
 
 
 def record_cascade_latency(elapsed_ms: float) -> None:
     if elapsed_ms <= 0:
         return
+    now = _now()
     with _lock:
-        _latencies_ms.append(elapsed_ms)
+        _samples.append((now, elapsed_ms))
+        _prune_locked(now)
 
 
 def recent_avg_latency_ms() -> Optional[float]:
-    """Rolling average of recorded cascade latencies, or None when empty."""
+    """Rolling average of non-expired cascade latencies, or None when empty."""
     with _lock:
-        if not _latencies_ms:
+        _prune_locked(_now())
+        if not _samples:
             return None
-        return sum(_latencies_ms) / len(_latencies_ms)
+        return sum(lat for _, lat in _samples) / len(_samples)
 
 
 def recent_sample_count() -> int:
     with _lock:
-        return len(_latencies_ms)
+        _prune_locked(_now())
+        return len(_samples)
 
 
 def should_skip_cascade() -> bool:
-    """Return True when computed avg latency exceeds the env threshold."""
+    """Return True when the average of non-expired cascade latencies meets the env
+    threshold. Stale samples are evicted first so this recovers on its own."""
     cfg = _config
     if not cfg.enabled:
         return False
 
     with _lock:
-        count = len(_latencies_ms)
+        _prune_locked(_now())
+        count = len(_samples)
         if count < cfg.min_samples:
             return False
-        avg = sum(_latencies_ms) / count
+        avg = sum(lat for _, lat in _samples) / count
 
     return avg >= cfg.threshold_ms
 
@@ -128,7 +165,7 @@ def cascade_skip_details() -> Dict[str, object]:
 
 
 def reset_for_tests() -> None:
-    global _config, _latencies_ms
+    global _config, _samples
     _config = BackpressureConfig()
     with _lock:
-        _latencies_ms.clear()
+        _samples.clear()

--- a/apps/agent-guard/python-service/worker-py/src/scan_handler.py
+++ b/apps/agent-guard/python-service/worker-py/src/scan_handler.py
@@ -81,24 +81,18 @@ async def scan_payload(
             config = {**default_cfg, **config, "modelConfigs": default_cfg["modelConfigs"]}
         if scanner_name in GEMMA_ONLY_SCANNERS:
             config = {**config, "modelConfigs": strip_qwen_tier(config.get("modelConfigs"))}
-        if cascade_backpressure.should_skip_cascade():
-            return shape_response(
-                scanner_name,
-                True,
-                0.0,
-                text,
-                {**cascade_backpressure.cascade_skip_details(), "scanner_type": scanner_type},
-            )
         store_fn = None
         if config.get("storeAllResults"):
             store_fn = lambda completed, name: schedule(alerts.store_results(completed, name))
 
-        # Semantic cache, decide mode: embed + lookup once before paying for the
-        # cascade. A fresh within-threshold hit short-circuits — safe verdicts on
-        # a fuzzy match, blocks only on a (near-)exact repeat (see cache.try_serve);
-        # a miss/error falls through. The served verdict (is_valid) is honoured so
-        # cached blocks still block. `prep` is reused by observe() so a miss embeds
-        # only once.
+        # Semantic cache, decide mode: consult the cache BEFORE applying
+        # backpressure, so a cached verdict (including a cached block) is still
+        # served correctly while Vertex is slow — backpressure must only short-
+        # circuit a genuine miss, never a known answer. A fresh within-threshold
+        # hit short-circuits — safe verdicts on a fuzzy match, blocks only on a
+        # (near-)exact repeat (see cache.try_serve); a miss/error falls through.
+        # The served verdict (is_valid) is honoured so cached blocks still block.
+        # `prep` is reused by observe() so a miss embeds only once.
         prep = None
         if cache.serving():
             prep = await cache.prepare(scanner_name, scanner_type, text, config)
@@ -108,6 +102,17 @@ async def scan_payload(
                 return shape_response(
                     scanner_name, served["is_valid"], served["risk_score"], text, served["details"]
                 )
+
+        # Cache miss (or cache not serving): only now does backpressure fail-open
+        # to avoid paying for the slow cascade while Vertex latency is elevated.
+        if cascade_backpressure.should_skip_cascade():
+            return shape_response(
+                scanner_name,
+                True,
+                0.0,
+                text,
+                {**cascade_backpressure.cascade_skip_details(), "scanner_type": scanner_type},
+            )
         try:
             result = await scan_with_model_map(
                 scanner_name, scanner_type, text, config, store_fn=store_fn

--- a/apps/agent-guard/python-service/worker-py/tests/test_cascade_backpressure.py
+++ b/apps/agent-guard/python-service/worker-py/tests/test_cascade_backpressure.py
@@ -1,0 +1,116 @@
+"""cascade_backpressure — trip on sustained high latency, and SELF-HEAL.
+
+The core regression: a count-only window latches ON forever, because once it
+skips, no cascade runs, so no fresh latency is ever recorded to push the stale
+high samples out. These tests drive a controllable clock to prove the
+time-bounded window expires stale samples and recovers without a restart.
+"""
+
+import cascade_backpressure as bp
+
+
+def _set_clock(monkeypatch, holder):
+    monkeypatch.setattr(bp, "_now", lambda: holder[0])
+
+
+def _configure(monkeypatch, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, str(v))
+    bp.configure_from_env()
+
+
+def test_does_not_skip_below_min_samples(monkeypatch):
+    t = [1000.0]; _set_clock(monkeypatch, t)
+    bp.reset_for_tests()
+    _configure(monkeypatch, AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES=5,
+               AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS=1000,
+               AGW_CASCADE_BACKPRESSURE_TTL_SECONDS=30)
+    for _ in range(4):                       # only 4 high samples (< min 5)
+        bp.record_cascade_latency(9000)
+    assert bp.should_skip_cascade() is False
+
+
+def test_trips_on_sustained_high_latency(monkeypatch):
+    t = [1000.0]; _set_clock(monkeypatch, t)
+    bp.reset_for_tests()
+    _configure(monkeypatch, AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES=5,
+               AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS=1000,
+               AGW_CASCADE_BACKPRESSURE_TTL_SECONDS=30)
+    for _ in range(6):
+        bp.record_cascade_latency(9000)      # avg 9000 >= 1000
+    assert bp.should_skip_cascade() is True
+
+
+def test_self_heals_after_ttl_without_new_samples(monkeypatch):
+    # THE regression test: trip it, then advance the clock past the TTL with NO
+    # new cascades (simulating the skip path) — it must recover on its own.
+    t = [1000.0]; _set_clock(monkeypatch, t)
+    bp.reset_for_tests()
+    _configure(monkeypatch, AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES=5,
+               AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS=1000,
+               AGW_CASCADE_BACKPRESSURE_TTL_SECONDS=30)
+    for _ in range(6):
+        bp.record_cascade_latency(9000)
+    assert bp.should_skip_cascade() is True   # latched on
+    t[0] += 31                                # 31s pass, still skipping -> no new samples
+    assert bp.should_skip_cascade() is False  # stale samples expired -> recovered
+    assert bp.recent_sample_count() == 0
+
+
+def test_reopens_when_probe_latency_drops(monkeypatch):
+    # After recovery, fresh fast probes keep it open (Vertex healthy again).
+    t = [1000.0]; _set_clock(monkeypatch, t)
+    bp.reset_for_tests()
+    _configure(monkeypatch, AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES=5,
+               AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS=1000,
+               AGW_CASCADE_BACKPRESSURE_TTL_SECONDS=30)
+    for _ in range(6):
+        bp.record_cascade_latency(9000)
+    assert bp.should_skip_cascade() is True
+    t[0] += 31
+    for _ in range(6):                        # healthy probes
+        bp.record_cascade_latency(120)
+    assert bp.should_skip_cascade() is False  # avg 120 < 1000 -> stays open
+
+
+def test_retrips_if_still_slow_after_probe(monkeypatch):
+    t = [1000.0]; _set_clock(monkeypatch, t)
+    bp.reset_for_tests()
+    _configure(monkeypatch, AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES=5,
+               AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS=1000,
+               AGW_CASCADE_BACKPRESSURE_TTL_SECONDS=30)
+    for _ in range(6):
+        bp.record_cascade_latency(9000)
+    t[0] += 31
+    assert bp.should_skip_cascade() is False  # window expired
+    for _ in range(5):                        # probes show Vertex still slow
+        bp.record_cascade_latency(9000)
+    assert bp.should_skip_cascade() is True    # re-trips
+
+
+def test_disabled_never_skips(monkeypatch):
+    t = [1000.0]; _set_clock(monkeypatch, t)
+    bp.reset_for_tests()
+    _configure(monkeypatch, AGW_CASCADE_BACKPRESSURE_ENABLED="false",
+               AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES=5,
+               AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS=1000)
+    for _ in range(10):
+        bp.record_cascade_latency(9000)
+    assert bp.should_skip_cascade() is False
+
+
+def test_partial_expiry_keeps_recent_samples(monkeypatch):
+    # Old high samples expire; only recent ones count toward the average.
+    t = [1000.0]; _set_clock(monkeypatch, t)
+    bp.reset_for_tests()
+    _configure(monkeypatch, AGW_CASCADE_BACKPRESSURE_MIN_SAMPLES=3,
+               AGW_CASCADE_BACKPRESSURE_AVG_LATENCY_MS=1000,
+               AGW_CASCADE_BACKPRESSURE_TTL_SECONDS=10)
+    for _ in range(5):
+        bp.record_cascade_latency(9000)      # at t=1000
+    t[0] += 6
+    for _ in range(5):
+        bp.record_cascade_latency(100)       # at t=1006 (fast)
+    t[0] += 6                                 # now t=1012: the 9000s (t=1000) are >10s old
+    assert bp.recent_sample_count() == 5      # only the fast ones survive
+    assert bp.should_skip_cascade() is False  # avg 100 < 1000


### PR DESCRIPTION
…pressure

cascade_backpressure could latch ON permanently: once the rolling average of cascade latencies tripped the threshold, every request skipped the cascade, so no new latency was ever recorded — the count-based window never evicted the stale high samples and the average stayed above threshold until the process restarted. Result: guardrails silently fail-open indefinitely after any transient Vertex slowdown.

Make the latency window time-bounded: samples older than AGW_CASCADE_BACKPRESSURE_TTL_SECONDS (default 30s) are evicted on every read/write, independent of new traffic. Stale samples now age out, the window empties, the next cascade runs as a natural probe, and fresh latencies decide whether to re-trip — so a transient slowdown self-clears within ~TTL.

Also reorder scan_handler to consult the semantic cache BEFORE applying backpressure, so a cached verdict (including a cached block) is still served correctly while Vertex is slow; backpressure now only short-circuits a genuine cache miss.

Adds tests/test_cascade_backpressure.py (7 tests incl. the self-heal regression).