### PR TITLE
Support testRunResultSummaryId on testing log inserts.

### DIFF
--- a/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
@@ -2964,6 +2964,7 @@ public class DbAction extends ActionSupport {
                 return Action.SUCCESS.toUpperCase();
             }
             Log dbLog = new Log(log.getString("log"), log.getString("key"), log.getInt("timestamp"));
+            dbLog.setTestRunResultSummaryId(log.getString("testRunResultSummaryId"));
 
             // Skip writing cyborg call logs.
             if (dbLog.getLog().contains("ApiExecutor") &&

--- a/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/DbAction.java
@@ -2968,7 +2968,15 @@ public class DbAction extends ActionSupport {
                 return Action.SUCCESS.toUpperCase();
             }
             Log dbLog = new Log(log.getString("log"), log.getString("key"), log.getInt("timestamp"));
-            dbLog.setTestRunResultSummaryId(log.getString("testRunResultSummaryId"));
+            dbLog.setActivityId(log.getString("activityId"));
+            String activityTypeStr = log.getString("activityType");
+            if (activityTypeStr != null) {
+                try {
+                    dbLog.setActivityType(Log.ActivityType.valueOf(activityTypeStr));
+                } catch (IllegalArgumentException e) {
+                    loggerMaker.errorAndAddToDb("Unknown activityType in insertTestingLog: " + activityTypeStr);
+                }
+            }
 
             // Skip writing cyborg call logs.
             if (dbLog.getLog().contains("ApiExecutor") &&

--- a/libs/dao/src/main/java/com/akto/DaoInit.java
+++ b/libs/dao/src/main/java/com/akto/DaoInit.java
@@ -384,7 +384,8 @@ public class DaoInit {
                 new EnumCodec<>(GuardrailPolicies.ModelRole.class),
                 new EnumCodec<>(EndpointRemoteCommand.Status.class),
                 new EnumCodec<>(EndpointRemoteCommand.TargetType.class),
-                new EnumCodec<>(EndpointRemoteCommandExecution.Status.class)
+                new EnumCodec<>(EndpointRemoteCommandExecution.Status.class),
+                new EnumCodec<>(Log.ActivityType.class)
         );
 
         return fromRegistries(MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry,

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -35,8 +35,8 @@ public class LogsDao extends AccountsContextDao<Log> {
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
 
-        String[] summaryIdFields = {Log.TEST_RUN_RESULT_SUMMARY_ID};
-        MCollection.createIndexIfAbsent(getDBName(), getCollName(), summaryIdFields,false);
+        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID};
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(), activityFields,false);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -35,7 +35,7 @@ public class LogsDao extends AccountsContextDao<Log> {
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
 
-        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID};
+        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID, Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), activityFields,false);
     }
 

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -34,6 +34,9 @@ public class LogsDao extends AccountsContextDao<Log> {
 
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
+
+        String[] summaryIdFields = {Log.TEST_RUN_RESULT_SUMMARY_ID};
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(), summaryIdFields,false);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/context/Context.java
+++ b/libs/dao/src/main/java/com/akto/dao/context/Context.java
@@ -2,6 +2,7 @@ package com.akto.dao.context;
 
 import com.akto.dao.AccountsDao;
 import com.akto.dto.Account;
+import com.akto.dto.Log;
 
 import java.math.BigDecimal;
 import java.time.*;
@@ -10,13 +11,15 @@ import java.time.format.DateTimeFormatter;
 public class Context {
     public static ThreadLocal<Integer> accountId = new ThreadLocal<Integer>();
     public static ThreadLocal<Boolean> tokenExpired = new ThreadLocal<Boolean>();
-    public static ThreadLocal<String> testRunResultSummaryId = new ThreadLocal<String>();
+    public static ThreadLocal<String> activityId = new ThreadLocal<String>();
+    public static ThreadLocal<Log.ActivityType> activityType = new ThreadLocal<Log.ActivityType>();
 
 
     public static void resetContextThreadLocals() {
         accountId.remove();
         tokenExpired.remove();
-        testRunResultSummaryId.remove();
+        activityId.remove();
+        activityType.remove();
     }
 
     public static int getId() {

--- a/libs/dao/src/main/java/com/akto/dao/context/Context.java
+++ b/libs/dao/src/main/java/com/akto/dao/context/Context.java
@@ -10,11 +10,13 @@ import java.time.format.DateTimeFormatter;
 public class Context {
     public static ThreadLocal<Integer> accountId = new ThreadLocal<Integer>();
     public static ThreadLocal<Boolean> tokenExpired = new ThreadLocal<Boolean>();
+    public static ThreadLocal<String> testRunResultSummaryId = new ThreadLocal<String>();
 
 
     public static void resetContextThreadLocals() {
         accountId.remove();
         tokenExpired.remove();
+        testRunResultSummaryId.remove();
     }
 
     public static int getId() {

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -8,6 +8,10 @@ import org.bson.types.ObjectId;
 
 public class Log {
 
+    public enum ActivityType {
+        TESTING_RUN_RESULT_SUMMARY_ACTIVITY
+    }
+
     private ObjectId id;
     public ObjectId getId() {
         return id;
@@ -31,10 +35,16 @@ public class Log {
     public static final String TIMESTAMP = "timestamp";
     private int timestamp;
 
-    public static final String TEST_RUN_RESULT_SUMMARY_ID = "testRunResultSummaryId";
+    public static final String ACTIVITY_ID = "activityId";
+    public static final String ACTIVITY_TYPE = "activityType";
+
     @Getter
     @Setter
-    private String testRunResultSummaryId;
+    private String activityId; // activity id for the log eg test run result summary id
+
+    @Getter
+    @Setter
+    private ActivityType activityType; // activity type for the log eg TESTING_RUN_RESULT_SUMMARY_ACTIVITY
 
     public Log() {
     }
@@ -75,7 +85,8 @@ public class Log {
             " log='" + getLog() + "'" +
             ", key='" + getKey() + "'" +
             ", timestamp='" + getTimestamp() + "'" +
-            ", testRunResultSummaryId='" + getTestRunResultSummaryId() + "'" +
+            ", activityId='" + getActivityId() + "'" +
+            ", activityType='" + getActivityType() + "'" +
             "}";
     }
 
@@ -84,7 +95,8 @@ public class Log {
                 .append("log", getLog())
                 .append("key", getKey())
                 .append("timestamp", getTimestamp())
-                .append(TEST_RUN_RESULT_SUMMARY_ID, getTestRunResultSummaryId());
+                .append(ACTIVITY_ID, getActivityId())
+                .append(ACTIVITY_TYPE, getActivityType());
     }
 
 }

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -81,13 +81,18 @@ public class Log {
 
     @Override
     public String toString() {
-        return "{" +
-            " log='" + getLog() + "'" +
-            ", key='" + getKey() + "'" +
-            ", timestamp='" + getTimestamp() + "'" +
-            ", activityId='" + getActivityId() + "'" +
-            ", activityType='" + getActivityType() + "'" +
-            "}";
+        StringBuilder sb = new StringBuilder("{");
+        sb.append(" log='").append(getLog()).append("'");
+        sb.append(", key='").append(getKey()).append("'");
+        sb.append(", timestamp='").append(getTimestamp()).append("'");
+        if (getActivityId() != null) {
+            sb.append(", activityId='").append(getActivityId()).append("'");
+        }
+        if (getActivityType() != null) {
+            sb.append(", activityType='").append(getActivityType()).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
     }
 
     public BasicDBObject toBasicDBObject(){

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -1,6 +1,8 @@
 package com.akto.dto;
 
 import com.mongodb.BasicDBObject;
+import lombok.Getter;
+import lombok.Setter;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.types.ObjectId;
 
@@ -28,6 +30,11 @@ public class Log {
 
     public static final String TIMESTAMP = "timestamp";
     private int timestamp;
+
+    public static final String TEST_RUN_RESULT_SUMMARY_ID = "testRunResultSummaryId";
+    @Getter
+    @Setter
+    private String testRunResultSummaryId;
 
     public Log() {
     }
@@ -68,6 +75,7 @@ public class Log {
             " log='" + getLog() + "'" +
             ", key='" + getKey() + "'" +
             ", timestamp='" + getTimestamp() + "'" +
+            ", testRunResultSummaryId='" + getTestRunResultSummaryId() + "'" +
             "}";
     }
 
@@ -75,7 +83,8 @@ public class Log {
         return new BasicDBObject("_id", getId())
                 .append("log", getLog())
                 .append("key", getKey())
-                .append("timestamp", getTimestamp());
+                .append("timestamp", getTimestamp())
+                .append(TEST_RUN_RESULT_SUMMARY_ID, getTestRunResultSummaryId());
     }
 
 }

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -296,11 +296,23 @@ public class LoggerMaker  {
         return true;
     }
     
+    /**
+     * Stamps the current thread's activity context onto the log only when both the type and a
+     * non-empty id are present. Leaves the fields unset otherwise so null is never persisted/printed.
+     */
+    private static void applyActivityContext(Log log) {
+        Log.ActivityType type = Context.activityType.get();
+        String id = Context.activityId.get();
+        if (type != null && id != null && !id.isEmpty()) {
+            log.setActivityId(id);
+            log.setActivityType(type);
+        }
+    }
+
     private void insert(String info, String key, LogDb db) {
         String text = aClass + " : " + info;
         Log log = new Log(text, key, Context.now());
-        log.setActivityId(Context.activityId.get());
-        log.setActivityType(Context.activityType.get());
+        applyActivityContext(log);
 
         if(checkUpdate() && db!=null){
             switch(db){

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -299,7 +299,8 @@ public class LoggerMaker  {
     private void insert(String info, String key, LogDb db) {
         String text = aClass + " : " + info;
         Log log = new Log(text, key, Context.now());
-        log.setTestRunResultSummaryId(Context.testRunResultSummaryId.get());
+        log.setActivityId(Context.activityId.get());
+        log.setActivityType(Context.activityType.get());
 
         if(checkUpdate() && db!=null){
             switch(db){

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -299,7 +299,8 @@ public class LoggerMaker  {
     private void insert(String info, String key, LogDb db) {
         String text = aClass + " : " + info;
         Log log = new Log(text, key, Context.now());
-        
+        log.setTestRunResultSummaryId(Context.testRunResultSummaryId.get());
+
         if(checkUpdate() && db!=null){
             switch(db){
                 case TESTING:


### PR DESCRIPTION
Extend the Log model and database-abstractor insertTestingLog path so hybrid testing modules can persist logs scoped to a specific test run result summary.