### PR TITLE
fix: scope legacy context filter to legacy accounts only

### DIFF
--- a/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/MaliciousEventService.java
+++ b/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/MaliciousEventService.java
@@ -373,7 +373,7 @@ public class MaliciousEventService {
     Set<String> hosts = new HashSet<>();
 
     // Scope all dropdown values to the current context source, same filter the events table uses.
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     Bson eventsFilter = Filters.and(
         buildTimeRangeFilter(request.getDetectedAtTimeRange(), "detectedAt"),
         contextFilter);
@@ -392,7 +392,7 @@ public class MaliciousEventService {
   }
 
   private Set<String> fetchActorsForFilters(String accountId, FetchAlertFiltersRequest request, String contextSource) {
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (USE_ACTOR_INFO_TABLE) {
       ActorInfoDao actorInfoDao = ActorInfoDao.instance;
       // actor_info uses discoveredAt for its time field; scope to the current context source.
@@ -519,7 +519,7 @@ public class MaliciousEventService {
     // }
 
     // Apply simple context filter (only for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       query.putAll(contextFilter);
     }
@@ -633,13 +633,13 @@ public class MaliciousEventService {
         update = Updates.set("jiraTicketUrl", jiraTicketUrl);
       }
 
-      Document query = buildQuery(eventIds, filterMap, "update", contextSource);
+      Document query = buildQuery(eventIds, filterMap, "update", contextSource, accountId);
       if (query == null) {
         return 0;
       }
 
       String logMessage = String.format("Updating events %s to status: %s and jiraTicketUrl: %s",
-          getQueryDescription(eventIds, filterMap), status, jiraTicketUrl != null && !jiraTicketUrl.isEmpty() ? jiraTicketUrl : "null");
+          getQueryDescription(eventIds, filterMap, accountId), status, jiraTicketUrl != null && !jiraTicketUrl.isEmpty() ? jiraTicketUrl : "null");
       logger.info(logMessage);
 
       long modifiedCount = maliciousEventDao.getCollection(accountId).updateMany(query, update).getModifiedCount();
@@ -652,12 +652,12 @@ public class MaliciousEventService {
 
   public int deleteMaliciousEvents(String accountId, List<String> eventIds, Map<String, Object> filterMap, String contextSource) {
     try {
-      Document query = buildQuery(eventIds, filterMap, "delete", contextSource);
+      Document query = buildQuery(eventIds, filterMap, "delete", contextSource, accountId);
       if (query == null) {
         return 0;
       }
 
-      String logMessage = "Deleting events " + getQueryDescription(eventIds, filterMap);
+      String logMessage = "Deleting events " + getQueryDescription(eventIds, filterMap, accountId);
       logger.info(logMessage);
 
       long deletedCount = maliciousEventDao.getCollection(accountId).deleteMany(query).getDeletedCount();
@@ -670,24 +670,24 @@ public class MaliciousEventService {
     }
   }
 
-  private Document buildQuery(List<String> eventIds, Map<String, Object> filterMap, String operation, String contextSource) {
+  private Document buildQuery(List<String> eventIds, Map<String, Object> filterMap, String operation, String contextSource, String accountId) {
     if (eventIds != null && !eventIds.isEmpty()) {
       // Query by event IDs
       return new Document("_id", new Document("$in", eventIds));
     } else if (filterMap != null && !filterMap.isEmpty()) {
       // Query by filter criteria
-      return buildQueryFromFilter(filterMap, contextSource);
+      return buildQueryFromFilter(filterMap, contextSource, accountId);
     } else {
       logger.warn("Neither eventIds nor filterMap provided for " + operation);
       return null;
     }
   }
 
-  private String getQueryDescription(List<String> eventIds, Map<String, Object> filterMap) {
+  private String getQueryDescription(List<String> eventIds, Map<String, Object> filterMap, String accountId) {
     if (eventIds != null && !eventIds.isEmpty()) {
       return "by IDs: " + eventIds;
     } else if (filterMap != null && !filterMap.isEmpty()) {
-      Document query = buildQueryFromFilter(filterMap, null);
+      Document query = buildQueryFromFilter(filterMap, null, accountId);
       return "by filter: " + query.toJson();
     }
     return "";
@@ -710,7 +710,7 @@ public class MaliciousEventService {
     }
   }
 
-  private Document buildQueryFromFilter(Map<String, Object> filter, String contextSource) {
+  private Document buildQueryFromFilter(Map<String, Object> filter, String contextSource, String accountId) {
     Document query = new Document();
 
     // Handle ips/actors filter
@@ -789,7 +789,7 @@ public class MaliciousEventService {
     }
 
     // Apply simple context filter (only for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       query.putAll(contextFilter);
     }

--- a/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/ThreatActorService.java
+++ b/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/ThreatActorService.java
@@ -266,7 +266,7 @@ public class ThreatActorService {
         Bson sortBson = sortOrder == 1 ? Sorts.ascending("_id") : Sorts.descending("_id");
 
         // Build base query filter
-        Document match = buildActorInfoQueryFilter(filter, request, contextSource);
+        Document match = buildActorInfoQueryFilter(filter, request, contextSource, accountId);
 
         // Always count total BEFORE applying cursor filter (to get consistent total across pages)
         long total = countActors(accountId, match);
@@ -320,7 +320,8 @@ public class ThreatActorService {
     private Document buildActorInfoQueryFilter(
             ListThreatActorsRequest.Filter filter,
             ListThreatActorsRequest request,
-            String contextSource) {
+            String contextSource,
+            String accountId) {
 
         Document match = new Document();
 
@@ -346,7 +347,7 @@ public class ThreatActorService {
         addIpFilter(match, filter);
 
         // 6. Context Filter
-        Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+        Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
         if (!contextFilter.isEmpty()) {
             match.putAll(contextFilter);
             loggerMaker.infoAndAddToDb(
@@ -515,7 +516,7 @@ public class ThreatActorService {
         }
 
         // Apply simple context filter (only for ENDPOINT and AGENTIC)
-        Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+        Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
         if (!contextFilter.isEmpty()) {
             match.putAll(contextFilter);
         }
@@ -611,7 +612,7 @@ public class ThreatActorService {
         }
 
     // Apply simple context filter (only for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
         matchConditions.putAll(contextFilter);
     }
@@ -761,7 +762,7 @@ public class ThreatActorService {
     }
 
     // Apply context filter
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       match.putAll(contextFilter);
     }
@@ -928,7 +929,7 @@ public class ThreatActorService {
       match.append("detectedAt", new Document("$gte", startTs).append("$lte", endTs));
 
     // Apply simple context filter (only for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
         match.putAll(contextFilter);
     }
@@ -1084,7 +1085,7 @@ public class ThreatActorService {
     }
 
     // Apply context filter (for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       match.putAll(contextFilter);
     }
@@ -1156,7 +1157,7 @@ public class ThreatActorService {
     }
 
     // Apply simple context filter (only for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
         match.putAll(contextFilter);
     }
@@ -1286,7 +1287,7 @@ public class ThreatActorService {
 
     Document activityQuery = new Document("actor", actor);
 
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       activityQuery.putAll(contextFilter);
     }
@@ -1339,7 +1340,7 @@ public class ThreatActorService {
         }
 
         // Apply simple context filter (only for ENDPOINT and AGENTIC)
-        Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+        Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
         if (!contextFilter.isEmpty()) {
             match.putAll(contextFilter);
         }
@@ -1445,7 +1446,7 @@ public class ThreatActorService {
       if (endTs > 0) tsRange.append("$lte", endTs);
       match.append("detectedAt", tsRange);
     }
-    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilterNew(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       match.putAll(contextFilter);
     }

--- a/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/ThreatApiService.java
+++ b/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/service/ThreatApiService.java
@@ -62,7 +62,7 @@ public class ThreatApiService {
     }
 
     // Apply simple context filter (only for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       match.putAll(contextFilter);
     }
@@ -147,7 +147,7 @@ public class ThreatApiService {
     }
 
     // Apply simple context filter (only for ENDPOINT and AGENTIC)
-    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource);
+    Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource, accountId);
     if (!contextFilter.isEmpty()) {
       match.putAll(contextFilter);
     }
@@ -208,7 +208,7 @@ public class ThreatApiService {
     }
 
       // Apply simple context filter (only for ENDPOINT and AGENTIC)
-      Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource);
+      Document contextFilter = ThreatUtils.buildSimpleContextFilter(contextSource, accountId);
       if (!contextFilter.isEmpty()) {
           match.putAll(contextFilter);
       }

--- a/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/utils/ThreatUtils.java
+++ b/apps/threat-detection-backend/src/main/java/com/akto/threat/backend/utils/ThreatUtils.java
@@ -24,24 +24,32 @@ public class ThreatUtils {
         "MCPGuardrails", "AuditPolicy", "MCPMaliciousComponent"
     );
 
-    public static Document buildSimpleContextFilterNew(String contextSource) {
+    public static Document buildSimpleContextFilterNew(String contextSource, String accountId) {
         if (contextSource == null || contextSource.isEmpty()) {
             contextSource = CONTEXT_SOURCE.API.name();
         }
 
-        if (USE_ACTOR_INFO_TABLE &&"API".equalsIgnoreCase(contextSource)) {
+        if (USE_ACTOR_INFO_TABLE && "API".equalsIgnoreCase(contextSource)) {
             return new Document("contextSource", "API");
         }
 
-        // For ENDPOINT and AGENTIC, need to include legacy filter for backward compatibility
         Document contextSourceFilter = new Document("contextSource", contextSource);
-        Document legacyFilter = buildLegacyContextFilter(contextSource);
 
-        return new Document("$or", Arrays.asList(contextSourceFilter, legacyFilter));
+        // For legacy accounts, include a legacy filter for backward compatibility
+        List<Integer> legacyAccounts = Arrays.asList(1700087964, 1726615470, 1728622642, 1737683011, 1745563576, 1760499072);
+        try {
+            if (accountId != null && legacyAccounts.contains(Integer.parseInt(accountId))) {
+                Document legacyFilter = buildLegacyContextFilter(contextSource);
+                return new Document("$or", Arrays.asList(contextSourceFilter, legacyFilter));
+            }
+        } catch (NumberFormatException ignored) {
+        }
+
+        return contextSourceFilter;
     }
 
-    public static Document buildSimpleContextFilter(String contextSource) {
-        return buildSimpleContextFilterNew(contextSource);
+    public static Document buildSimpleContextFilter(String contextSource, String accountId) {
+        return buildSimpleContextFilterNew(contextSource, accountId);
     }
 
     private static Document buildLegacyContextFilter(String contextSource) {


### PR DESCRIPTION
## Summary
- Added `accountId` parameter to `ThreatUtils.buildSimpleContextFilterNew` and `buildSimpleContextFilter`
- The legacy `$or` filter (backward-compatibility for old `contextSource` schema) is now only applied for known legacy accounts, not every account
- Threaded `accountId` through private helpers in `MaliciousEventService` (`buildQueryFromFilter`, `buildQuery`, `getQueryDescription`) and `ThreatActorService` (`buildActorInfoQueryFilter`) that previously lacked it

## Test plan
- [ ] Verify that non-legacy accounts receive a simple `{ contextSource: <value> }` filter
- [ ] Verify that legacy account IDs (e.g. `1700087964`) still receive the `$or [contextSourceFilter, legacyFilter]` query
- [ ] Run existing threat detection service tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)