### PR TITLE
Fix violations tab loading

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/ViolationsTab.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/ViolationsTab.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { Box, VerticalStack, Text } from "@shopify/polaris";
 import AgGridTable from "@/apps/dashboard/components/tables/AgGridTable";
+import SpinnerCentered from "@/apps/dashboard/components/progress/SpinnerCentered";
 import { SeverityBadge } from "./AgenticCellRenderers";
 import { fetchAgenticViolations, openViolationInThreatActivity, deviceServiceKey, isClaudeConfigHost } from "./agenticObserveApi";
 import func from "@/util/func";
@@ -32,21 +33,22 @@ const GRID_DEFAULT_COL = { sortable: true, resizable: true, filter: false };
 
 export default function ViolationsTab({ asset, collections = [], startTimestamp, endTimestamp, onViolationClick }) {
     const [violations, setViolations] = useState([]);
+    const [loading, setLoading] = useState(true);
 
     // Reset immediately when the asset changes so stale rows from the previous asset
     // are never visible while the new fetch is in flight.
-    useEffect(() => { setViolations([]); }, [asset?.id]);
+    useEffect(() => { setViolations([]); setLoading(true); }, [asset?.id]);
 
     useEffect(() => {
         const isClaudeAsset = asset?.assetTagValue?.toLowerCase() === "claude";
         if (!asset?.collectionIds?.length || !collections.length) {
-            if (!isClaudeAsset) { setViolations([]); return; }
+            if (!isClaudeAsset) { setViolations([]); setLoading(false); return; }
         }
 
         const ids = new Set((asset.collectionIds || []).map(Number));
         const hostNames = collections.filter(c => ids.has(Number(c.id)) && c.hostName).map(c => c.hostName);
 
-        if (!hostNames.length && !isClaudeAsset) { setViolations([]); return; }
+        if (!hostNames.length && !isClaudeAsset) { setViolations([]); setLoading(false); return; }
 
         // Collect device IDs that have a claude-type collection among this asset's collections.
         // This covers both direct Claude AI Agent assets and Skills/MCPs whose collections
@@ -77,9 +79,10 @@ export default function ViolationsTab({ asset, collections = [], startTimestamp,
                     time: r.timeEpoch ? func.formatChatTimestamp(r.timeEpoch) : "",
                     deviceId: r.host ? r.host.split(".")[0] : "",
                 })));
+                setLoading(false);
             })
             .catch(() => {
-                if (!cancelled) setViolations([]);
+                if (!cancelled) { setViolations([]); setLoading(false); }
             });
         return () => { cancelled = true; };
     }, [asset?.id, asset?.assetTagValue, asset?.collectionIds, collections, startTimestamp, endTimestamp]);
@@ -92,6 +95,10 @@ export default function ViolationsTab({ asset, collections = [], startTimestamp,
             openViolationInThreatActivity(e.data);
         }
     }, [onViolationClick]);
+
+    if (loading) {
+        return <SpinnerCentered height="200px" />;
+    }
 
     if (violations.length === 0) {
         return (

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/ViolationsTab.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/ViolationsTab.jsx
@@ -33,13 +33,10 @@ const GRID_DEFAULT_COL = { sortable: true, resizable: true, filter: false };
 
 export default function ViolationsTab({ asset, collections = [], startTimestamp, endTimestamp, onViolationClick }) {
     const [violations, setViolations] = useState([]);
-    const [loading, setLoading] = useState(true);
-
-    // Reset immediately when the asset changes so stale rows from the previous asset
-    // are never visible while the new fetch is in flight.
-    useEffect(() => { setViolations([]); setLoading(true); }, [asset?.id]);
+    const [loading, setLoading] = useState(false);
 
     useEffect(() => {
+        setLoading(true);
         const isClaudeAsset = asset?.assetTagValue?.toLowerCase() === "claude";
         if (!asset?.collectionIds?.length || !collections.length) {
             if (!isClaudeAsset) { setViolations([]); setLoading(false); return; }


### PR DESCRIPTION
Violations tab showed the No violations empty state immediately on open, then swapped in real rows a few seconds later once the fetch resolved, since there was no way to tell "not fetched yet" apart from "fetched and confirmed zero". Adds a loading state that shows a spinner while the fetch is in flight, and only falls back to the empty state once the API confirms there are no violations.