### PR TITLE
Hide Guardrail Policies Agent filter on Atlas.

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailPolicies.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailPolicies.jsx
@@ -85,8 +85,6 @@ const agentFilterHeader = {
     showFilter: true,
 };
 
-const tableHeaders = [...headings, agentFilterHeader];
-
 const sortOptions = [
   {
     label: "Created",
@@ -165,6 +163,11 @@ function GuardrailPolicies() {
             agent: getApplicableAgentKeys(row.originalData, allCollections, agentFilterOptions),
         }))
     ), [policyData, allCollections, agentFilterOptions]);
+
+    // Agent filter is Argus-only; hide on Atlas.
+    const tableHeaders = isEndpointSecurityCategory()
+        ? headings
+        : [...headings, agentFilterHeader];
 
     const policyName = new URLSearchParams(window.location.search).get("policy");
 


### PR DESCRIPTION
Keep the Agent table filter Argus-only so Endpoint Security accounts no longer see collection-ID filter choices.