### PR TITLE
Account Id added for new violations layout access

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
@@ -397,9 +397,7 @@ function ViolationsDashboard({ summaryData, loading: summaryLoading, onSeverityC
     // Latency graph is Akto-internal only (matches the same gate on ThreatDetectionPage.jsx).
     // Everyone else gets Open/Other Violations side by side instead of stacked, since there's
     // no third column to fill the space next to them.
-    // TEMP: forced off to preview the non-Akto layout — revert before shipping.
-    // const isAktoUser = window.USER_NAME?.includes('@akto.io');
-    const isAktoUser = false;
+    const isAktoUser = window.USER_NAME?.includes('@akto.io');
 
     const openCard = (
         <Box

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDetectionPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDetectionPage.jsx
@@ -354,7 +354,7 @@ function ThreatDetectionPage() {
     const [pendingRowContext, setPendingRowContext] = useState(null);
 
     const threatFiltersMap = SessionStore((state) => state.threatFiltersMap);
-    const showNewLayoutToggle = func.isDemoAccount() && isEndpointSecurityCategory();
+    const showNewLayoutToggle = (func.isDemoAccount() || window.ACTIVE_ACCOUNT === 1726615470) && isEndpointSecurityCategory();
     const newLayout = LocalStore((state) => state.guardrailViolationsNewLayout);
     const setGuardrailViolationsNewLayout = LocalStore((state) => state.setGuardrailViolationsNewLayout);
 


### PR DESCRIPTION
Adds account 1726615470 to the new Violations layout gate on both places it needs to be:

- `ViolationsPage.jsx` — allows staying on the new layout.
- `ThreatDetectionPage.jsx` — shows the "New Layout" opt-in toggle on the legacy page, without which the setting could never actually be turned on for this account.

Also reverts the leftover `isAktoUser = false` debug override (used to preview the non-Akto layout) that was accidentally left in.