### PR TITLE
perf: run agent-guard services with multiple uvicorn workers

### DIFF
--- a/apps/agent-guard/python-service/anonymizer-container/Dockerfile
+++ b/apps/agent-guard/python-service/anonymizer-container/Dockerfile
@@ -12,4 +12,6 @@ ENV PYTHONUNBUFFERED=1
 ENV PORT=8093
 EXPOSE 8093
 
-CMD ["uvicorn", "anonymizer_service:app", "--host", "0.0.0.0", "--port", "8093"]
+# Multiple workers so anonymization isn't pinned to one core. Each worker loads
+# its own spaCy model (small); default 4, override with ANONYMIZER_WORKERS.
+CMD exec uvicorn anonymizer_service:app --host 0.0.0.0 --port 8093 --workers ${ANONYMIZER_WORKERS:-4}

--- a/apps/agent-guard/python-service/embedder-container/Dockerfile
+++ b/apps/agent-guard/python-service/embedder-container/Dockerfile
@@ -18,6 +18,14 @@ COPY src/ .
 
 ENV PYTHONUNBUFFERED=1
 ENV PORT=8094
+# Pin torch/BLAS to one thread PER worker so N uvicorn workers don't each spawn
+# nproc compute threads and oversubscribe the CPU (workers × threads contention).
+ENV OMP_NUM_THREADS=1
+ENV MKL_NUM_THREADS=1
+ENV TORCH_NUM_THREADS=1
 EXPOSE 8094
 
-CMD ["uvicorn", "embedder_service:app", "--host", "0.0.0.0", "--port", "8094"]
+# Multiple workers so embedding (the cache-miss CPU cost) spreads across cores
+# instead of one. Each worker loads its own model (~torch+MiniLM), so default to
+# a moderate 4; override with EMBEDDER_WORKERS.
+CMD exec uvicorn embedder_service:app --host 0.0.0.0 --port 8094 --workers ${EMBEDDER_WORKERS:-4}

--- a/apps/agent-guard/python-service/worker-py/Dockerfile
+++ b/apps/agent-guard/python-service/worker-py/Dockerfile
@@ -16,4 +16,8 @@ ENV PORT=8090
 
 EXPOSE 8090
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8090"]
+# Run one uvicorn worker per CPU core. A single process pins the cache-serve path
+# to one core (the rest of the box sits idle) — the per-instance throughput
+# ceiling. The worker is stateless (state lives in Redis), so workers parallelize
+# cleanly. Override with UVICORN_WORKERS. `exec` makes uvicorn PID 1 for signals.
+CMD exec uvicorn app:app --host 0.0.0.0 --port 8090 --workers ${UVICORN_WORKERS:-$(nproc)}


### PR DESCRIPTION
The worker ran a single uvicorn process, pinning the cache-serve path to one core (~63 rps/instance, measured) while the other 7 cores on the n2-standard-8 box sat idle — the real per-instance throughput ceiling for high-RPM traffic. Run one worker per core (UVICORN_WORKERS, default $(nproc)); the worker is stateless (all state in Redis) so workers parallelize cleanly. ~8x per instance.

Also give the embedder and anonymizer multiple workers for the cache-miss CPU path, and pin torch/BLAS to one thread per embedder worker so N workers don't each spawn nproc compute threads and oversubscribe the CPU.