### PR TITLE
Fix agentic device last seen

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
@@ -109,7 +109,7 @@ const COL_DEFS = [
   {
     field: "violations",
     headerName: "Violations",
-    width: 160,
+    width: 200,
     sortable: true,
     filter: false,
     cellRenderer: ViolationsCellRenderer,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticCellRenderers.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticCellRenderers.jsx
@@ -120,7 +120,7 @@ export function ViolationsCellRenderer({ value }) {
     const parts = ["critical", "high", "medium", "low"].filter((k) => value[k] > 0);
     if (!parts.length) return dash;
     return (
-        <HorizontalStack gap="1" blockAlign="center">
+        <HorizontalStack gap="1" blockAlign="center" wrap={false}>
             {parts.map((k) => <SeverityBadge key={k} severity={k}>{value[k]}</SeverityBadge>)}
         </HorizontalStack>
     );

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceEndpoints.jsx
@@ -200,7 +200,7 @@ function ViolationsCellRenderer({ value }) {
     const parts = ["critical", "high", "medium", "low"].filter(k => value[k] > 0);
     if (!parts.length) return null;
     return (
-        <HorizontalStack gap="1" blockAlign="center">
+        <HorizontalStack gap="1" blockAlign="center" wrap={false}>
             {parts.map(k => <SeverityBadge key={k} severity={k}>{value[k]}</SeverityBadge>)}
         </HorizontalStack>
     );
@@ -313,7 +313,7 @@ function buildDeviceColDefs(agentRiskData) {
     {
         field: "violations",
         headerName: "Violations",
-        width: 160,
+        width: 200,
         sortable: true,
         filter: false,
         cellRenderer: ViolationsCellRenderer,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -754,7 +754,7 @@ function buildTeamGroupsForAsset(group, usernameMap, userMetadataMap) {
     return Object.entries(teamCounts).map(([name, count]) => ({ name, count }));
 }
 
-function buildDevicesForGroup(group, usernameMap = {}, riskScoreMap = {}) {
+function buildDevicesForGroup(group, usernameMap = {}, riskScoreMap = {}, trafficMap = {}) {
     const byDevice = new Map();
     (group.collections || []).forEach((c) => {
         const hostName = c.hostName || c.displayName || c.name;
@@ -762,24 +762,25 @@ function buildDevicesForGroup(group, usernameMap = {}, riskScoreMap = {}) {
         if (!deviceId) return;
         const serviceName = extractServiceName(hostName);
         const collRisk = riskScoreMap[c.id] || 0;
+        const collTraffic = trafficMap[c.id] || 0;
         if (!byDevice.has(deviceId)) {
             const resolved = getResolvedUsernameForCollection(c, usernameMap);
             const username = (resolved && resolved !== DEFAULT_VALUE) ? resolved : "";
-            const maxTraffic = group.detectedTimestamp || 0;
             byDevice.set(deviceId, {
                 deviceId,
                 endpoint: deviceId,
                 username,
                 os: null,
                 riskScore: collRisk,
-                lastSeen: maxTraffic > 0 ? func.prettifyEpoch(maxTraffic) : "-",
-                lastSeenEpoch: maxTraffic,
+                lastSeenEpoch: collTraffic,
                 services: [],
             });
         }
         const entry = byDevice.get(deviceId);
         // accumulate max risk across all collections this device appears in
         if (collRisk > (entry.riskScore || 0)) entry.riskScore = collRisk;
+        // accumulate max traffic timestamp across all collections this device appears in
+        if (collTraffic > (entry.lastSeenEpoch || 0)) entry.lastSeenEpoch = collTraffic;
         if (serviceName && !entry.services.includes(serviceName)) {
             entry.services.push(serviceName);
         }
@@ -788,6 +789,7 @@ function buildDevicesForGroup(group, usernameMap = {}, riskScoreMap = {}) {
     return [...byDevice.values()].map(d => ({
         ...d,
         riskScore: d.riskScore > 0 ? Math.round(d.riskScore * 10) / 10 : null,
+        lastSeen: d.lastSeenEpoch > 0 ? func.formatChatTimestamp(d.lastSeenEpoch) : "-",
     }));
 }
 
@@ -916,7 +918,7 @@ export function buildAgenticAssetsPageData(
         // that declares them, not to the skill itself. Suppress to avoid double-counting.
         const violations = violationsForCollections(collectionIds, violationsByCollectionId);
         const groups = buildTeamGroupsForAsset(group, usernameMap, userMetadataMap);
-        const devices = buildDevicesForGroup(group, usernameMap, riskScoreMap);
+        const devices = buildDevicesForGroup(group, usernameMap, riskScoreMap, trafficMap);
         const skillNames = uniqueSkillNamesForGroup(group);
         const riskScore = group.riskScore ?? group.maxRiskScore ?? null;
         const lastSeen = group.detectedTimestamp || 0;


### PR DESCRIPTION
Each device row in the agentic asset Devices tab was showing the whole agent group's max traffic timestamp instead of its own, so a stale device could display a falsely recent last seen time. Also fixes the Violations column wrapping onto two lines when all four severities are present.