### PR TITLE
Add per-run testing logs on the test result page.

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/DbLogsAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/DbLogsAction.java
@@ -65,7 +65,7 @@ public class DbLogsAction extends UserAction {
             addActionError("Invalid testing run result summary id");
             return ERROR.toUpperCase();
         }
-        logs = loggerMaker.fetchTestingLogRecordsBySummaryId(testingRunResultSummaryId, logKeys);
+        logs = loggerMaker.fetchTestingLogRecordsByActivity(Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY, testingRunResultSummaryId, logKeys);
 
         return SUCCESS.toUpperCase();
     }

--- a/apps/dashboard/src/main/java/com/akto/action/DbLogsAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/DbLogsAction.java
@@ -45,12 +45,27 @@ public class DbLogsAction extends UserAction {
     @Setter
     private List<String> logKeys;
 
+    /** Testing run result summary id whose scoped TESTING logs should be fetched. */
+    @Getter
+    @Setter
+    private String testingRunResultSummaryId;
+
     public String fetchLogsFromDb() {
         if(logDb==null){
             addActionError("Invalid log collection");
             return ERROR.toUpperCase();
         }
         logs = loggerMaker.fetchLogRecords(startTime, endTime, logDb, logKeys);
+
+        return SUCCESS.toUpperCase();
+    }
+
+    public String fetchTestRunLogs() {
+        if (testingRunResultSummaryId == null || testingRunResultSummaryId.isEmpty()) {
+            addActionError("Invalid testing run result summary id");
+            return ERROR.toUpperCase();
+        }
+        logs = loggerMaker.fetchTestingLogRecordsBySummaryId(testingRunResultSummaryId, logKeys);
 
         return SUCCESS.toUpperCase();
     }

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -6837,6 +6837,27 @@
             </result>
         </action>
 
+        <action name="api/fetchTestRunLogs" class="com.akto.action.DbLogsAction" method="fetchTestRunLogs">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <interceptor-ref name="roleAccessInterceptor">
+                <param name="featureLabel">TEST_RESULTS</param>
+                <param name="accessType">READ</param>
+            </interceptor-ref>
+
+            <result name="FORBIDDEN" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="SUCCESS" type="json"/>
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/fetchAllIssues" class="com.akto.action.testing_issues.IssuesAction" method="fetchAllIssues">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/health_logs/LogsContainer.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/health_logs/LogsContainer.jsx
@@ -15,7 +15,16 @@ const logLineStyle = {
     maxWidth: "100%",
 }
 
-const LogsContainer = ({ logs, displayedLogData }) => {
+const formatLogLine = (entry) => {
+    const message = entry.log ?? ""
+    const summaryId = entry.testRunResultSummaryId
+    if (summaryId && !message.includes("trrs:")) {
+        return `trrs: ${summaryId}, ${message}`
+    }
+    return message
+}
+
+const LogsContainer = ({ logs, displayedLogData, runSummaryHexId }) => {
     const d1 = func.epochToDateTime(Math.floor(logs.startTime / 1000))
     const d2 = func.epochToDateTime(Math.floor(logs.endTime / 1000))
     const totalLoaded = logs.logData.length
@@ -24,6 +33,11 @@ const LogsContainer = ({ logs, displayedLogData }) => {
 
     return (
         <Box width="100%" minWidth="0">
+            {runSummaryHexId ? (
+                <Box paddingBlockEnd="2">
+                    <Text as="p" variant="bodySm" color="subdued">Run summary id: {runSummaryHexId}</Text>
+                </Box>
+            ) : null}
             <Text as="p" variant="bodyMd">
                 <span>Fetched logs from </span>
                 <span style={{ color: tokens.color["color-bg-success-strong"] }}>{d1}</span>
@@ -43,7 +57,7 @@ const LogsContainer = ({ logs, displayedLogData }) => {
                         <VerticalStack gap="1">
                             {displayedLogData.map((entry, idx) => (
                                 <Box key={idx} width="100%" minWidth="0" style={logLineStyle}>
-                                    [{func.epochToDateTime(entry.timestamp)}] {entry.log}
+                                    [{func.epochToDateTime(entry.timestamp)}] {formatLogLine(entry)}
                                 </Box>
                             ))}
                         </VerticalStack>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/health_logs/LogsContainer.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/health_logs/LogsContainer.jsx
@@ -17,9 +17,9 @@ const logLineStyle = {
 
 const formatLogLine = (entry) => {
     const message = entry.log ?? ""
-    const summaryId = entry.testRunResultSummaryId
-    if (summaryId && !message.includes("trrs:")) {
-        return `trrs: ${summaryId}, ${message}`
+    const activityId = entry.activityId
+    if (activityId && !message.includes("trrs:")) {
+        return `trrs: ${activityId}, ${message}`
     }
     return message
 }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/SingleTestRunPage.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/SingleTestRunPage.js
@@ -28,7 +28,8 @@ import {
   PlusMinor,
   SettingsMinor,
   ViewMajor,
-  CircleAlertMajor
+  CircleAlertMajor,
+  FileMinor
 } from '@shopify/polaris-icons';
 import api from "../api";
 import observeApi from "../../observe/api";
@@ -142,6 +143,7 @@ function SingleTestRunPage() {
   const [selected, setSelected] = useState(0)
   const [workflowTest, setWorkflowTest] = useState(false);
   const [secondaryPopover, setSecondaryPopover] = useState(false)
+  const [logsModalActive, setLogsModalActive] = useState(false)
   const setErrorsObject = TestingStore((state) => state.setErrorsObject)
   const setTestingEndpointsApisList = TestingStore((state) => state.setTestingEndpointsApisList)
   const currentTestingRuns = []
@@ -950,8 +952,7 @@ function SingleTestRunPage() {
 
   const components = [
     runningTestsComp, <TrendChart key={tempLoading.running} hexId={hexId} setSummary={setSummary} show={true} totalVulnerabilities={tableCountObj.vulnerable} refreshTrigger={chartRefreshCounter} />,
-    tokenRateLimitBannerComp, metadataComponent(), loading ? <SpinnerCentered key="loading" /> : (!workflowTest ? resultTable : workflowTestBuilder),
-    currentSummary?.hexId ? <TestRunLogs key="test-run-logs" summaryHexId={currentSummary.hexId} startTimestamp={currentSummary.startTimestamp} endTimestamp={currentSummary.endTimestamp} /> : null];
+    tokenRateLimitBannerComp, metadataComponent(), loading ? <SpinnerCentered key="loading" /> : (!workflowTest ? resultTable : workflowTestBuilder)];
 
   const openVulnerabilityReport = async (summaryMode = false) => {
     const currentPageKey = "/dashboard/testing/" + selectedTestRun?.id + "/#" + selectedTab
@@ -1284,7 +1285,12 @@ function SingleTestRunPage() {
         content: 'Re-Calculate Issues Count',
         icon: RefreshMajor,
         onAction: () => { setConfirmationModal(true) }
-      }
+      },
+      ...(currentSummary?.hexId ? [{
+        content: 'View logs',
+        icon: FileMinor,
+        onAction: () => { setSecondaryPopover(false); setLogsModalActive(true) }
+      }] : [])
     ]
   })
   const moreActionsComp = (
@@ -1313,6 +1319,15 @@ function SingleTestRunPage() {
         components={useComponents}
       />
       <ReRunModal selectedTestRun={selectedTestRun} shouldRefresh={false} />
+      {currentSummary?.hexId ? (
+        <TestRunLogs
+          open={logsModalActive}
+          onClose={() => setLogsModalActive(false)}
+          summaryHexId={currentSummary.hexId}
+          startTimestamp={currentSummary.startTimestamp}
+          endTimestamp={currentSummary.endTimestamp}
+        />
+      ) : null}
       <SeveritySelector
         open={severityModalActive}
         onClose={() => setSeverityModalActive(false)}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/SingleTestRunPage.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/SingleTestRunPage.js
@@ -42,6 +42,7 @@ import SpinnerCentered from "../../../components/progress/SpinnerCentered";
 import TooltipText from "../../../components/shared/TooltipText";
 import PersistStore from "../../../../main/PersistStore";
 import TrendChart from "./TrendChart";
+import TestRunLogs from "./TestRunLogs";
 import useTable from "../../../components/tables/TableContext";
 import ReRunModal from "./ReRunModal";
 import TestingStore from "../testingStore";
@@ -949,7 +950,8 @@ function SingleTestRunPage() {
 
   const components = [
     runningTestsComp, <TrendChart key={tempLoading.running} hexId={hexId} setSummary={setSummary} show={true} totalVulnerabilities={tableCountObj.vulnerable} refreshTrigger={chartRefreshCounter} />,
-    tokenRateLimitBannerComp, metadataComponent(), loading ? <SpinnerCentered key="loading" /> : (!workflowTest ? resultTable : workflowTestBuilder)];
+    tokenRateLimitBannerComp, metadataComponent(), loading ? <SpinnerCentered key="loading" /> : (!workflowTest ? resultTable : workflowTestBuilder),
+    currentSummary?.hexId ? <TestRunLogs key="test-run-logs" summaryHexId={currentSummary.hexId} startTimestamp={currentSummary.startTimestamp} endTimestamp={currentSummary.endTimestamp} /> : null];
 
   const openVulnerabilityReport = async (summaryMode = false) => {
     const currentPageKey = "/dashboard/testing/" + selectedTestRun?.id + "/#" + selectedTab

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TestRunLogs.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TestRunLogs.jsx
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback } from "react";
+import { Card, HorizontalStack, VerticalStack, Text, Button, TextField } from "@shopify/polaris";
+import { RefreshMajor } from "@shopify/polaris-icons";
+import api from "../api";
+import LogsContainer from "../../settings/health_logs/LogsContainer";
+import SpinnerCentered from "../../../components/progress/SpinnerCentered";
+
+const TestRunLogs = ({ summaryHexId, startTimestamp, endTimestamp }) => {
+    const [logData, setLogData] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [searchValue, setSearchValue] = useState("");
+
+    const fetchLogs = useCallback(async () => {
+        if (!summaryHexId) {
+            return;
+        }
+        setLoading(true);
+        try {
+            const resp = await api.fetchTestRunLogs(summaryHexId);
+            setLogData(resp?.logs ?? []);
+        } finally {
+            setLoading(false);
+        }
+    }, [summaryHexId]);
+
+    useEffect(() => {
+        fetchLogs();
+    }, [fetchLogs]);
+
+    const displayedLogData = searchValue
+        ? logData.filter((entry) => `${entry.log ?? ""}`.toLowerCase().includes(searchValue.toLowerCase()))
+        : logData;
+
+    const logs = {
+        startTime: (startTimestamp || 0) * 1000,
+        endTime: (endTimestamp || 0) * 1000,
+        logData,
+    };
+
+    return (
+        <Card key="test-run-logs">
+            <VerticalStack gap="3">
+                <HorizontalStack align="space-between" blockAlign="center">
+                    <Text variant="headingMd" as="h2">Logs</Text>
+                    <Button icon={RefreshMajor} onClick={fetchLogs} loading={loading}>Refresh</Button>
+                </HorizontalStack>
+                <TextField
+                    value={searchValue}
+                    onChange={setSearchValue}
+                    placeholder="Filter by text in timestamp or message"
+                    autoComplete="off"
+                    clearButton
+                    onClearButtonClick={() => setSearchValue("")}
+                />
+                {loading
+                    ? <SpinnerCentered />
+                    : (logData.length === 0
+                        ? <Text color="subdued">No logs found for this test run.</Text>
+                        : <LogsContainer logs={logs} displayedLogData={displayedLogData} />)}
+            </VerticalStack>
+        </Card>
+    );
+};
+
+export default TestRunLogs;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TestRunLogs.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TestRunLogs.jsx
@@ -32,7 +32,7 @@ const TestRunLogs = ({ open, onClose, summaryHexId, startTimestamp, endTimestamp
     const matchesSearch = (entry) => {
         const term = searchValue.toLowerCase();
         return `${entry.log ?? ""}`.toLowerCase().includes(term)
-            || `${entry.testRunResultSummaryId ?? ""}`.toLowerCase().includes(term);
+            || `${entry.activityId ?? ""}`.toLowerCase().includes(term);
     };
 
     const displayedLogData = searchValue ? logData.filter(matchesSearch) : logData;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TestRunLogs.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TestRunLogs.jsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
-import { Card, HorizontalStack, VerticalStack, Text, Button, TextField } from "@shopify/polaris";
+import { Modal, HorizontalStack, VerticalStack, Text, Button, TextField } from "@shopify/polaris";
 import { RefreshMajor } from "@shopify/polaris-icons";
 import api from "../api";
 import LogsContainer from "../../settings/health_logs/LogsContainer";
 import SpinnerCentered from "../../../components/progress/SpinnerCentered";
 
-const TestRunLogs = ({ summaryHexId, startTimestamp, endTimestamp }) => {
+const TestRunLogs = ({ open, onClose, summaryHexId, startTimestamp, endTimestamp }) => {
     const [logData, setLogData] = useState([]);
     const [loading, setLoading] = useState(false);
     const [searchValue, setSearchValue] = useState("");
@@ -24,12 +24,18 @@ const TestRunLogs = ({ summaryHexId, startTimestamp, endTimestamp }) => {
     }, [summaryHexId]);
 
     useEffect(() => {
-        fetchLogs();
-    }, [fetchLogs]);
+        if (open) {
+            fetchLogs();
+        }
+    }, [open, fetchLogs]);
 
-    const displayedLogData = searchValue
-        ? logData.filter((entry) => `${entry.log ?? ""}`.toLowerCase().includes(searchValue.toLowerCase()))
-        : logData;
+    const matchesSearch = (entry) => {
+        const term = searchValue.toLowerCase();
+        return `${entry.log ?? ""}`.toLowerCase().includes(term)
+            || `${entry.testRunResultSummaryId ?? ""}`.toLowerCase().includes(term);
+    };
+
+    const displayedLogData = searchValue ? logData.filter(matchesSearch) : logData;
 
     const logs = {
         startTime: (startTimestamp || 0) * 1000,
@@ -38,27 +44,34 @@ const TestRunLogs = ({ summaryHexId, startTimestamp, endTimestamp }) => {
     };
 
     return (
-        <Card key="test-run-logs">
-            <VerticalStack gap="3">
-                <HorizontalStack align="space-between" blockAlign="center">
-                    <Text variant="headingMd" as="h2">Logs</Text>
-                    <Button icon={RefreshMajor} onClick={fetchLogs} loading={loading}>Refresh</Button>
-                </HorizontalStack>
-                <TextField
-                    value={searchValue}
-                    onChange={setSearchValue}
-                    placeholder="Filter by text in timestamp or message"
-                    autoComplete="off"
-                    clearButton
-                    onClearButtonClick={() => setSearchValue("")}
-                />
-                {loading
-                    ? <SpinnerCentered />
-                    : (logData.length === 0
-                        ? <Text color="subdued">No logs found for this test run.</Text>
-                        : <LogsContainer logs={logs} displayedLogData={displayedLogData} />)}
-            </VerticalStack>
-        </Card>
+        <Modal
+            large
+            open={open}
+            onClose={onClose}
+            title="Test run logs"
+        >
+            <Modal.Section>
+                <VerticalStack gap="3">
+                    <HorizontalStack align="space-between" blockAlign="center">
+                        <Text variant="bodySm" color="subdued" as="span">Run summary id: {summaryHexId}</Text>
+                        <Button icon={RefreshMajor} onClick={fetchLogs} loading={loading}>Refresh</Button>
+                    </HorizontalStack>
+                    <TextField
+                        value={searchValue}
+                        onChange={setSearchValue}
+                        placeholder="Filter by text in timestamp, message or summary id"
+                        autoComplete="off"
+                        clearButton
+                        onClearButtonClick={() => setSearchValue("")}
+                    />
+                    {loading
+                        ? <SpinnerCentered />
+                        : (logData.length === 0
+                            ? <Text color="subdued">No logs found for this test run.</Text>
+                            : <LogsContainer logs={logs} displayedLogData={displayedLogData} runSummaryHexId={summaryHexId} />)}
+                </VerticalStack>
+            </Modal.Section>
+        </Modal>
     );
 };
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/api.js
@@ -34,6 +34,17 @@ export default {
         })
         return resp        
     },
+    async fetchTestRunLogs(testingRunResultSummaryId, logKeys) {
+        const resp = await request({
+            url: '/api/fetchTestRunLogs',
+            method: 'post',
+            data: {
+                testingRunResultSummaryId,
+                ...(Array.isArray(logKeys) && logKeys.length > 0 ? { logKeys } : {})
+            }
+        })
+        return resp
+    },
     async fetchTestRunResultsCount(testingRunResultSummaryHexId, filters) {
         const resp = await request({
             url: '/api/fetchTestRunResultsCount',

--- a/libs/dao/src/main/java/com/akto/DaoInit.java
+++ b/libs/dao/src/main/java/com/akto/DaoInit.java
@@ -467,7 +467,8 @@ public class DaoInit {
                 new EnumCodec<>(GlobalEnums.DashboardCategory.class),
                 new EnumCodec<>(McpRegistryConfig.RegistryType.class),
                 new EnumCodec<>(McpAllowlist.Source.class),
-                new EnumCodec<>(GuardrailPolicies.ModelRole.class)
+                new EnumCodec<>(GuardrailPolicies.ModelRole.class),
+                new EnumCodec<>(Log.ActivityType.class)
         );
 
         return fromRegistries(MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry,

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -35,8 +35,8 @@ public class LogsDao extends AccountsContextDao<Log> {
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
 
-        String[] summaryIdFields = {Log.TEST_RUN_RESULT_SUMMARY_ID};
-        MCollection.createIndexIfAbsent(getDBName(), getCollName(), summaryIdFields,false);
+        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID};
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(), activityFields,false);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -35,7 +35,7 @@ public class LogsDao extends AccountsContextDao<Log> {
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
 
-        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID};
+        String[] activityFields = {Log.ACTIVITY_TYPE, Log.ACTIVITY_ID, Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), activityFields,false);
     }
 

--- a/libs/dao/src/main/java/com/akto/dao/LogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/LogsDao.java
@@ -34,6 +34,9 @@ public class LogsDao extends AccountsContextDao<Log> {
 
         String[] fieldNames = {Log.TIMESTAMP};
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), fieldNames,false);
+
+        String[] summaryIdFields = {Log.TEST_RUN_RESULT_SUMMARY_ID};
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(), summaryIdFields,false);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/context/Context.java
+++ b/libs/dao/src/main/java/com/akto/dao/context/Context.java
@@ -13,12 +13,14 @@ public static ThreadLocal<Integer> accountId = new ThreadLocal<Integer>();
 public static ThreadLocal<Integer> userId = new ThreadLocal<Integer>();
 public static ThreadLocal<CONTEXT_SOURCE> contextSource = new ThreadLocal<CONTEXT_SOURCE>();
 public static ThreadLocal<Boolean> isRedactPayload = new ThreadLocal<>();
+public static ThreadLocal<String> testRunResultSummaryId = new ThreadLocal<String>();
 
     public static void resetContextThreadLocals() {
         accountId.remove();
         userId.remove();
         contextSource.remove();
         isRedactPayload.remove();
+        testRunResultSummaryId.remove();
     }
 
     public static int getId() {

--- a/libs/dao/src/main/java/com/akto/dao/context/Context.java
+++ b/libs/dao/src/main/java/com/akto/dao/context/Context.java
@@ -2,6 +2,7 @@ package com.akto.dao.context;
 
 import com.akto.dao.AccountsDao;
 import com.akto.dto.Account;
+import com.akto.dto.Log;
 import com.akto.util.enums.GlobalEnums.CONTEXT_SOURCE;
 
 import java.math.BigDecimal;
@@ -13,14 +14,16 @@ public static ThreadLocal<Integer> accountId = new ThreadLocal<Integer>();
 public static ThreadLocal<Integer> userId = new ThreadLocal<Integer>();
 public static ThreadLocal<CONTEXT_SOURCE> contextSource = new ThreadLocal<CONTEXT_SOURCE>();
 public static ThreadLocal<Boolean> isRedactPayload = new ThreadLocal<>();
-public static ThreadLocal<String> testRunResultSummaryId = new ThreadLocal<String>();
+public static ThreadLocal<String> activityId = new ThreadLocal<String>();
+public static ThreadLocal<Log.ActivityType> activityType = new ThreadLocal<Log.ActivityType>();
 
     public static void resetContextThreadLocals() {
         accountId.remove();
         userId.remove();
         contextSource.remove();
         isRedactPayload.remove();
-        testRunResultSummaryId.remove();
+        activityId.remove();
+        activityType.remove();
     }
 
     public static int getId() {

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -1,6 +1,8 @@
 package com.akto.dto;
 
 import com.mongodb.BasicDBObject;
+import lombok.Getter;
+import lombok.Setter;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.types.ObjectId;
 
@@ -29,6 +31,11 @@ public class Log {
     public static final String TIMESTAMP = "timestamp";
     public static final String KEY = "key";
     private int timestamp;
+
+    public static final String TEST_RUN_RESULT_SUMMARY_ID = "testRunResultSummaryId";
+    @Getter
+    @Setter
+    private String testRunResultSummaryId;
 
     public Log() {
     }
@@ -69,6 +76,7 @@ public class Log {
             " log='" + getLog() + "'" +
             ", key='" + getKey() + "'" +
             ", timestamp='" + getTimestamp() + "'" +
+            ", testRunResultSummaryId='" + getTestRunResultSummaryId() + "'" +
             "}";
     }
 
@@ -76,7 +84,8 @@ public class Log {
         return new BasicDBObject("_id", getId())
                 .append("log", getLog())
                 .append("key", getKey())
-                .append("timestamp", getTimestamp());
+                .append("timestamp", getTimestamp())
+                .append(TEST_RUN_RESULT_SUMMARY_ID, getTestRunResultSummaryId());
     }
 
 }

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -8,6 +8,10 @@ import org.bson.types.ObjectId;
 
 public class Log {
 
+    public enum ActivityType {
+        TESTING_RUN_RESULT_SUMMARY_ACTIVITY
+    }
+
     private ObjectId id;
     public ObjectId getId() {
         return id;
@@ -32,10 +36,16 @@ public class Log {
     public static final String KEY = "key";
     private int timestamp;
 
-    public static final String TEST_RUN_RESULT_SUMMARY_ID = "testRunResultSummaryId";
+    public static final String ACTIVITY_ID = "activityId";
+    public static final String ACTIVITY_TYPE = "activityType";
+
     @Getter
     @Setter
-    private String testRunResultSummaryId;
+    private String activityId; // activity id for the log eg test run result summary id
+
+    @Getter
+    @Setter
+    private ActivityType activityType; // activity type for the log eg TESTING_RUN_RESULT_SUMMARY_ACTIVITY
 
     public Log() {
     }
@@ -76,7 +86,8 @@ public class Log {
             " log='" + getLog() + "'" +
             ", key='" + getKey() + "'" +
             ", timestamp='" + getTimestamp() + "'" +
-            ", testRunResultSummaryId='" + getTestRunResultSummaryId() + "'" +
+            ", activityId='" + getActivityId() + "'" +
+            ", activityType='" + getActivityType() + "'" +
             "}";
     }
 
@@ -85,7 +96,8 @@ public class Log {
                 .append("log", getLog())
                 .append("key", getKey())
                 .append("timestamp", getTimestamp())
-                .append(TEST_RUN_RESULT_SUMMARY_ID, getTestRunResultSummaryId());
+                .append(ACTIVITY_ID, getActivityId())
+                .append(ACTIVITY_TYPE, getActivityType());
     }
 
 }

--- a/libs/dao/src/main/java/com/akto/dto/Log.java
+++ b/libs/dao/src/main/java/com/akto/dto/Log.java
@@ -82,13 +82,18 @@ public class Log {
 
     @Override
     public String toString() {
-        return "{" +
-            " log='" + getLog() + "'" +
-            ", key='" + getKey() + "'" +
-            ", timestamp='" + getTimestamp() + "'" +
-            ", activityId='" + getActivityId() + "'" +
-            ", activityType='" + getActivityType() + "'" +
-            "}";
+        StringBuilder sb = new StringBuilder("{");
+        sb.append(" log='").append(getLog()).append("'");
+        sb.append(", key='").append(getKey()).append("'");
+        sb.append(", timestamp='").append(getTimestamp()).append("'");
+        if (getActivityId() != null) {
+            sb.append(", activityId='").append(getActivityId()).append("'");
+        }
+        if (getActivityType() != null) {
+            sb.append(", activityType='").append(getActivityType()).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
     }
 
     public BasicDBObject toBasicDBObject(){

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -175,14 +175,18 @@ public class LoggerMaker  {
         sendToSlack(slackWebhookUrl, err);
     }
 
-    private String trrsPrefix() {
-        String summaryId = Context.testRunResultSummaryId.get();
-        return (summaryId != null && !summaryId.isEmpty()) ? "trrs: " + summaryId + ", " : "";
+    private String activityPrefix() {
+        Log.ActivityType type = Context.activityType.get();
+        String id = Context.activityId.get();
+        if (type == Log.ActivityType.TESTING_RUN_RESULT_SUMMARY_ACTIVITY && id != null && !id.isEmpty()) {
+            return "trrs: " + id + ", ";
+        }
+        return "";
     }
 
     protected String basicError(String err, LogDb db) {
         if(Context.accountId.get() != null){
-            err = String.format("%s%s\nAccount id: %d", trrsPrefix(), err, Context.accountId.get());
+            err = String.format("%s%s\nAccount id: %d", activityPrefix(), err, Context.accountId.get());
         }
         if (!isSendToInfraOnly()) {
             logger.error(err);
@@ -242,7 +246,7 @@ public class LoggerMaker  {
     @Deprecated
     public void infoAndAddToDb(String info, LogDb db) {
         String accountId = Context.accountId.get() != null ? Context.accountId.get().toString() : "NA";
-        String infoMessage = trrsPrefix() + "acc: " + accountId + ", " + info;
+        String infoMessage = activityPrefix() + "acc: " + accountId + ", " + info;
         if (!isSendToInfraOnly()) {
             logger.info(infoMessage);
         }
@@ -255,7 +259,7 @@ public class LoggerMaker  {
 
     public void warnAndAddToDb(String info, LogDb db) {
         String accountId = Context.accountId.get() != null ? Context.accountId.get().toString() : "NA";
-        String infoMessage = trrsPrefix() + "acc: " + accountId + ", " + info;
+        String infoMessage = activityPrefix() + "acc: " + accountId + ", " + info;
         if (!isSendToInfraOnly()) {
             logger.warn(infoMessage);
         }
@@ -336,7 +340,8 @@ public class LoggerMaker  {
 
         String text = aClass + " : " + info;
         Log log = new Log(text, key, Context.now());
-        log.setTestRunResultSummaryId(Context.testRunResultSummaryId.get());
+        log.setActivityId(Context.activityId.get());
+        log.setActivityType(Context.activityType.get());
         if(checkUpdate() && db!=null){
             switch(db){
                 case TESTING: 
@@ -451,26 +456,29 @@ public class LoggerMaker  {
     }
 
     /**
-     * Fetches TESTING logs scoped to a specific testing run result summary id (instead of a time range).
-     * These are the logs stamped with the summary id at insert time, used by the per-run Logs tab.
+     * Fetches TESTING logs scoped to a specific activity (instead of a time range).
+     * These are the logs stamped with the activity id/type at insert time, used by the per-run Logs tab.
      */
-    public List<Log> fetchTestingLogRecordsBySummaryId(String testRunResultSummaryId, List<String> logKeysFilter) {
+    public List<Log> fetchTestingLogRecordsByActivity(Log.ActivityType activityType, String activityId, List<String> logKeysFilter) {
         List<Log> logs = new ArrayList<>();
-        if (testRunResultSummaryId == null || testRunResultSummaryId.isEmpty()) {
+        if (activityType == null || activityId == null || activityId.isEmpty()) {
             return logs;
         }
 
-        Bson summaryFilter = Filters.eq(Log.TEST_RUN_RESULT_SUMMARY_ID, testRunResultSummaryId);
+        Bson activityFilter = Filters.and(
+            Filters.eq(Log.ACTIVITY_TYPE, activityType),
+            Filters.eq(Log.ACTIVITY_ID, activityId)
+        );
         Bson filters;
         List<String> normalized = normalizeLogKeysFilter(logKeysFilter);
         if (normalized == null || normalized.size() >= STORED_LOG_KEYS.size()) {
-            filters = summaryFilter;
+            filters = activityFilter;
         } else {
-            filters = Filters.and(summaryFilter, Filters.in(Log.KEY, normalized));
+            filters = Filters.and(activityFilter, Filters.in(Log.KEY, normalized));
         }
 
         Bson sortAscending = Sorts.ascending(Log.TIMESTAMP);
-        Bson standardProjection = Projections.include("log", Log.TIMESTAMP, Log.KEY, Log.TEST_RUN_RESULT_SUMMARY_ID);
+        Bson standardProjection = Projections.include("log", Log.TIMESTAMP, Log.KEY, Log.ACTIVITY_ID, Log.ACTIVITY_TYPE);
         logs = LogsDao.instance.findAll(filters, 0, 1_000_000, sortAscending, standardProjection);
         return logs;
     }

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -331,6 +331,7 @@ public class LoggerMaker  {
 
         String text = aClass + " : " + info;
         Log log = new Log(text, key, Context.now());
+        log.setTestRunResultSummaryId(Context.testRunResultSummaryId.get());
         if(checkUpdate() && db!=null){
             switch(db){
                 case TESTING: 
@@ -442,6 +443,31 @@ public class LoggerMaker  {
             return timeRange;
         }
         return Filters.and(timeRange, Filters.in(Log.KEY, normalized));
+    }
+
+    /**
+     * Fetches TESTING logs scoped to a specific testing run result summary id (instead of a time range).
+     * These are the logs stamped with the summary id at insert time, used by the per-run Logs tab.
+     */
+    public List<Log> fetchTestingLogRecordsBySummaryId(String testRunResultSummaryId, List<String> logKeysFilter) {
+        List<Log> logs = new ArrayList<>();
+        if (testRunResultSummaryId == null || testRunResultSummaryId.isEmpty()) {
+            return logs;
+        }
+
+        Bson summaryFilter = Filters.eq(Log.TEST_RUN_RESULT_SUMMARY_ID, testRunResultSummaryId);
+        Bson filters;
+        List<String> normalized = normalizeLogKeysFilter(logKeysFilter);
+        if (normalized == null || normalized.size() >= STORED_LOG_KEYS.size()) {
+            filters = summaryFilter;
+        } else {
+            filters = Filters.and(summaryFilter, Filters.in(Log.KEY, normalized));
+        }
+
+        Bson sortAscending = Sorts.ascending(Log.TIMESTAMP);
+        Bson standardProjection = Projections.include("log", Log.TIMESTAMP, Log.KEY);
+        logs = LogsDao.instance.findAll(filters, 0, 1_000_000, sortAscending, standardProjection);
+        return logs;
     }
 
     /**

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -175,9 +175,14 @@ public class LoggerMaker  {
         sendToSlack(slackWebhookUrl, err);
     }
 
+    private String trrsPrefix() {
+        String summaryId = Context.testRunResultSummaryId.get();
+        return (summaryId != null && !summaryId.isEmpty()) ? "trrs: " + summaryId + ", " : "";
+    }
+
     protected String basicError(String err, LogDb db) {
         if(Context.accountId.get() != null){
-            err = String.format("%s\nAccount id: %d", err, Context.accountId.get());
+            err = String.format("%s%s\nAccount id: %d", trrsPrefix(), err, Context.accountId.get());
         }
         if (!isSendToInfraOnly()) {
             logger.error(err);
@@ -237,7 +242,7 @@ public class LoggerMaker  {
     @Deprecated
     public void infoAndAddToDb(String info, LogDb db) {
         String accountId = Context.accountId.get() != null ? Context.accountId.get().toString() : "NA";
-        String infoMessage = "acc: " + accountId + ", " + info;
+        String infoMessage = trrsPrefix() + "acc: " + accountId + ", " + info;
         if (!isSendToInfraOnly()) {
             logger.info(infoMessage);
         }
@@ -250,7 +255,7 @@ public class LoggerMaker  {
 
     public void warnAndAddToDb(String info, LogDb db) {
         String accountId = Context.accountId.get() != null ? Context.accountId.get().toString() : "NA";
-        String infoMessage = "acc: " + accountId + ", " + info;
+        String infoMessage = trrsPrefix() + "acc: " + accountId + ", " + info;
         if (!isSendToInfraOnly()) {
             logger.warn(infoMessage);
         }
@@ -465,7 +470,7 @@ public class LoggerMaker  {
         }
 
         Bson sortAscending = Sorts.ascending(Log.TIMESTAMP);
-        Bson standardProjection = Projections.include("log", Log.TIMESTAMP, Log.KEY);
+        Bson standardProjection = Projections.include("log", Log.TIMESTAMP, Log.KEY, Log.TEST_RUN_RESULT_SUMMARY_ID);
         logs = LogsDao.instance.findAll(filters, 0, 1_000_000, sortAscending, standardProjection);
         return logs;
     }

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -184,6 +184,19 @@ public class LoggerMaker  {
         return "";
     }
 
+    /**
+     * Stamps the current thread's activity context onto the log only when both the type and a
+     * non-empty id are present. Leaves the fields unset otherwise so null is never persisted/printed.
+     */
+    private static void applyActivityContext(Log log) {
+        Log.ActivityType type = Context.activityType.get();
+        String id = Context.activityId.get();
+        if (type != null && id != null && !id.isEmpty()) {
+            log.setActivityId(id);
+            log.setActivityType(type);
+        }
+    }
+
     protected String basicError(String err, LogDb db) {
         if(Context.accountId.get() != null){
             err = String.format("%s%s\nAccount id: %d", activityPrefix(), err, Context.accountId.get());
@@ -340,8 +353,7 @@ public class LoggerMaker  {
 
         String text = aClass + " : " + info;
         Log log = new Log(text, key, Context.now());
-        log.setActivityId(Context.activityId.get());
-        log.setActivityType(Context.activityType.get());
+        applyActivityContext(log);
         if(checkUpdate() && db!=null){
             switch(db){
                 case TESTING: 


### PR DESCRIPTION
Stamp logs with testRunResultSummaryId, expose a summary-scoped fetch API, and show a Logs section on SingleTestRunPage so each run's service logs are viewable in the dashboard.