### PR TITLE
chore: debug logging for endpoint-shield capped collection init

### DIFF
--- a/libs/dao/src/main/java/com/akto/DaoInit.java
+++ b/libs/dao/src/main/java/com/akto/DaoInit.java
@@ -107,6 +107,7 @@ import org.bson.codecs.pojo.ClassModel;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.akto.dao.context.Context;
 
 import static com.akto.dao.MCollection.clients;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
@@ -445,6 +446,8 @@ public class DaoInit {
     }
 
     public static void createIndices() {
+        logger.info("[initCheck] DaoInit.createIndices() ENTER for account={} dbType={} allowCappedCollections={} setupType={}",
+                Context.accountId.get(), DbMode.dbType, DbMode.allowCappedCollections(), DbMode.setupType);
         try {
             TestingRunResultDao.instance.convertToCappedCollection();
         } catch (Exception e) {
@@ -496,6 +499,7 @@ public class DaoInit {
         McpAuditInfoDao.instance.createIndicesIfAbsent();
         McpReconRequestDao.instance.createIndicesIfAbsent();
         GuardrailPoliciesDao.instance.createIndicesIfAbsent();
+        logger.info("[initCheck] calling EndpointShieldLogsDao.createIndicesIfAbsent() for account={}", Context.accountId.get());
         EndpointShieldLogsDao.instance.createIndicesIfAbsent();
         AgentConversationDao.instance.createIndexIfAbsent();
         AgentConversationResultDao.instance.createIndexIfAbsent();

--- a/libs/dao/src/main/java/com/akto/dao/monitoring/EndpointShieldLogsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/monitoring/EndpointShieldLogsDao.java
@@ -9,11 +9,17 @@ import com.akto.util.DbMode;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.Filters;
+import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class EndpointShieldLogsDao extends AccountsContextDao<EndpointShieldLog> {
+
+    private static final Logger logger = LoggerFactory.getLogger(EndpointShieldLogsDao.class);
+    private static final String LOG_PREFIX = "[EndpointShieldLogsDao.capped]";
 
     public static final long CAPPED_SIZE_IN_BYTES = 100_000_000L; // 100MB
 
@@ -42,14 +48,29 @@ public class EndpointShieldLogsDao extends AccountsContextDao<EndpointShieldLog>
             }
         };
 
+        boolean allowCapped = DbMode.allowCappedCollections();
+        boolean cappedBefore = exists && isCapped();
+        logger.info("{} account={} coll={} exists={} allowCappedCollections={} isCapped(before)={} dbType={}",
+                LOG_PREFIX, dbName, getCollName(), exists, allowCapped, cappedBefore, DbMode.dbType);
+
         if (!exists) {
-            if (DbMode.allowCappedCollections()) {
+            if (allowCapped) {
                 db.createCollection(getCollName(), new CreateCollectionOptions().capped(true).sizeInBytes(CAPPED_SIZE_IN_BYTES));
+                logger.info("{} action=CREATE_CAPPED size={} isCapped(after)={}", LOG_PREFIX, CAPPED_SIZE_IN_BYTES, isCapped());
             } else {
                 db.createCollection(getCollName());
+                logger.info("{} action=CREATE_PLAIN (capped disabled for dbType={})", LOG_PREFIX, DbMode.dbType);
             }
-        } else if (DbMode.allowCappedCollections() && !isCapped()) {
-            convertToCappedCollection(CAPPED_SIZE_IN_BYTES);
+        } else if (allowCapped && !cappedBefore) {
+            logger.info("{} action=CONVERT_TO_CAPPED size={} — existing collection is not capped", LOG_PREFIX, CAPPED_SIZE_IN_BYTES);
+            try {
+                Document result = convertToCappedCollection(CAPPED_SIZE_IN_BYTES);
+                logger.info("{} convertToCapped runCommand result={} isCapped(after)={}", LOG_PREFIX, result, isCapped());
+            } catch (Exception e) {
+                logger.error("{} convertToCapped FAILED: {}", LOG_PREFIX, e.getMessage(), e);
+            }
+        } else {
+            logger.info("{} action=SKIP (exists={} allowCapped={} cappedBefore={})", LOG_PREFIX, exists, allowCapped, cappedBefore);
         }
 
         // Single secondary index, matching master. Every real query is served by the API-serving
@@ -61,6 +82,8 @@ public class EndpointShieldLogsDao extends AccountsContextDao<EndpointShieldLog>
         // because Log.KEY is not present on all of these job branches; the resulting index is
         // identical to master's.
         MCollection.createIndexIfAbsent(getDBName(), getCollName(), new String[] { EndpointShieldLog.AGENT_ID, "key", MCollection.ID }, false);
+        logger.info("{} createIndicesIfAbsent DONE for account={} coll={} (isCapped={})",
+                LOG_PREFIX, dbName, getCollName(), isCapped());
     }
     public List<EndpointShieldLog> findByAgentId(String agentId) {
         Bson filter = Filters.eq(EndpointShieldLog.AGENT_ID, agentId);


### PR DESCRIPTION
## What
Adds INFO-level debug logging to diagnose why `logs_endpoint_shield` capping isn't taking effect in prod on this job branch (backs container `infra_important-crons_1`). **Logging only — no behavioural change** to the capping/index logic.

## Log markers
Grep the container with:
```
docker logs infra_important-crons_1 2>&1 | grep -F -e "[initCheck]" -e "[EndpointShieldLogsDao.capped]"
```

- `DaoInit.createIndices()` — logs `account`, **`dbType`**, **`allowCappedCollections`**, `setupType` on entry (per account), and logs right before calling the endpoint-shield DAO.
- `EndpointShieldLogsDao.createIndicesIfAbsent()` — logs `exists` / `allowCapped` / `isCapped(before)` / `dbType`, the `action` taken (`CREATE_CAPPED` / `CREATE_PLAIN` / `CONVERT_TO_CAPPED` / `SKIP`), the raw `convertToCapped` result, and `isCapped(after)`. The convert call is now wrapped in try/catch so a failure is logged at ERROR instead of propagating.

## Why
The initializer is confirmed running for all accounts (backward-compat logs), and the capping code is already merged here — yet capping isn't working. These logs pin down whether `allowCappedCollections`/`dbType` disables it, or the convert runs but doesn't take.

## Verification
`mvn package --projects :dashboard --also-make -DskipTests` → BUILD SUCCESS on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)