### PR TITLE
Enable same-page table filter on Guardrail Activity chart clicks.

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDetectionPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDetectionPage.jsx
@@ -27,6 +27,7 @@ import { LABELS } from "./constants";
 import useThreatReportDownload from "../../hooks/useThreatReportDownload";
 import WebhookIntegrationModal from "./components/WebhookIntegrationModal";
 import { updateThreatFiltersStore } from "./utils/threatFilters";
+import { applyThreatActivityTableFilter } from "./utils/threatDashboardUtils";
 import { redactSampleDataByKeywords } from "./utils/redactSampleData";
 import { resolveComplianceClauseMap, extractBehaviour } from "./utils/formatUtils";
 import LocalStore from "@/apps/main/LocalStorageStore";
@@ -45,7 +46,7 @@ const convertToGraphData = (severityMap) => {
         let text = func.toSentenceCase(x)
         const value =  severityMap[x]
         dataArr.push({
-            text, value, color
+            text, value, color, filterKey: x
         })
     })
     return dataArr
@@ -145,13 +146,14 @@ const flaggedData = [
     }
 ]
 
-const ChartComponent = ({ subCategoryCount, severityCountMap }) => {
+const ChartComponent = ({ subCategoryCount, severityCountMap, onThreatTypeClick, onSeverityClick }) => {
     return (
       <VerticalStack gap={4} columns={2}>
         <HorizontalGrid gap={4} columns={2}>
           <TopThreatTypeChart
             key={"top-threat-types"}
             data={subCategoryCount}
+            onBarClick={onThreatTypeClick}
           />
           <InfoCard
                 title={`${mapLabel("Threat", getDashboardCategory())} by severity`}
@@ -171,6 +173,7 @@ const ChartComponent = ({ subCategoryCount, severityCountMap }) => {
                         showGridLines={true}
                         barWidth={100 - (severityCountMap.length * 6)}
                         barGap={12}
+                        onBarClick={onSeverityClick}
                     />
                 }
             />
@@ -254,6 +257,31 @@ function ThreatDetectionPage() {
     
     const [eventState, setEventState] = useState(initialEventState);
     const [triggerTableRefresh, setTriggerTableRefresh] = useState(0)
+
+    const applyChartTableFilter = useCallback((filterKey, filterValue, label) => {
+        if (!filterValue) return;
+        const result = applyThreatActivityTableFilter(filterKey, filterValue);
+        if (!result) return;
+        const params = new URLSearchParams(location.search);
+        if (result.filterStr) {
+            params.set("filters", result.filterStr);
+        } else {
+            params.delete("filters");
+        }
+        navigate({ pathname: location.pathname, search: params.toString(), hash: location.hash }, { replace: true });
+        func.setToast(true, false, `Table filtered by "${label || result.resolvedValue}" — scroll down to view results`);
+        // Remount after navigate updates location so GithubServerTable reads the new filters= param
+        setTimeout(() => setTriggerTableRefresh(prev => prev + 1), 0);
+    }, [navigate, location.pathname, location.search, location.hash]);
+
+    const handleThreatTypeClick = useCallback((_name, custom) => {
+        applyChartTableFilter('latestAttack', custom?.filterKey, _name);
+    }, [applyChartTableFilter]);
+
+    const handleSeverityClick = useCallback((_name, custom) => {
+        applyChartTableFilter('severity', custom?.filterKey, _name);
+    }, [applyChartTableFilter]);
+
     const initialVal = useMemo(() => {
         // Support navigation from dashboard with period passed via location state
         const period = location.state?.period;
@@ -691,7 +719,12 @@ function ThreatDetectionPage() {
 
     // Normal mode - show table, charts, and sidebar
     const components = [
-        <ChartComponent subCategoryCount={subCategoryCount} severityCountMap={severityCountMap} />,
+        <ChartComponent
+            subCategoryCount={subCategoryCount}
+            severityCountMap={severityCountMap}
+            onThreatTypeClick={handleThreatTypeClick}
+            onSeverityClick={handleSeverityClick}
+        />,
         ...((isEndpointSecurityCategory() || isAgenticSecurityCategory()) && window.USER_NAME?.includes('@akto.io') ? [
             <P95LatencyGraph
                 key="threat-detection-latency"

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/TopThreatTypeChart.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/components/TopThreatTypeChart.jsx
@@ -3,7 +3,7 @@ import InfoCard from "../../dashboard/new_components/InfoCard";
 import BarGraph from "../../../components/charts/BarGraph";
 import { getDashboardCategory, mapLabel } from "../../../../main/labelHelper";
 
-const TopThreatTypeChart = ({ data }) => {
+const TopThreatTypeChart = ({ data, onBarClick }) => {
   const [chartData, setChartData] = useState([]);
   useEffect(() => {
     const chartData = data
@@ -12,6 +12,7 @@ const TopThreatTypeChart = ({ data }) => {
         text: x.text.replaceAll("_", " "),
         value: x.value,
         color: x.color,
+        filterKey: x.filterKey,
       }));
     setChartData(chartData);
   }, [data]);
@@ -35,6 +36,7 @@ const TopThreatTypeChart = ({ data }) => {
           barWidth={100 - (data.length * 6)}
           barGap={12}
           showGridLines={true}
+          onBarClick={onBarClick}
         />
       }
     />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/transform.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/transform.js
@@ -29,6 +29,7 @@ const threatDetectionFunc = {
                   text: usedName,
                   value: subCategoryRes[x],
                   color: "#A5B4FC",
+                  filterKey: x,
                 };
             })
     

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/utils/threatDashboardUtils.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/utils/threatDashboardUtils.js
@@ -1,5 +1,6 @@
 import { flags } from "../components/flags/index.mjs";
 import SessionStore from "../../../../main/SessionStore";
+import PersistStore from "../../../../main/PersistStore";
 import { getDashboardCategory, categoryToShortName } from "../../../../main/labelHelper";
 
 // New tab starts with a fresh PersistStore, so carry the category via ?category= (see ThreatReport.jsx).
@@ -49,6 +50,53 @@ export const countryCodeToName = (code) => {
 export const getFlagSrc = (countryCode) => {
     if (!countryCode) return flags["earth"];
     return countryCode in flags ? flags[countryCode] : flags["earth"];
+};
+
+/**
+ * Apply a single filter dimension on the Threat/Guardrail Activity table (same page).
+ * Replaces only the given filter key; keeps all other applied filters.
+ * Page key matches GithubServerTable: pathname + "/" + hash.
+ * Returns { resolvedValue, filterStr } so the caller can sync the filters= URL via react-router.
+ */
+export const applyThreatActivityTableFilter = (filterKey, filterValue) => {
+    if (!filterKey || filterValue == null || filterValue === '') return null;
+    const resolvedValue = filterKey === 'latestAttack'
+        ? subCategoryToFilterId(filterValue)
+        : filterValue;
+    const pageKey = window.location.pathname + "/" + window.location.hash;
+    const prev = PersistStore.getState().filtersMap || {};
+    const fromStore = (prev[pageKey]?.filters || []).filter(f => f.key !== filterKey);
+
+    const params = new URLSearchParams(window.location.search);
+    const urlFiltersStr = decodeURIComponent(params.get("filters") || "");
+    const fromUrl = (urlFiltersStr ? urlFiltersStr.split("&").filter(Boolean) : [])
+        .map((part) => {
+            const [key, valuesStr = ""] = part.split("__");
+            const clean = valuesStr.replace("|negated", "");
+            return { key, value: clean.split(",").filter(Boolean) };
+        })
+        .filter((f) => f.key && f.key !== filterKey);
+
+    const storeKeys = new Set(fromStore.map((f) => f.key));
+    const mergedOthers = [...fromStore, ...fromUrl.filter((f) => !storeKeys.has(f.key))];
+    const newFilters = [...mergedOthers, { key: filterKey, value: [resolvedValue] }];
+
+    PersistStore.getState().setFiltersMap({
+        ...prev,
+        [pageKey]: {
+            filters: newFilters,
+            sort: prev[pageKey]?.sort || [],
+        },
+    });
+
+    const filterStr = newFilters.map((f) => {
+        const vals = Array.isArray(f.value)
+            ? f.value.join(",")
+            : (f.value?.values ? f.value.values.join(",") : f.value);
+        return `${f.key}__${vals}`;
+    }).join("&");
+
+    return { resolvedValue, filterStr };
 };
 
 export const openThreatActivityPage = (filters = {}) => {


### PR DESCRIPTION
Wire Top Guardrail Types and severity bars to filter the activity table in place so users can drill down without opening a new tab.