### PR TITLE
Add bulk update functionality for user device tags

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
@@ -43,6 +43,9 @@ public class ModuleInfoAction extends UserAction {
     private String username;
     @Getter
     @Setter
+    private List<String> usernames;
+    @Getter
+    @Setter
     private String team;
     @Getter
     @Setter
@@ -267,6 +270,19 @@ public class ModuleInfoAction extends UserAction {
         }
 
         AgentUsersDao.instance.upsertTagFromDashboard(username, userEmail, team, userRole, getSUser().getLogin());
+        return SUCCESS.toUpperCase();
+    }
+
+    public String bulkUpdateUserDeviceTag() {
+        if (usernames == null || usernames.isEmpty()) {
+            addActionError("At least one username is required");
+            return ERROR.toUpperCase();
+        }
+
+        String updatedBy = getSUser().getLogin();
+        for (String u : usernames) {
+            AgentUsersDao.instance.upsertTagFromDashboard(u, null, team, userRole, updatedBy);
+        }
         return SUCCESS.toUpperCase();
     }
 

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -584,6 +584,29 @@
             </result>
         </action>
 
+        <action name="api/bulkUpdateUserDeviceTag" class="com.akto.action.settings.ModuleInfoAction" method="bulkUpdateUserDeviceTag">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <interceptor-ref name="roleAccessInterceptor">
+                <param name="featureLabel">ADMIN_ACTIONS</param>
+                <param name="accessType">READ_WRITE</param>
+                <param name="actionDescription">User bulk updated team and role for device users</param>
+            </interceptor-ref>
+
+            <result name="FORBIDDEN" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="SUCCESS" type="json"/>
+
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/fetchAgenticUsers" class="com.akto.action.settings.ModuleInfoAction" method="fetchAgenticUsers">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
@@ -250,11 +250,8 @@ function UsersAndDevices() {
         setEditTagModal((prev) => ({ ...prev, saving: true }));
         try {
             const selectedUsers = data.users.filter((u) => editTagModal.usernames.includes(u.id));
-            await Promise.all(
-                selectedUsers.map((u) =>
-                    settingRequests.updateUserDeviceTag(u.groupName, editTagModal.team, editTagModal.userRole)
-                )
-            );
+            const groupNames = selectedUsers.map((u) => u.groupName).filter(Boolean);
+            await settingRequests.bulkUpdateUserDeviceTag(groupNames, editTagModal.team, editTagModal.userRole);
             setData((prev) => ({
                 ...prev,
                 users: prev.users.map((u) =>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
@@ -888,6 +888,13 @@ const settingRequests = {
             data: { username, team, userRole }
         })
     },
+    async bulkUpdateUserDeviceTag(usernames, team, userRole) {
+        return await request({
+            url: '/api/bulkUpdateUserDeviceTag',
+            method: 'post',
+            data: { usernames, team, userRole }
+        })
+    },
     async fetchAgenticUsers(params = {}) {
         return await request({
             url: '/api/fetchAgenticUsers',

--- a/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
@@ -70,7 +70,22 @@ public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
         if (teamSourceToWrite != null) updates.add(Updates.set(AgenticUsers.TEAM_SOURCE, teamSourceToWrite));
         if (roleSourceToWrite != null) updates.add(Updates.set(AgenticUsers.ROLE_SOURCE, roleSourceToWrite));
 
-        instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, trimmedName), Updates.combine(updates));
+        if (existing == null) {
+            AgenticUsers newUser = new AgenticUsers();
+            newUser.setUserName(trimmedName);
+            if (userEmail != null && !userEmail.trim().isEmpty()) {
+                newUser.setUserEmail(userEmail.trim());
+            }
+            newUser.setTeamName(effectiveTeam);
+            newUser.setUserRole(effectiveRole);
+            newUser.setTeamSource(teamSourceToWrite != null ? teamSourceToWrite : AgenticUsers.SOURCE_MANUAL);
+            newUser.setRoleSource(roleSourceToWrite != null ? roleSourceToWrite : AgenticUsers.SOURCE_MANUAL);
+            newUser.setLastUpdatedAt(Context.now());
+            newUser.setLastUpdatedBy(lastUpdatedBy);
+            instance.insertOne(newUser);
+        } else {
+            instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, trimmedName), Updates.combine(updates));
+        }
     }
 
     /** SSO write — skips teamName/userRole if already pinned as "manual" by a dashboard override. */


### PR DESCRIPTION
- Introduced a new method `bulkUpdateUserDeviceTag` in `ModuleInfoAction` to handle bulk updates of user device tags.
- Updated `struts.xml` to define the new action and its JSON response handling.
- Modified the frontend to call the new bulk update API instead of individual updates.
- Added corresponding API request method in `api.js` for the bulk update functionality.
- Enhanced `AgentUsersDao` to support the creation of new users if they do not exist during the update process.