### PR TITLE
feat: cap logs_endpoint_shield and align indexes with master

### DIFF
--- a/libs/dao/src/main/java/com/akto/dao/monitoring/EndpointShieldLogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/monitoring/EndpointShieldLogsDao.java
@@ -5,16 +5,20 @@ import com.akto.dao.MCollection;
 import com.akto.dao.context.Context;
 import com.akto.dto.ApiSequences;
 import com.akto.dto.monitoring.EndpointShieldLog;
+import com.akto.util.DbMode;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.Filters;
 import org.bson.conversions.Bson;
 
 import java.util.List;
 
 public class EndpointShieldLogsDao extends AccountsContextDao<EndpointShieldLog> {
-    
+
+    public static final long CAPPED_SIZE_IN_BYTES = 100_000_000L; // 100MB
+
     public static final EndpointShieldLogsDao instance = new EndpointShieldLogsDao();
-    
+
     private EndpointShieldLogsDao() {}
 
     @Override
@@ -39,12 +43,24 @@ public class EndpointShieldLogsDao extends AccountsContextDao<EndpointShieldLog>
         };
 
         if (!exists) {
-            db.createCollection(getCollName());
+            if (DbMode.allowCappedCollections()) {
+                db.createCollection(getCollName(), new CreateCollectionOptions().capped(true).sizeInBytes(CAPPED_SIZE_IN_BYTES));
+            } else {
+                db.createCollection(getCollName());
+            }
+        } else if (DbMode.allowCappedCollections() && !isCapped()) {
+            convertToCappedCollection(CAPPED_SIZE_IN_BYTES);
         }
 
-        MCollection.createIndexIfAbsent(getDBName(), getCollName(), new String[] { EndpointShieldLog.TIMESTAMP }, false);
-        MCollection.createIndexIfAbsent(getDBName(), getCollName(), new String[] { EndpointShieldLog.AGENT_ID}, false);
-        MCollection.createIndexIfAbsent(getDBName(), getCollName(), new String[] { EndpointShieldLog.DEVICE_ID }, false);
+        // Single secondary index, matching master. Every real query is served by the API-serving
+        // dashboard (not these job-runner instances): it targets one (agentId, key) partition and
+        // sorts+ranges on _id, so {agentId, key, _id} serves it with no in-memory sort. The
+        // previously-created {timestamp}, {agentId} and {deviceId} indexes are dropped to cut write
+        // amplification on this now-capped, high-write collection.
+        // NOTE: the key field is referenced by literal ("key") rather than EndpointShieldLog.KEY
+        // because Log.KEY is not present on all of these job branches; the resulting index is
+        // identical to master's.
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(), new String[] { EndpointShieldLog.AGENT_ID, "key", MCollection.ID }, false);
     }
     public List<EndpointShieldLog> findByAgentId(String agentId) {
         Bson filter = Filters.eq(EndpointShieldLog.AGENT_ID, agentId);


### PR DESCRIPTION
## What
Port the endpoint-shield log capping + index cleanup from master (`a104c00576`) to this job-runner branch.

- `logs_endpoint_shield` is now created as / converted to a **100 MB capped collection**, guarded by `DbMode.allowCappedCollections()` (DocumentDB/Cosmos fall back to a plain collection).
- Reduced to a **single `{agentId, key, _id}` index**, matching master. Dropped the previously-created `{timestamp}`, `{agentId}` and `{deviceId}` indexes to cut write amplification on this high-write collection.

## Why this branch
These branches run the jobs (`AKTO_RUN_JOB`) that perform DAO init / `createIndices` in production; they do **not** serve the dashboard APIs. So the index set they create must match what the API-serving dashboard (master) queries — hence porting master's index set verbatim.

## Notes
- **DAO-only** change. No `EndpointShieldAgentAction` change (these branches don't serve that query) and no Liquibase migration (the `account/` changelog dir doesn't exist on this branch).
- The key field is referenced by the string literal `"key"` instead of `EndpointShieldLog.KEY`, because `Log.KEY` isn't present on all of these branches; the resulting index is byte-identical to master's.
- `convertToCapped` on an existing large collection performs a locking server-side clone (and drops non-`_id` indexes, which are then rebuilt) — roll out in a maintenance window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
