### PR TITLE
Stamp testing logs with testRunResultSummaryId during test execution.

### DIFF
--- a/apps/mini-testing/src/main/java/com/akto/test_editor/execution/Executor.java
+++ b/apps/mini-testing/src/main/java/com/akto/test_editor/execution/Executor.java
@@ -89,7 +89,6 @@ public class Executor {
         WorkflowTest workflowTest = null;
         if (node.getChildNodes().size() < 2) {
             testLogs.add(new TestingRunResult.TestLog(TestingRunResult.TestLogType.ERROR, "executor child nodes is less than 2, returning empty execution result"));
-            loggerMaker.errorAndAddToDb("executor child nodes is less than 2, returning empty execution result " + logId, LogDb.TESTING);
             result.add(invalidExecutionResult);
             yamlTestResult = new YamlTestResult(result, workflowTest);
             return yamlTestResult;

--- a/apps/mini-testing/src/main/java/com/akto/testing/TestExecutor.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/TestExecutor.java
@@ -899,6 +899,25 @@ public class TestExecutor {
         return respMap;
     }
 
+    /**
+     * Establishes a clean activity context for a test run. Tests start from several flows that run on
+     * pooled/reused threads, so we always set explicitly when a summaryId is present and otherwise clear
+     * any stale value left behind by a previous task on the same thread.
+     */
+    public static void setTestRunActivityContext(ObjectId summaryId) {
+        if (summaryId != null) {
+            Context.activityId.set(summaryId.toHexString());
+            Context.activityType.set(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY);
+        } else {
+            clearActivityContext();
+        }
+    }
+
+    public static void clearActivityContext() {
+        Context.activityId.remove();
+        Context.activityType.remove();
+    }
+
     public Void startWithLatch(
         List<String> testingRunSubCategories,int accountId,ApiInfo.ApiInfoKey apiInfoKey,
         List<String> messages, ObjectId summaryId, SyncLimit syncLimit, Map<ApiInfoKey, String> apiInfoKeyToHostMap,
@@ -906,12 +925,7 @@ public class TestExecutor {
         List<TestingRunResult.TestLog> testLogs, TestingRun testingRun, CountDownLatch latch, Map<ApiInfoKey, List<String>> apiInfoKeySubcategoryMap) {
 
         Context.accountId.set(accountId);
-        String previousActivityId = Context.activityId.get();
-        Log.ActivityType previousActivityType = Context.activityType.get();
-        if (summaryId != null) {
-            Context.activityId.set(summaryId.toHexString());
-            Context.activityType.set(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY);
-        }
+        setTestRunActivityContext(summaryId);
         loggerMaker.warnAndAddToDb("Starting test for " + apiInfoKey);
         AtomicBoolean isApiInfoTested = new AtomicBoolean(false);
         try {
@@ -928,8 +942,7 @@ public class TestExecutor {
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "error while running tests: " + e);
         } finally {
-            Context.activityId.set(previousActivityId);
-            Context.activityType.set(previousActivityType);
+            clearActivityContext();
         }
         if(isApiInfoTested.get()){
             loggerMaker.warnAndAddToDb("API: " + apiInfoKey.toString() + " has been successfully tested");
@@ -1120,18 +1133,14 @@ public class TestExecutor {
             TestingRunResult testingRunResult = null;
             Future<TestingRunResult> future = legacyTestTimeoutExecutor.submit(() -> {
                 Context.accountId.set(currentAccountId);
-                if (summaryId != null) {
-                    Context.activityId.set(summaryId.toHexString());
-                    Context.activityType.set(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY);
-                }
+                setTestRunActivityContext(summaryId);
                 try {
                     TestingRunResult legacyResult = runTestNew(apiInfoKey, summaryId, instance.getTestingUtil(), summaryId, testConfig,
                         instance.getTestingRunConfig(), instance.isDebug(), testLogs, sampleMessage);
                     persistTestLogsToDb(legacyResult != null ? legacyResult.getTestLogs() : null);
                     return legacyResult;
                 } finally {
-                    Context.activityId.remove();
-                    Context.activityType.remove();
+                    clearActivityContext();
                 }
             });
             try {

--- a/apps/mini-testing/src/main/java/com/akto/testing/TestExecutor.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/TestExecutor.java
@@ -10,6 +10,7 @@ import com.akto.dto.ApiCollection;
 import com.akto.dto.ApiInfo;
 import com.akto.dto.ApiInfo.ApiInfoKey;
 import com.akto.dto.CustomAuthType;
+import com.akto.dto.Log;
 import com.akto.dto.DependencyNode;
 import com.akto.dto.DependencyNode.ParamInfo;
 import com.akto.dto.OriginalHttpRequest;
@@ -905,9 +906,11 @@ public class TestExecutor {
         List<TestingRunResult.TestLog> testLogs, TestingRun testingRun, CountDownLatch latch, Map<ApiInfoKey, List<String>> apiInfoKeySubcategoryMap) {
 
         Context.accountId.set(accountId);
-        String previousSummaryIdContext = Context.testRunResultSummaryId.get();
+        String previousActivityId = Context.activityId.get();
+        Log.ActivityType previousActivityType = Context.activityType.get();
         if (summaryId != null) {
-            Context.testRunResultSummaryId.set(summaryId.toHexString());
+            Context.activityId.set(summaryId.toHexString());
+            Context.activityType.set(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY);
         }
         loggerMaker.warnAndAddToDb("Starting test for " + apiInfoKey);
         AtomicBoolean isApiInfoTested = new AtomicBoolean(false);
@@ -925,7 +928,8 @@ public class TestExecutor {
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "error while running tests: " + e);
         } finally {
-            Context.testRunResultSummaryId.set(previousSummaryIdContext);
+            Context.activityId.set(previousActivityId);
+            Context.activityType.set(previousActivityType);
         }
         if(isApiInfoTested.get()){
             loggerMaker.warnAndAddToDb("API: " + apiInfoKey.toString() + " has been successfully tested");
@@ -1117,7 +1121,8 @@ public class TestExecutor {
             Future<TestingRunResult> future = legacyTestTimeoutExecutor.submit(() -> {
                 Context.accountId.set(currentAccountId);
                 if (summaryId != null) {
-                    Context.testRunResultSummaryId.set(summaryId.toHexString());
+                    Context.activityId.set(summaryId.toHexString());
+                    Context.activityType.set(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY);
                 }
                 try {
                     TestingRunResult legacyResult = runTestNew(apiInfoKey, summaryId, instance.getTestingUtil(), summaryId, testConfig,
@@ -1125,7 +1130,8 @@ public class TestExecutor {
                     persistTestLogsToDb(legacyResult != null ? legacyResult.getTestLogs() : null);
                     return legacyResult;
                 } finally {
-                    Context.testRunResultSummaryId.remove();
+                    Context.activityId.remove();
+                    Context.activityType.remove();
                 }
             });
             try {
@@ -1151,7 +1157,7 @@ public class TestExecutor {
     /**
      * Persists the per-test transient testLogs (which are @BsonIgnore on TestingRunResult and would
      * otherwise be dropped) into the TESTING logs collection. The current thread's
-     * Context.testRunResultSummaryId is expected to be set so each line is scoped to the run summary.
+     * Context.activityId/activityType (TESTING_RUN_RESULT_SUMMARY_ACTIVITY) is expected to be set so each line is scoped to the run summary.
      */
     public void persistTestLogsToDb(List<TestingRunResult.TestLog> testLogs) {
         if (testLogs == null || testLogs.isEmpty()) {

--- a/apps/mini-testing/src/main/java/com/akto/testing/TestExecutor.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/TestExecutor.java
@@ -905,6 +905,10 @@ public class TestExecutor {
         List<TestingRunResult.TestLog> testLogs, TestingRun testingRun, CountDownLatch latch, Map<ApiInfoKey, List<String>> apiInfoKeySubcategoryMap) {
 
         Context.accountId.set(accountId);
+        String previousSummaryIdContext = Context.testRunResultSummaryId.get();
+        if (summaryId != null) {
+            Context.testRunResultSummaryId.set(summaryId.toHexString());
+        }
         loggerMaker.warnAndAddToDb("Starting test for " + apiInfoKey);
         AtomicBoolean isApiInfoTested = new AtomicBoolean(false);
         try {
@@ -920,6 +924,8 @@ public class TestExecutor {
             }
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "error while running tests: " + e);
+        } finally {
+            Context.testRunResultSummaryId.set(previousSummaryIdContext);
         }
         if(isApiInfoTested.get()){
             loggerMaker.warnAndAddToDb("API: " + apiInfoKey.toString() + " has been successfully tested");
@@ -1110,8 +1116,17 @@ public class TestExecutor {
             TestingRunResult testingRunResult = null;
             Future<TestingRunResult> future = legacyTestTimeoutExecutor.submit(() -> {
                 Context.accountId.set(currentAccountId);
-                return runTestNew(apiInfoKey, summaryId, instance.getTestingUtil(), summaryId, testConfig,
-                    instance.getTestingRunConfig(), instance.isDebug(), testLogs, sampleMessage);
+                if (summaryId != null) {
+                    Context.testRunResultSummaryId.set(summaryId.toHexString());
+                }
+                try {
+                    TestingRunResult legacyResult = runTestNew(apiInfoKey, summaryId, instance.getTestingUtil(), summaryId, testConfig,
+                        instance.getTestingRunConfig(), instance.isDebug(), testLogs, sampleMessage);
+                    persistTestLogsToDb(legacyResult != null ? legacyResult.getTestLogs() : null);
+                    return legacyResult;
+                } finally {
+                    Context.testRunResultSummaryId.remove();
+                }
             });
             try {
                 testingRunResult = future.get(MAX_LEGACY_PER_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -1131,6 +1146,27 @@ public class TestExecutor {
             return testingRunResult;
         }
         return null;
+    }
+
+    /**
+     * Persists the per-test transient testLogs (which are @BsonIgnore on TestingRunResult and would
+     * otherwise be dropped) into the TESTING logs collection. The current thread's
+     * Context.testRunResultSummaryId is expected to be set so each line is scoped to the run summary.
+     */
+    public void persistTestLogsToDb(List<TestingRunResult.TestLog> testLogs) {
+        if (testLogs == null || testLogs.isEmpty()) {
+            return;
+        }
+        for (TestingRunResult.TestLog testLog : testLogs) {
+            if (testLog == null || testLog.getMessage() == null) {
+                continue;
+            }
+            if (testLog.getTestLogType() == TestingRunResult.TestLogType.ERROR) {
+                loggerMaker.errorAndAddToDb(testLog.getMessage(), LogDb.TESTING);
+            } else {
+                loggerMaker.infoAndAddToDb(testLog.getMessage(), LogDb.TESTING);
+            }
+        }
     }
 
     // Track auth status per test run: if auth fails, kill all remaining tests

--- a/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
@@ -70,25 +70,34 @@ public class ConsumerUtil {
     public void runTestFromMessage(String message){
         SingleTestPayload singleTestPayload = parseTestMessage(message);
         Context.accountId.set(singleTestPayload.getAccountId());
-        TestExecutor executor = new TestExecutor();
+        ObjectId summaryId = singleTestPayload.getTestingRunResultSummaryId();
+        if (summaryId != null) {
+            Context.testRunResultSummaryId.set(summaryId.toHexString());
+        }
+        try {
+            TestExecutor executor = new TestExecutor();
 
-        TestingConfigurations instance = TestingConfigurations.getInstance();
-        String subCategory = singleTestPayload.getSubcategory();
-        TestConfig testConfig = instance.getTestConfigMap().get(subCategory);
-        ApiInfoKey apiInfoKey = singleTestPayload.getApiInfoKey();
+            TestingConfigurations instance = TestingConfigurations.getInstance();
+            String subCategory = singleTestPayload.getSubcategory();
+            TestConfig testConfig = instance.getTestConfigMap().get(subCategory);
+            ApiInfoKey apiInfoKey = singleTestPayload.getApiInfoKey();
 
-        List<String> messagesList = instance.getTestingUtil().getSampleMessages().get(apiInfoKey);
-        int timeNow = Context.now();
-        if(messagesList == null || messagesList.isEmpty()){}
-        else{
-            String sample = messagesList.get(messagesList.size() - 1);
-            loggerMaker.infoAndAddToDb("Running test for: " + apiInfoKey + " with subcategory: " + subCategory);
-            TestingRunResult runResult = executor.runTestNew(apiInfoKey, singleTestPayload.getTestingRunId(), instance.getTestingUtil(), singleTestPayload.getTestingRunResultSummaryId(),testConfig , instance.getTestingRunConfig(), instance.isDebug(), singleTestPayload.getTestLogs(), sample);
-            executor.insertResultsAndMakeIssues(Collections.singletonList(runResult), singleTestPayload.getTestingRunResultSummaryId());
+            List<String> messagesList = instance.getTestingUtil().getSampleMessages().get(apiInfoKey);
+            int timeNow = Context.now();
+            if(messagesList == null || messagesList.isEmpty()){}
+            else{
+                String sample = messagesList.get(messagesList.size() - 1);
+                loggerMaker.infoAndAddToDb("Running test for: " + apiInfoKey + " with subcategory: " + subCategory);
+                TestingRunResult runResult = executor.runTestNew(apiInfoKey, singleTestPayload.getTestingRunId(), instance.getTestingUtil(), singleTestPayload.getTestingRunResultSummaryId(),testConfig , instance.getTestingRunConfig(), instance.isDebug(), singleTestPayload.getTestLogs(), sample);
+                executor.persistTestLogsToDb(runResult != null ? runResult.getTestLogs() : null);
+                executor.insertResultsAndMakeIssues(Collections.singletonList(runResult), singleTestPayload.getTestingRunResultSummaryId());
 
-            testedApisMap.put(apiInfoKey, Context.now());
+                testedApisMap.put(apiInfoKey, Context.now());
 
-            loggerMaker.insertImportantTestingLog("Test completed for: " + apiInfoKey + " with subcategory: " + subCategory + " in " + (Context.now() - timeNow) + " seconds");
+                loggerMaker.insertImportantTestingLog("Test completed for: " + apiInfoKey + " with subcategory: " + subCategory + " in " + (Context.now() - timeNow) + " seconds");
+            }
+        } finally {
+            Context.testRunResultSummaryId.remove();
         }
     }
 

--- a/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
@@ -25,7 +25,6 @@ import com.akto.crons.GetRunningTestsStatus;
 import com.akto.dao.context.Context;
 import com.akto.dto.ApiInfo;
 import com.akto.dto.ApiInfo.ApiInfoKey;
-import com.akto.dto.Log;
 import com.akto.dto.test_editor.TestConfig;
 import com.akto.dto.testing.TestingRun;
 import com.akto.dto.testing.TestingRunResult;
@@ -72,10 +71,7 @@ public class ConsumerUtil {
         SingleTestPayload singleTestPayload = parseTestMessage(message);
         Context.accountId.set(singleTestPayload.getAccountId());
         ObjectId summaryId = singleTestPayload.getTestingRunResultSummaryId();
-        if (summaryId != null) {
-            Context.activityId.set(summaryId.toHexString());
-            Context.activityType.set(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY);
-        }
+        TestExecutor.setTestRunActivityContext(summaryId);
         try {
             TestExecutor executor = new TestExecutor();
 
@@ -99,25 +95,28 @@ public class ConsumerUtil {
                 loggerMaker.insertImportantTestingLog("Test completed for: " + apiInfoKey + " with subcategory: " + subCategory + " in " + (Context.now() - timeNow) + " seconds");
             }
         } finally {
-            Context.activityId.remove();
-            Context.activityType.remove();
+            TestExecutor.clearActivityContext();
         }
     }
 
     private void createTimedOutResultFromMessage(String message){
         SingleTestPayload singleTestPayload = parseTestMessage(message);
         Context.accountId.set(singleTestPayload.getAccountId());
+        TestExecutor.setTestRunActivityContext(singleTestPayload.getTestingRunResultSummaryId());
+        try {
+            TestExecutor testExecutor = new TestExecutor();
 
-        TestExecutor testExecutor = new TestExecutor();
+            String subCategory = singleTestPayload.getSubcategory();
+            TestConfig testConfig = TestingConfigurations.getInstance().getTestConfigMap().get(subCategory);
 
-        String subCategory = singleTestPayload.getSubcategory();
-        TestConfig testConfig = TestingConfigurations.getInstance().getTestConfigMap().get(subCategory);
+            String testSuperType = testConfig.getInfo().getCategory().getName();
+            String testSubType = testConfig.getInfo().getSubCategory();
 
-        String testSuperType = testConfig.getInfo().getCategory().getName();
-        String testSubType = testConfig.getInfo().getSubCategory();
-
-        TestingRunResult runResult = Utils.generateFailedRunResultForMessage(singleTestPayload.getTestingRunId(), singleTestPayload.getApiInfoKey(), testSuperType, testSubType, singleTestPayload.getTestingRunResultSummaryId(), new ArrayList<>(),  TestError.TEST_TIMED_OUT.getMessage());
-        testExecutor.insertResultsAndMakeIssues(Collections.singletonList(runResult), singleTestPayload.getTestingRunResultSummaryId());
+            TestingRunResult runResult = Utils.generateFailedRunResultForMessage(singleTestPayload.getTestingRunId(), singleTestPayload.getApiInfoKey(), testSuperType, testSubType, singleTestPayload.getTestingRunResultSummaryId(), new ArrayList<>(),  TestError.TEST_TIMED_OUT.getMessage());
+            testExecutor.insertResultsAndMakeIssues(Collections.singletonList(runResult), singleTestPayload.getTestingRunResultSummaryId());
+        } finally {
+            TestExecutor.clearActivityContext();
+        }
     }
 
     /**

--- a/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
@@ -25,6 +25,7 @@ import com.akto.crons.GetRunningTestsStatus;
 import com.akto.dao.context.Context;
 import com.akto.dto.ApiInfo;
 import com.akto.dto.ApiInfo.ApiInfoKey;
+import com.akto.dto.Log;
 import com.akto.dto.test_editor.TestConfig;
 import com.akto.dto.testing.TestingRun;
 import com.akto.dto.testing.TestingRunResult;
@@ -72,7 +73,8 @@ public class ConsumerUtil {
         Context.accountId.set(singleTestPayload.getAccountId());
         ObjectId summaryId = singleTestPayload.getTestingRunResultSummaryId();
         if (summaryId != null) {
-            Context.testRunResultSummaryId.set(summaryId.toHexString());
+            Context.activityId.set(summaryId.toHexString());
+            Context.activityType.set(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY);
         }
         try {
             TestExecutor executor = new TestExecutor();
@@ -97,7 +99,8 @@ public class ConsumerUtil {
                 loggerMaker.insertImportantTestingLog("Test completed for: " + apiInfoKey + " with subcategory: " + subCategory + " in " + (Context.now() - timeNow) + " seconds");
             }
         } finally {
-            Context.testRunResultSummaryId.remove();
+            Context.activityId.remove();
+            Context.activityType.remove();
         }
     }
 

--- a/libs/dao/src/main/java/com/akto/DaoInit.java
+++ b/libs/dao/src/main/java/com/akto/DaoInit.java
@@ -332,7 +332,8 @@ public class DaoInit {
                 new EnumCodec<>(FileUploadLog.UploadLogStatus.class),
                 new EnumCodec<>(TestCollectionProperty.Id.class),
                 new EnumCodec<>(CustomAuthType.TypeOfToken.class),
-                new EnumCodec<>(TLSAuthParam.CertificateType.class)
+                new EnumCodec<>(TLSAuthParam.CertificateType.class),
+                new EnumCodec<>(Log.ActivityType.class)
         );
 
         return fromRegistries(MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry,

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -42,8 +42,8 @@ public class LogsDao extends AccountsContextDao<Log> {
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
 
-        String[] summaryIdFields = {Log.TEST_RUN_RESULT_SUMMARY_ID};
-        MCollection.createIndexIfAbsent(getDBName(), getCollName(), summaryIdFields,false);
+        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID};
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(), activityFields,false);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -41,6 +41,9 @@ public class LogsDao extends AccountsContextDao<Log> {
 
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
+
+        String[] summaryIdFields = {Log.TEST_RUN_RESULT_SUMMARY_ID};
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(), summaryIdFields,false);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -42,7 +42,7 @@ public class LogsDao extends AccountsContextDao<Log> {
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
 
-        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID};
+        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID, Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), activityFields,false);
     }
 

--- a/libs/dao/src/main/java/com/akto/dao/context/Context.java
+++ b/libs/dao/src/main/java/com/akto/dao/context/Context.java
@@ -2,6 +2,7 @@ package com.akto.dao.context;
 
 import com.akto.dao.AccountsDao;
 import com.akto.dto.Account;
+import com.akto.dto.Log;
 import java.math.BigDecimal;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -11,13 +12,15 @@ import org.slf4j.LoggerFactory;
 
 public class Context {
     public static ThreadLocal<Integer> accountId = new ThreadLocal<Integer>();
-    public static ThreadLocal<String> testRunResultSummaryId = new ThreadLocal<String>();
+    public static ThreadLocal<String> activityId = new ThreadLocal<String>();
+    public static ThreadLocal<Log.ActivityType> activityType = new ThreadLocal<Log.ActivityType>();
 
     private static final Logger logger = LoggerFactory.getLogger(Context.class);
 
     public static void resetContextThreadLocals() {
         accountId.remove();
-        testRunResultSummaryId.remove();
+        activityId.remove();
+        activityType.remove();
     }
 
     public static int getId() {

--- a/libs/dao/src/main/java/com/akto/dao/context/Context.java
+++ b/libs/dao/src/main/java/com/akto/dao/context/Context.java
@@ -11,11 +11,13 @@ import org.slf4j.LoggerFactory;
 
 public class Context {
     public static ThreadLocal<Integer> accountId = new ThreadLocal<Integer>();
+    public static ThreadLocal<String> testRunResultSummaryId = new ThreadLocal<String>();
 
     private static final Logger logger = LoggerFactory.getLogger(Context.class);
 
     public static void resetContextThreadLocals() {
         accountId.remove();
+        testRunResultSummaryId.remove();
     }
 
     public static int getId() {

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -8,6 +8,10 @@ import org.bson.types.ObjectId;
 
 public class Log {
 
+    public enum ActivityType {
+        TESTING_RUN_RESULT_SUMMARY_ACTIVITY
+    }
+
     private ObjectId id;
     public ObjectId getId() {
         return id;
@@ -31,10 +35,16 @@ public class Log {
     public static final String TIMESTAMP = "timestamp";
     private int timestamp;
 
-    public static final String TEST_RUN_RESULT_SUMMARY_ID = "testRunResultSummaryId";
+    public static final String ACTIVITY_ID = "activityId";
+    public static final String ACTIVITY_TYPE = "activityType";
+
     @Getter
     @Setter
-    private String testRunResultSummaryId;
+    private String activityId; // activity id for the log eg test run result summary id
+
+    @Getter
+    @Setter
+    private ActivityType activityType; // activity type for the log eg TESTING_RUN_RESULT_SUMMARY_ACTIVITY
 
     public Log() {
     }
@@ -75,7 +85,8 @@ public class Log {
             " log='" + getLog() + "'" +
             ", key='" + getKey() + "'" +
             ", timestamp='" + getTimestamp() + "'" +
-            ", testRunResultSummaryId='" + getTestRunResultSummaryId() + "'" +
+            ", activityId='" + getActivityId() + "'" +
+            ", activityType='" + getActivityType() + "'" +
             "}";
     }
 
@@ -84,7 +95,8 @@ public class Log {
                 .append("log", getLog())
                 .append("key", getKey())
                 .append("timestamp", getTimestamp())
-                .append(TEST_RUN_RESULT_SUMMARY_ID, getTestRunResultSummaryId());
+                .append(ACTIVITY_ID, getActivityId())
+                .append(ACTIVITY_TYPE, getActivityType());
     }
 
 }

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -81,13 +81,18 @@ public class Log {
 
     @Override
     public String toString() {
-        return "{" +
-            " log='" + getLog() + "'" +
-            ", key='" + getKey() + "'" +
-            ", timestamp='" + getTimestamp() + "'" +
-            ", activityId='" + getActivityId() + "'" +
-            ", activityType='" + getActivityType() + "'" +
-            "}";
+        StringBuilder sb = new StringBuilder("{");
+        sb.append(" log='").append(getLog()).append("'");
+        sb.append(", key='").append(getKey()).append("'");
+        sb.append(", timestamp='").append(getTimestamp()).append("'");
+        if (getActivityId() != null) {
+            sb.append(", activityId='").append(getActivityId()).append("'");
+        }
+        if (getActivityType() != null) {
+            sb.append(", activityType='").append(getActivityType()).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
     }
 
     public BasicDBObject toBasicDBObject(){

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -1,6 +1,8 @@
 package com.akto.dto;
 
 import com.mongodb.BasicDBObject;
+import lombok.Getter;
+import lombok.Setter;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.types.ObjectId;
 
@@ -28,6 +30,11 @@ public class Log {
 
     public static final String TIMESTAMP = "timestamp";
     private int timestamp;
+
+    public static final String TEST_RUN_RESULT_SUMMARY_ID = "testRunResultSummaryId";
+    @Getter
+    @Setter
+    private String testRunResultSummaryId;
 
     public Log() {
     }
@@ -68,6 +75,7 @@ public class Log {
             " log='" + getLog() + "'" +
             ", key='" + getKey() + "'" +
             ", timestamp='" + getTimestamp() + "'" +
+            ", testRunResultSummaryId='" + getTestRunResultSummaryId() + "'" +
             "}";
     }
 
@@ -75,7 +83,8 @@ public class Log {
         return new BasicDBObject("_id", getId())
                 .append("log", getLog())
                 .append("key", getKey())
-                .append("timestamp", getTimestamp());
+                .append("timestamp", getTimestamp())
+                .append(TEST_RUN_RESULT_SUMMARY_ID, getTestRunResultSummaryId());
     }
 
 }

--- a/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
@@ -3601,8 +3601,11 @@ public class ClientActor extends DataActor {
         logObj.put("key", log.getKey());
         logObj.put("log", log.getLog());
         logObj.put("timestamp", log.getTimestamp());
-        if (log.getTestRunResultSummaryId() != null) {
-            logObj.put("testRunResultSummaryId", log.getTestRunResultSummaryId());
+        if (log.getActivityId() != null) {
+            logObj.put("activityId", log.getActivityId());
+        }
+        if (log.getActivityType() != null) {
+            logObj.put("activityType", log.getActivityType().name());
         }
         obj.put("log", logObj);
         OriginalHttpRequest request = new OriginalHttpRequest(url + "/insertTestingLog", "", "POST", obj.toString(), headers, "");

--- a/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
@@ -3598,6 +3598,9 @@ public class ClientActor extends DataActor {
         logObj.put("key", log.getKey());
         logObj.put("log", log.getLog());
         logObj.put("timestamp", log.getTimestamp());
+        if (log.getTestRunResultSummaryId() != null) {
+            logObj.put("testRunResultSummaryId", log.getTestRunResultSummaryId());
+        }
         obj.put("log", logObj);
         OriginalHttpRequest request = new OriginalHttpRequest(url + "/insertTestingLog", "", "POST", obj.toString(), headers, "");
         try {

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -214,12 +214,18 @@ public class LoggerMaker {
         }
     }
 
+    private String activityPrefix() {
+        Log.ActivityType type = Context.activityType.get();
+        String id = Context.activityId.get();
+        if (type == Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY && id != null && !id.isEmpty()) {
+            return "trrs: " + id + ", ";
+        }
+        return "";
+    }
+
     private String formatMessageWithAccountId(String info) {
         StringBuilder sb = new StringBuilder();
-        String summaryId = Context.testRunResultSummaryId.get();
-        if (summaryId != null && !summaryId.isEmpty()) {
-            sb.append("trrs: ").append(summaryId).append(", ");
-        }
+        sb.append(activityPrefix());
         sb.append("acc: ").append(Context.getActualAccountId()).append(", ").append(info);
         return sb.toString();
     }
@@ -252,6 +258,8 @@ public class LoggerMaker {
         if(checkUpdate()){
             String text = aClass + " : " + " [" + moduleId + " ] " + infoMessage;
             Log log = new Log(text, "info", Context.now());
+            log.setActivityId(Context.activityId.get());
+            log.setActivityType(Context.activityType.get());
             dataActor.insertTestingLog(log);
             logCount++;
         }
@@ -306,7 +314,8 @@ public class LoggerMaker {
         }
 
         Log log = new Log(text, key, Context.now());
-        log.setTestRunResultSummaryId(Context.testRunResultSummaryId.get());
+        log.setActivityId(Context.activityId.get());
+        log.setActivityType(Context.activityType.get());
 
         if(checkUpdate() && db!=null){
             switch(db){

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -223,6 +223,19 @@ public class LoggerMaker {
         return "";
     }
 
+    /**
+     * Stamps the current thread's activity context onto the log only when both the type and a
+     * non-empty id are present. Leaves the fields unset otherwise so null is never persisted/printed.
+     */
+    private static void applyActivityContext(Log log) {
+        Log.ActivityType type = Context.activityType.get();
+        String id = Context.activityId.get();
+        if (type != null && id != null && !id.isEmpty()) {
+            log.setActivityId(id);
+            log.setActivityType(type);
+        }
+    }
+
     private String formatMessageWithAccountId(String info) {
         StringBuilder sb = new StringBuilder();
         sb.append(activityPrefix());
@@ -258,8 +271,7 @@ public class LoggerMaker {
         if(checkUpdate()){
             String text = aClass + " : " + " [" + moduleId + " ] " + infoMessage;
             Log log = new Log(text, "info", Context.now());
-            log.setActivityId(Context.activityId.get());
-            log.setActivityType(Context.activityType.get());
+            applyActivityContext(log);
             dataActor.insertTestingLog(log);
             logCount++;
         }
@@ -314,8 +326,7 @@ public class LoggerMaker {
         }
 
         Log log = new Log(text, key, Context.now());
-        log.setActivityId(Context.activityId.get());
-        log.setActivityType(Context.activityType.get());
+        applyActivityContext(log);
 
         if(checkUpdate() && db!=null){
             switch(db){

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -300,7 +300,8 @@ public class LoggerMaker {
         }
 
         Log log = new Log(text, key, Context.now());
-        
+        log.setTestRunResultSummaryId(Context.testRunResultSummaryId.get());
+
         if(checkUpdate() && db!=null){
             switch(db){
                 case TESTING:

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -161,7 +161,7 @@ public class LoggerMaker {
     }
 
     protected String basicError(String err, LogDb db) {
-        err = String.format("%s\nAccount id: %d", err, Context.getActualAccountId());
+        err = formatMessageWithAccountId(err);
         logger.error(err);
         try{
             insert(err, "error", db);
@@ -215,7 +215,13 @@ public class LoggerMaker {
     }
 
     private String formatMessageWithAccountId(String info) {
-        return "acc: " + Context.getActualAccountId() + ", " + info;
+        StringBuilder sb = new StringBuilder();
+        String summaryId = Context.testRunResultSummaryId.get();
+        if (summaryId != null && !summaryId.isEmpty()) {
+            sb.append("trrs: ").append(summaryId).append(", ");
+        }
+        sb.append("acc: ").append(Context.getActualAccountId()).append(", ").append(info);
+        return sb.toString();
     }
 
     @Deprecated
@@ -244,7 +250,7 @@ public class LoggerMaker {
         String infoMessage = formatMessageWithAccountId(info);
         logger.info(infoMessage);
         if(checkUpdate()){
-            String text = aClass + " : " + " [" + moduleId + " ] " + info;
+            String text = aClass + " : " + " [" + moduleId + " ] " + infoMessage;
             Log log = new Log(text, "info", Context.now());
             dataActor.insertTestingLog(log);
             logCount++;


### PR DESCRIPTION
Use a ThreadLocal context to tag LoggerMaker output per run, persist transient testLogs to the logs collection, and carry summary id over the hybrid insertTestingLog API.