### PR TITLE
chore: update akto-endpoint-shield dependency to latest version

### DIFF
--- a/apps/guardrails-service/container/src/go.mod
+++ b/apps/guardrails-service/container/src/go.mod
@@ -3,7 +3,7 @@ module github.com/akto-api-security/guardrails-service
 go 1.24.11
 
 require (
-	github.com/akto-api-security/akto-endpoint-shield v0.0.0-20260626152350-c2056d2a58a2
+	github.com/akto-api-security/akto-endpoint-shield v0.0.0-20260630080827-6063a8d18082
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/segmentio/kafka-go v0.4.49
@@ -130,6 +130,6 @@ require (
 )
 
 replace (
-	github.com/akto-api-security/akto-endpoint-shield => github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260626152350-c2056d2a58a2
+	github.com/akto-api-security/akto-endpoint-shield => github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260630080827-6063a8d18082
 	github.com/shoenig/go-m1cpu => ./internal/stub/go-m1cpu
 )

--- a/apps/guardrails-service/container/src/go.sum
+++ b/apps/guardrails-service/container/src/go.sum
@@ -29,8 +29,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/STARRY-S/zip v0.2.1 h1:pWBd4tuSGm3wtpoqRZZ2EAwOmcHK6XFf7bU9qcJXyFg=
 github.com/STARRY-S/zip v0.2.1/go.mod h1:xNvshLODWtC4EJ702g7cTYn13G53o1+X9BWnPFpcWV4=
-github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260626152350-c2056d2a58a2 h1:dHhx/N4blT26Inlyn9YZWyPZsh3vP/qayITlOUsAWxs=
-github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260626152350-c2056d2a58a2/go.mod h1:tvCEIiZdk36hyCOeN/GLBqcQtFU8Hgua4UoaZYDDbkM=
+github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260630080827-6063a8d18082 h1:Qa45xGBfYQ4LmpqjbPtJvbJ+JZH9XWTi6FRP8KZVnWU=
+github.com/akto-api-security/akto-gateway/mcp-endpoint-shield v0.0.0-20260630080827-6063a8d18082/go.mod h1:tvCEIiZdk36hyCOeN/GLBqcQtFU8Hgua4UoaZYDDbkM=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=


### PR DESCRIPTION
- Updated the version of github.com/akto-api-security/akto-endpoint-shield in go.mod and go.sum to v0.0.0-20260630080827-6063a8d18082.
- Ensured consistency in the module replacement path for the akto-gateway/mcp-endpoint-shield.