### PR TITLE
Fix Agentic assets page-level time filter for inventory and metrics.

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
@@ -23,7 +23,7 @@ import {
   InteractionsCellRenderer,
   GroupCellRenderer,
 } from "./AgenticCellRenderers";
-import { cumulativeByMonth } from "./agenticPageBuilders";
+import { cumulativeByMonth, filterAssetsByLastSeen } from "./agenticPageBuilders";
 import SmoothAreaChart from "@/apps/dashboard/pages/dashboard/new_components/SmoothChart";
 import SpinnerCentered from "@/apps/dashboard/components/progress/SpinnerCentered";
 import "../../../components/layouts/style.css";
@@ -331,7 +331,7 @@ export default function AgenticAssetsPage() {
     }
   }, [navigate]);
 
-  // Date range — only data with real time fields is filtered (violations + last-seen)
+  // Date range — scopes inventory (last-seen), violations, and charts page-wide
   const [currDateRange, dispatchCurrDateRange] = useReducer(
     produce((draft, action) => func.dateRangeReducer(draft, action)),
     values.ranges[4],
@@ -404,8 +404,19 @@ export default function AgenticAssetsPage() {
           },
         );
 
-        setAgenticTreeData(pageData.agenticTreeData);
-        setAgenticFlatData(pageData.agenticFlatData);
+        const treeData = filterAssetsByLastSeen(
+          pageData.agenticTreeData,
+          startTimestamp,
+          endTimestamp,
+        );
+        const flatData = filterAssetsByLastSeen(
+          pageData.agenticFlatData,
+          startTimestamp,
+          endTimestamp,
+        );
+
+        setAgenticTreeData(treeData);
+        setAgenticFlatData(flatData);
         setAssetDevices(pageData.assetDevices);
         setAgenticViolationRows(violationRows);
         setCollections(collections);
@@ -639,11 +650,8 @@ export default function AgenticAssetsPage() {
   ], [violationTotals]);
 
   const assetSeries = useMemo(() =>
-    anchorSeriesToTotal(
-      cumulativeByMonth(agenticFlatData, r => r.lastSeenEpoch || 0, startTimestamp, endTimestamp),
-      totalAssets,
-    ),
-    [agenticFlatData, startTimestamp, endTimestamp, totalAssets, anchorSeriesToTotal],
+    cumulativeByMonth(agenticFlatData, r => r.lastSeenEpoch || 0, startTimestamp, endTimestamp),
+    [agenticFlatData, startTimestamp, endTimestamp],
   );
 
   const assetDelta = useMemo(() => windowDelta(assetSeries.counts), [assetSeries.counts, windowDelta]);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/agenticPageBuilders.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/agenticPageBuilders.js
@@ -361,6 +361,20 @@ function buildModuleDeviceMap(moduleInfos = []) {
 }
 
 /**
+ * Keep assets whose Last Seen falls in [startTimestamp, endTimestamp].
+ * When startTimestamp <= 0 (all-time), returns rows unchanged.
+ * Rows with missing/zero lastSeenEpoch are excluded when a range is active.
+ */
+export function filterAssetsByLastSeen(rows, startTimestamp, endTimestamp) {
+    if (!rows?.length || startTimestamp <= 0) return rows || [];
+    const end = endTimestamp > 0 ? endTimestamp : Math.floor(Date.now() / 1000);
+    return rows.filter((r) => {
+        const ts = r?.lastSeenEpoch || 0;
+        return ts >= startTimestamp && ts <= end;
+    });
+}
+
+/**
  * Bucket a list of items into 12 monthly slots covering the given time window.
  * Each slot counts how many items fall in that calendar month.
  * If startTimestamp is 0 (all-time), uses the earliest item's month as the window start.


### PR DESCRIPTION
Apply the date range to asset rows by lastSeen so the table and Agentic Assets header count follow the selected window, not only violations.