### PR TITLE
Browser Extension settings revamp + config-driven account rows

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
@@ -186,13 +186,13 @@ public class BrowserExtensionConfigAction extends UserAction {
             addIfPresent(updates, BrowserExtensionConfig.TRANSPORT, emptyToNull(browserExtensionConfig.getTransport()));
             addIfPresent(updates, BrowserExtensionConfig.METHOD, emptyToNull(browserExtensionConfig.getMethod()));
             addIfPresent(updates, BrowserExtensionConfig.FORMAT, emptyToNull(browserExtensionConfig.getFormat()));
-            addIfPresent(updates, BrowserExtensionConfig.PATH, nonEmptyObject(browserExtensionConfig.getPath()));
+            addIfPresent(updates, BrowserExtensionConfig.PATH, nonEmpty(browserExtensionConfig.getPath()));
             addIfPresent(updates, BrowserExtensionConfig.OPERATIONS, nonEmpty(browserExtensionConfig.getOperations()));
             addIfPresent(updates, BrowserExtensionConfig.FRAME_MATCH,
                 (browserExtensionConfig.getFrameMatch() != null && !browserExtensionConfig.getFrameMatch().isEmpty()) ? browserExtensionConfig.getFrameMatch() : null);
             addIfPresent(updates, BrowserExtensionConfig.RESPONSE_FORMAT, emptyToNull(browserExtensionConfig.getResponseFormat()));
-            addIfPresent(updates, BrowserExtensionConfig.RESPONSE_PATH, nonEmptyObject(browserExtensionConfig.getResponsePath()));
-            addIfPresent(updates, BrowserExtensionConfig.MODEL_PATH, nonEmptyObject(browserExtensionConfig.getModelPath()));
+            addIfPresent(updates, BrowserExtensionConfig.RESPONSE_PATH, nonEmpty(browserExtensionConfig.getResponsePath()));
+            addIfPresent(updates, BrowserExtensionConfig.MODEL_PATH, nonEmpty(browserExtensionConfig.getModelPath()));
 
             BrowserExtensionConfigDao.instance.getMCollection().updateOne(
                 filter,
@@ -249,16 +249,5 @@ public class BrowserExtensionConfigAction extends UserAction {
 
     private static <T> List<T> nonEmpty(List<T> list) {
         return (list == null || list.isEmpty()) ? null : list;
-    }
-
-    // path/responsePath/modelPath are polymorphic (a String or a List); drop only when empty/blank.
-    private static Object nonEmptyObject(Object value) {
-        if (value instanceof List) {
-            return ((List<?>) value).isEmpty() ? null : value;
-        }
-        if (value instanceof String) {
-            return ((String) value).trim().isEmpty() ? null : ((String) value).trim();
-        }
-        return value;
     }
 }

--- a/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
@@ -47,10 +47,8 @@ public class BrowserExtensionConfigAction extends UserAction {
     @Setter
     private String hexId;
 
-    // account rows are read through the tolerant common mapper (their `path`/`modelPath` are
-    // polymorphic and would break the pojo codec), so both lists are BrowserExtensionConfigCommon.
     @Getter
-    private List<BrowserExtensionConfigCommon> browserExtensionConfigs;
+    private List<BrowserExtensionConfig> browserExtensionConfigs;
 
     @Getter
     private List<BrowserExtensionConfigCommon> browserExtensionConfigsCommon;
@@ -60,7 +58,7 @@ public class BrowserExtensionConfigAction extends UserAction {
 
     public String fetchBrowserExtensionConfigs() {
         try {
-            this.browserExtensionConfigs = BrowserExtensionConfigDao.instance.findAllSortedByCreatedTimestamp(0, 100);
+            this.browserExtensionConfigs = BrowserExtensionConfigDao.instance.findAllConfigs();
             return SUCCESS.toUpperCase();
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb("Error fetching browser extension configs: " + e.getMessage(), LogDb.DASHBOARD);
@@ -188,13 +186,13 @@ public class BrowserExtensionConfigAction extends UserAction {
             addIfPresent(updates, BrowserExtensionConfig.TRANSPORT, emptyToNull(browserExtensionConfig.getTransport()));
             addIfPresent(updates, BrowserExtensionConfig.METHOD, emptyToNull(browserExtensionConfig.getMethod()));
             addIfPresent(updates, BrowserExtensionConfig.FORMAT, emptyToNull(browserExtensionConfig.getFormat()));
-            addIfPresent(updates, BrowserExtensionConfig.PATH, nonEmpty(browserExtensionConfig.getPath()));
+            addIfPresent(updates, BrowserExtensionConfig.PATH, nonEmptyObject(browserExtensionConfig.getPath()));
             addIfPresent(updates, BrowserExtensionConfig.OPERATIONS, nonEmpty(browserExtensionConfig.getOperations()));
             addIfPresent(updates, BrowserExtensionConfig.FRAME_MATCH,
                 (browserExtensionConfig.getFrameMatch() != null && !browserExtensionConfig.getFrameMatch().isEmpty()) ? browserExtensionConfig.getFrameMatch() : null);
             addIfPresent(updates, BrowserExtensionConfig.RESPONSE_FORMAT, emptyToNull(browserExtensionConfig.getResponseFormat()));
-            addIfPresent(updates, BrowserExtensionConfig.RESPONSE_PATH, nonEmpty(browserExtensionConfig.getResponsePath()));
-            addIfPresent(updates, BrowserExtensionConfig.MODEL_PATH, nonEmpty(browserExtensionConfig.getModelPath()));
+            addIfPresent(updates, BrowserExtensionConfig.RESPONSE_PATH, nonEmptyObject(browserExtensionConfig.getResponsePath()));
+            addIfPresent(updates, BrowserExtensionConfig.MODEL_PATH, nonEmptyObject(browserExtensionConfig.getModelPath()));
 
             BrowserExtensionConfigDao.instance.getMCollection().updateOne(
                 filter,
@@ -251,5 +249,16 @@ public class BrowserExtensionConfigAction extends UserAction {
 
     private static <T> List<T> nonEmpty(List<T> list) {
         return (list == null || list.isEmpty()) ? null : list;
+    }
+
+    // path/responsePath/modelPath are polymorphic (a String or a List); drop only when empty/blank.
+    private static Object nonEmptyObject(Object value) {
+        if (value instanceof List) {
+            return ((List<?>) value).isEmpty() ? null : value;
+        }
+        if (value instanceof String) {
+            return ((String) value).trim().isEmpty() ? null : ((String) value).trim();
+        }
+        return value;
     }
 }

--- a/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
@@ -15,15 +15,30 @@ import com.mongodb.client.model.Updates;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class BrowserExtensionConfigAction extends UserAction {
 
     private static final LoggerMaker loggerMaker = new LoggerMaker(BrowserExtensionConfigAction.class, LogDb.DASHBOARD);
+
+    // When enabling a supported host we copy the WHOLE catalogue document into the account row, so any
+    // extraction field - present or added in future - flows through with no code change. This set is not
+    // that allow-list; it is only the fields the account row owns and that this method sets itself.
+    // Copying them would either be illegal (`_id` cannot be $set) or clash with the explicit $set below
+    // ("update path twice" error) - and `active` must come from the toggle, not the catalogue.
+    private static final Set<String> ACCOUNT_OWNED_FIELDS = new HashSet<>(Arrays.asList(
+        "_id", BrowserExtensionConfig.HOST, BrowserExtensionConfig.ACTIVE,
+        BrowserExtensionConfig.CREATED_BY, BrowserExtensionConfig.UPDATED_BY,
+        BrowserExtensionConfig.CREATED_TIMESTAMP, BrowserExtensionConfig.UPDATED_TIMESTAMP
+    ));
 
     @Getter
     @Setter
@@ -32,8 +47,10 @@ public class BrowserExtensionConfigAction extends UserAction {
     @Setter
     private String hexId;
 
+    // account rows are read through the tolerant common mapper (their `path`/`modelPath` are
+    // polymorphic and would break the pojo codec), so both lists are BrowserExtensionConfigCommon.
     @Getter
-    private List<BrowserExtensionConfig> browserExtensionConfigs;
+    private List<BrowserExtensionConfigCommon> browserExtensionConfigs;
 
     @Getter
     private List<BrowserExtensionConfigCommon> browserExtensionConfigsCommon;
@@ -84,9 +101,34 @@ public class BrowserExtensionConfigAction extends UserAction {
             updates.add(Updates.set(BrowserExtensionConfig.ACTIVE, browserExtensionConfig.isActive()));
             updates.add(Updates.set(BrowserExtensionConfig.UPDATED_TIMESTAMP, currentTime));
             updates.add(Updates.set(BrowserExtensionConfig.UPDATED_BY, user.getLogin()));
-            updates.add(Updates.setOnInsert(BrowserExtensionConfig.PATHS, new ArrayList<String>()));
             updates.add(Updates.setOnInsert(BrowserExtensionConfig.CREATED_BY, user.getLogin()));
             updates.add(Updates.setOnInsert(BrowserExtensionConfig.CREATED_TIMESTAMP, currentTime));
+
+            // Enabling a supported host copies its full extraction spec (transport, format, prompt
+            // path, response/model paths, …) from the common catalogue into the account row, so the
+            // extension gets a config-driven entry rather than a bare host+paths one. Falls back to
+            // an empty paths list on insert when the host is not in the catalogue.
+            boolean pathsSet = false;
+            if (browserExtensionConfig.isActive()) {
+                Document commonDoc = BrowserExtensionConfigCommonDao.instance.findRawByHost(host);
+                if (commonDoc != null) {
+                    for (String field : commonDoc.keySet()) {
+                        if (ACCOUNT_OWNED_FIELDS.contains(field)) {
+                            continue;
+                        }
+                        Object value = commonDoc.get(field);
+                        if (value != null) {
+                            updates.add(Updates.set(field, value));
+                            if (BrowserExtensionConfig.PATHS.equals(field)) {
+                                pathsSet = true;
+                            }
+                        }
+                    }
+                }
+            }
+            if (!pathsSet) {
+                updates.add(Updates.setOnInsert(BrowserExtensionConfig.PATHS, new ArrayList<String>()));
+            }
 
             BrowserExtensionConfigDao.instance.getMCollection().updateOne(
                 Filters.eq(BrowserExtensionConfig.HOST, host),

--- a/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
@@ -64,6 +64,47 @@ public class BrowserExtensionConfigAction extends UserAction {
         }
     }
 
+    // Enables/disables a host for this account by upserting an account-level override row keyed by host.
+    // Unlike saveBrowserExtensionConfig this needs no paths, since toggling a supported (common) host is
+    // only about the active flag - the paths come from the common catalogue.
+    public String setBrowserExtensionConfigActive() {
+        try {
+            if (browserExtensionConfig == null
+                    || browserExtensionConfig.getHost() == null
+                    || browserExtensionConfig.getHost().trim().isEmpty()) {
+                addActionError("Host is required");
+                return ERROR.toUpperCase();
+            }
+
+            User user = getSUser();
+            int currentTime = Context.now();
+            String host = browserExtensionConfig.getHost().trim();
+
+            List<Bson> updates = new ArrayList<>();
+            updates.add(Updates.set(BrowserExtensionConfig.ACTIVE, browserExtensionConfig.isActive()));
+            updates.add(Updates.set(BrowserExtensionConfig.UPDATED_TIMESTAMP, currentTime));
+            updates.add(Updates.set(BrowserExtensionConfig.UPDATED_BY, user.getLogin()));
+            updates.add(Updates.setOnInsert(BrowserExtensionConfig.PATHS, new ArrayList<String>()));
+            updates.add(Updates.setOnInsert(BrowserExtensionConfig.CREATED_BY, user.getLogin()));
+            updates.add(Updates.setOnInsert(BrowserExtensionConfig.CREATED_TIMESTAMP, currentTime));
+
+            BrowserExtensionConfigDao.instance.getMCollection().updateOne(
+                Filters.eq(BrowserExtensionConfig.HOST, host),
+                Updates.combine(updates),
+                new UpdateOptions().upsert(true)
+            );
+
+            loggerMaker.info("Set browser extension config active=" + browserExtensionConfig.isActive()
+                + " for host: " + host + " by user: " + user.getLogin());
+
+            return SUCCESS.toUpperCase();
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("Error toggling browser extension config: " + e.getMessage(), LogDb.DASHBOARD);
+            addActionError("Failed to update browser extension config");
+            return ERROR.toUpperCase();
+        }
+    }
+
     public String saveBrowserExtensionConfig() {
         try {
             if (browserExtensionConfig == null) {
@@ -99,6 +140,19 @@ public class BrowserExtensionConfigAction extends UserAction {
             updates.add(Updates.set(BrowserExtensionConfig.UPDATED_BY, user.getLogin()));
             updates.add(Updates.setOnInsert(BrowserExtensionConfig.CREATED_BY, user.getLogin()));
             updates.add(Updates.setOnInsert(BrowserExtensionConfig.CREATED_TIMESTAMP, currentTime));
+
+            // config-driven monitoring fields — set only what the client sent, so a plain
+            // host+paths config stays minimal and a rich one carries its full extraction spec.
+            addIfPresent(updates, BrowserExtensionConfig.TRANSPORT, emptyToNull(browserExtensionConfig.getTransport()));
+            addIfPresent(updates, BrowserExtensionConfig.METHOD, emptyToNull(browserExtensionConfig.getMethod()));
+            addIfPresent(updates, BrowserExtensionConfig.FORMAT, emptyToNull(browserExtensionConfig.getFormat()));
+            addIfPresent(updates, BrowserExtensionConfig.PATH, nonEmpty(browserExtensionConfig.getPath()));
+            addIfPresent(updates, BrowserExtensionConfig.OPERATIONS, nonEmpty(browserExtensionConfig.getOperations()));
+            addIfPresent(updates, BrowserExtensionConfig.FRAME_MATCH,
+                (browserExtensionConfig.getFrameMatch() != null && !browserExtensionConfig.getFrameMatch().isEmpty()) ? browserExtensionConfig.getFrameMatch() : null);
+            addIfPresent(updates, BrowserExtensionConfig.RESPONSE_FORMAT, emptyToNull(browserExtensionConfig.getResponseFormat()));
+            addIfPresent(updates, BrowserExtensionConfig.RESPONSE_PATH, nonEmpty(browserExtensionConfig.getResponsePath()));
+            addIfPresent(updates, BrowserExtensionConfig.MODEL_PATH, nonEmpty(browserExtensionConfig.getModelPath()));
 
             BrowserExtensionConfigDao.instance.getMCollection().updateOne(
                 filter,
@@ -141,5 +195,19 @@ public class BrowserExtensionConfigAction extends UserAction {
             addActionError("Failed to delete browser extension configs");
             return ERROR.toUpperCase();
         }
+    }
+
+    private static void addIfPresent(List<Bson> updates, String field, Object value) {
+        if (value != null) {
+            updates.add(Updates.set(field, value));
+        }
+    }
+
+    private static String emptyToNull(String s) {
+        return (s == null || s.trim().isEmpty()) ? null : s.trim();
+    }
+
+    private static <T> List<T> nonEmpty(List<T> list) {
+        return (list == null || list.isEmpty()) ? null : list;
     }
 }

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -2219,6 +2219,36 @@
             </result>
         </action>
 
+        <action name="api/setBrowserExtensionConfigActive" class="com.akto.action.BrowserExtensionConfigAction" method="setBrowserExtensionConfigActive">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <interceptor-ref name="usageInterceptor">
+                <param name="featureLabel">API_COLLECTIONS</param>
+            </interceptor-ref>
+            <interceptor-ref name="roleAccessInterceptor">
+                <param name="featureLabel">INTEGRATIONS</param>
+                <param name="accessType">READ_WRITE</param>
+                <param name="actionDescription">User toggled browser extension config</param>
+            </interceptor-ref>
+            <result name="FORBIDDEN" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="SUCCESS" type="json">
+            </result>
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="UNAUTHORIZED" type="json">
+                 <param name="statusCode">403</param>
+                 <param name="ignoreHierarchy">false</param>
+                 <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/saveBrowserExtensionConfig" class="com.akto.action.BrowserExtensionConfigAction" method="saveBrowserExtensionConfig">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/layouts/PageWithMultipleCards.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/layouts/PageWithMultipleCards.jsx
@@ -8,7 +8,7 @@ import { useEffect, useRef } from "react";
 
 const PageWithMultipleCards = (props) => {
 
-    const {backUrl, isFirstPage, title, subtitle, primaryAction, secondaryActions, divider, components, fullWidth} = props
+    const {backUrl, isFirstPage, title, titleMetadata, subtitle, primaryAction, secondaryActions, divider, components, fullWidth} = props
 
     const location = useLocation();
     const navigate = useNavigate()
@@ -126,6 +126,7 @@ const PageWithMultipleCards = (props) => {
     return (
         <Page fullWidth={fullWidth === undefined ? true: fullWidth}
             title={title}
+            titleMetadata={titleMetadata}
             subtitle={subtitle}
             backAction={getBackAction()}
             primaryAction={primaryAction}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/api.js
@@ -83,6 +83,15 @@ export default {
         return resp
     },
 
+    async setBrowserExtensionConfigActive(host, active) {
+        const resp = await request({
+            url: '/api/setBrowserExtensionConfigActive',
+            method: 'post',
+            data: { browserExtensionConfig: { host, active } }
+        })
+        return resp
+    },
+
     async saveBrowserExtensionConfig(browserExtensionConfig, hexId) {
         const resp = await request({
             url: '/api/saveBrowserExtensionConfig',

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -2,12 +2,12 @@
    (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
    both track the theme. */
 
-/* row spacing/layout comes from Box padding + HorizontalStack gap; only the hover, the divider
-   between rows, and the disabled dim have no Polaris prop equivalent. */
-.bext-row { border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
-.bext-row:first-child { border-top:0; }
-.bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
-.bext-row.off { opacity:.6; }
+/* rows are spaced cards (border/radius/padding via Box props); only the hover lift and the
+   disabled dim have no Polaris prop equivalent. */
+.bext-row { transition:background .12s, box-shadow .12s, border-color .12s; }
+.bext-row:hover { background:var(--p-color-bg-surface-hover,#f9fafb); border-color:var(--p-color-border-emphasis,#cfcfe6);
+  box-shadow:0 1px 3px rgba(17,20,28,.07); }
+.bext-row.off { opacity:.55; }
 
 /* lightweight theme-aware toggle (Polaris ships no native switch in this version) */
 .bext-switch { position:relative; flex:0 0 auto; width:30px; height:18px; border:0; padding:0; appearance:none;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -2,13 +2,15 @@
    (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
    both track the theme. */
 
-/* white list card lifted off the page background; container border/radius come from Box props */
-.bext-list { box-shadow:0 1px 2px rgba(17,20,28,.04), 0 4px 16px rgba(17,20,28,.05); }
-/* rows: spacing via Box padding; only the divider, hover and disabled dim have no Polaris prop */
-.bext-row { border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .12s; }
+.bext-list { border:1px solid var(--p-color-border,#e9ebf1); border-radius:14px; overflow:hidden;
+  background:var(--p-color-bg-surface,#fff); box-shadow:0 1px 2px rgba(17,20,28,.04),0 4px 18px rgba(17,20,28,.05); }
+.bext-row { display:flex; align-items:center; gap:14px; padding:13px 16px;
+  border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
 .bext-row:first-child { border-top:0; }
 .bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
-.bext-row.off { opacity:.55; }
+.bext-row.off { opacity:.6; }
+.bext-grow { flex:1; min-width:0; }
+.bext-filter { width:230px; }
 
 /* lightweight theme-aware toggle (Polaris ships no native switch in this version) */
 .bext-switch { position:relative; flex:0 0 auto; width:30px; height:18px; border:0; padding:0; appearance:none;
@@ -20,10 +22,29 @@
   background:#fff; box-shadow:0 1px 2px rgba(17,20,28,.28); transition:left .18s ease; }
 .bext-switch.on .bext-switch-knob { left:15px; }
 
-/* unified favicon tile — every logo sits on the same small white rounded surface */
-.bext-tile { width:34px; height:34px; border-radius:9px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
-  border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
+.bext-summary { display:flex; align-items:center; gap:16px; margin-top:7px; }
+.bext-summary .k { display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--p-color-text-secondary,#5b6472); }
+.bext-summary .k b { color:var(--p-color-text,#14161c); font-weight:640; font-variant-numeric:tabular-nums; }
+.bext-summary .d { width:7px; height:7px; border-radius:50%; }
+.bext-summary .d.on { background:var(--p-color-bg-fill-success,#1f9d55); }
+.bext-summary .d.off { background:var(--p-color-icon-disabled,#98a1b0); }
 
+/* unified favicon tile — every logo sits on the same white rounded surface */
+.bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
+  border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
+.bext-tile.sm { width:30px; height:30px; border-radius:8px; }
+
+/* loading skeleton bars */
+.bext-sk { height:16px; border-radius:6px; background:linear-gradient(90deg,var(--p-color-bg-surface-secondary,#f3f5f8) 25%,var(--p-color-bg-surface-hover,#f6f7fa) 37%,var(--p-color-bg-surface-secondary,#f3f5f8) 63%); background-size:400% 100%; animation:bextsh 1.3s ease infinite; }
+.bext-sk-avatar { width:36px; height:36px; border-radius:9px; }
+.bext-sk-title { width:130px; }
+.bext-sk-sub { width:80px; height:11px; margin-top:7px; }
+.bext-sk-switch { width:70px; height:14px; }
+@keyframes bextsh { 0%{background-position:100% 0} 100%{background-position:-100% 0} }
+@media (prefers-reduced-motion:reduce){ .bext-sk{ animation:none } }
+
+.bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
+  color:var(--p-color-text-secondary,#9aa2b1); }
 .bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }
 .bext-info:hover { opacity:1; }
 .bext-info .Polaris-Icon { width:15px; height:15px; margin:0; }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -1,6 +1,6 @@
 /* Browser Extension settings — scoped styles for behaviours Polaris props can't express
-   (hover-reveal, row hover, status dot, custom toggle/segmented control). Uses Polaris
-   tokens so light/dark both track the theme. */
+   (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
+   both track the theme. */
 
 .bext-list { border:1px solid var(--p-color-border,#e9ebf1); border-radius:14px; overflow:hidden;
   background:var(--p-color-bg-surface,#fff); box-shadow:0 1px 2px rgba(17,20,28,.04),0 4px 18px rgba(17,20,28,.05); }
@@ -8,20 +8,41 @@
   border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
 .bext-row:first-child { border-top:0; }
 .bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
+.bext-row.off { opacity:.6; }
 .bext-grow { flex:1; min-width:0; }
-.bext-switch { border:0; padding:0; appearance:none; }
-.bext-switch:focus-visible { outline:2px solid var(--p-color-border-focus,#5b5bd6); outline-offset:2px; border-radius:999px; }
+.bext-filter { width:230px; }
+
+/* lightweight theme-aware toggle (Polaris ships no native switch in this version) */
+.bext-switch { position:relative; flex:0 0 auto; width:30px; height:18px; border:0; padding:0; appearance:none;
+  border-radius:999px; cursor:pointer; transition:background .18s ease;
+  background:var(--p-color-bg-fill-tertiary,#e6e8ee); box-shadow:inset 0 0 0 1px var(--p-color-border,#e0e2e8); }
+.bext-switch.on { background:var(--p-color-bg-fill-brand,#5a5ad6); box-shadow:none; }
+.bext-switch:focus-visible { outline:2px solid var(--p-color-border-focus,#5b5bd6); outline-offset:2px; }
+.bext-switch-knob { position:absolute; top:3px; left:3px; width:12px; height:12px; border-radius:50%;
+  background:#fff; box-shadow:0 1px 2px rgba(17,20,28,.28); transition:left .18s ease; }
+.bext-switch.on .bext-switch-knob { left:15px; }
+
 .bext-summary { display:flex; align-items:center; gap:16px; margin-top:7px; }
 .bext-summary .k { display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--p-color-text-secondary,#5b6472); }
 .bext-summary .k b { color:var(--p-color-text,#14161c); font-weight:640; font-variant-numeric:tabular-nums; }
 .bext-summary .d { width:7px; height:7px; border-radius:50%; }
+.bext-summary .d.on { background:var(--p-color-bg-fill-success,#1f9d55); }
+.bext-summary .d.off { background:var(--p-color-icon-disabled,#98a1b0); }
+
 /* unified favicon tile — every logo sits on the same white rounded surface */
 .bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
   border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
 .bext-tile.sm { width:30px; height:30px; border-radius:8px; }
+
+/* loading skeleton bars */
 .bext-sk { height:16px; border-radius:6px; background:linear-gradient(90deg,var(--p-color-bg-surface-secondary,#f3f5f8) 25%,var(--p-color-bg-surface-hover,#f6f7fa) 37%,var(--p-color-bg-surface-secondary,#f3f5f8) 63%); background-size:400% 100%; animation:bextsh 1.3s ease infinite; }
+.bext-sk-avatar { width:36px; height:36px; border-radius:9px; }
+.bext-sk-title { width:130px; }
+.bext-sk-sub { width:80px; height:11px; margin-top:7px; }
+.bext-sk-switch { width:70px; height:14px; }
 @keyframes bextsh { 0%{background-position:100% 0} 100%{background-position:-100% 0} }
 @media (prefers-reduced-motion:reduce){ .bext-sk{ animation:none } }
+
 .bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
   color:var(--p-color-text-secondary,#9aa2b1); }
 .bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -1,14 +1,6 @@
-/* Browser Extension settings — scoped styles for behaviours Polaris props can't express
-   (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
-   both track the theme. */
-
-/* white list card lifted off the page background; container border/radius come from Box props */
-.bext-list { box-shadow:0 1px 2px rgba(17,20,28,.04), 0 4px 16px rgba(17,20,28,.05); }
-/* rows: spacing via Box padding; only the divider, hover and disabled dim have no Polaris prop */
-.bext-row { border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .12s; }
-.bext-row:first-child { border-top:0; }
-.bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
-.bext-row.off { opacity:.55; }
+/* Browser Extension settings — the list is the product-standard GithubSimpleTable; only these few
+   behaviours have no Polaris prop/component: the custom toggle, the unified favicon tile, the title
+   info icon, and the modal text-color fix. Uses Polaris tokens so light/dark both track the theme. */
 
 /* lightweight theme-aware toggle (Polaris ships no native switch in this version) */
 .bext-switch { position:relative; flex:0 0 auto; width:30px; height:18px; border:0; padding:0; appearance:none;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -32,7 +32,6 @@
 /* unified favicon tile — every logo sits on the same white rounded surface */
 .bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
   border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
-.bext-tile.sm { width:30px; height:30px; border-radius:8px; }
 
 /* loading skeleton bars */
 .bext-sk { height:16px; border-radius:6px; background:linear-gradient(90deg,var(--p-color-bg-surface-secondary,#f3f5f8) 25%,var(--p-color-bg-surface-hover,#f6f7fa) 37%,var(--p-color-bg-surface-secondary,#f3f5f8) 63%); background-size:400% 100%; animation:bextsh 1.3s ease infinite; }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -2,8 +2,9 @@
    (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
    both track the theme. */
 
-.bext-row { display:flex; align-items:center; gap:14px; padding:13px 16px;
-  border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
+/* row spacing/layout comes from Box padding + HorizontalStack gap; only the hover, the divider
+   between rows, and the disabled dim have no Polaris prop equivalent. */
+.bext-row { border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
 .bext-row:first-child { border-top:0; }
 .bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
 .bext-row.off { opacity:.6; }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -2,11 +2,12 @@
    (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
    both track the theme. */
 
-/* rows are spaced cards (border/radius/padding via Box props); only the hover lift and the
-   disabled dim have no Polaris prop equivalent. */
-.bext-row { transition:background .12s, box-shadow .12s, border-color .12s; }
-.bext-row:hover { background:var(--p-color-bg-surface-hover,#f9fafb); border-color:var(--p-color-border-emphasis,#cfcfe6);
-  box-shadow:0 1px 3px rgba(17,20,28,.07); }
+/* white list card lifted off the page background; container border/radius come from Box props */
+.bext-list { box-shadow:0 1px 2px rgba(17,20,28,.04), 0 4px 16px rgba(17,20,28,.05); }
+/* rows: spacing via Box padding; only the divider, hover and disabled dim have no Polaris prop */
+.bext-row { border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .12s; }
+.bext-row:first-child { border-top:0; }
+.bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
 .bext-row.off { opacity:.55; }
 
 /* lightweight theme-aware toggle (Polaris ships no native switch in this version) */

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -1,0 +1,42 @@
+/* Browser Extension settings — scoped styles for behaviours Polaris props can't express
+   (hover-reveal, row hover, status dot, custom toggle/segmented control). Uses Polaris
+   tokens so light/dark both track the theme. */
+
+.bext-list { border:1px solid var(--p-color-border,#e9ebf1); border-radius:14px; overflow:hidden;
+  background:var(--p-color-bg-surface,#fff); box-shadow:0 1px 2px rgba(17,20,28,.04),0 4px 18px rgba(17,20,28,.05); }
+.bext-row { display:flex; align-items:center; gap:14px; padding:13px 16px;
+  border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
+.bext-row:first-child { border-top:0; }
+.bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
+.bext-grow { flex:1; min-width:0; }
+.bext-switch { border:0; padding:0; appearance:none; }
+.bext-switch:focus-visible { outline:2px solid var(--p-color-border-focus,#5b5bd6); outline-offset:2px; border-radius:999px; }
+.bext-summary { display:flex; align-items:center; gap:16px; margin-top:7px; }
+.bext-summary .k { display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--p-color-text-secondary,#5b6472); }
+.bext-summary .k b { color:var(--p-color-text,#14161c); font-weight:640; font-variant-numeric:tabular-nums; }
+.bext-summary .d { width:7px; height:7px; border-radius:50%; }
+/* unified favicon tile — every logo sits on the same white rounded surface */
+.bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
+  border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
+.bext-tile.sm { width:30px; height:30px; border-radius:8px; }
+.bext-sk { height:16px; border-radius:6px; background:linear-gradient(90deg,var(--p-color-bg-surface-secondary,#f3f5f8) 25%,var(--p-color-bg-surface-hover,#f6f7fa) 37%,var(--p-color-bg-surface-secondary,#f3f5f8) 63%); background-size:400% 100%; animation:bextsh 1.3s ease infinite; }
+@keyframes bextsh { 0%{background-position:100% 0} 100%{background-position:-100% 0} }
+@media (prefers-reduced-motion:reduce){ .bext-sk{ animation:none } }
+.bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
+  color:var(--p-color-text-secondary,#9aa2b1); }
+.bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }
+.bext-info:hover { opacity:1; }
+.bext-info .Polaris-Icon { width:15px; height:15px; margin:0; }
+.bext-pick { display:flex; align-items:center; gap:13px; padding:10px 10px; border-radius:12px; cursor:pointer; border:1px solid transparent; transition:background .1s; }
+.bext-pick:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
+.bext-pick.sel { background:var(--p-color-bg-surface-selected,#f1f1fd); border-color:var(--p-color-border-emphasis,#cfcef6); }
+.bext-chk { width:22px; height:22px; border-radius:7px; border:1.5px solid var(--p-color-border-strong,#dfe2ea); flex:0 0 auto; display:grid; place-items:center; color:#fff; font-size:12px; transition:.12s; }
+.bext-pick.sel .bext-chk { background:var(--p-color-bg-fill-brand,#5b5bd6); border-color:var(--p-color-bg-fill-brand,#5b5bd6); }
+/* custom-host form: force the product's default text color (base Polaris Text/labels inherit a themed
+   green in this modal); keep subdued/critical variants intact. */
+.bext-form .Polaris-Choice__Label,
+.bext-form .Polaris-Text--root:not(.Polaris-Text--subdued):not(.Polaris-Text--critical) { color: var(--text-default, #202223); }
+/* premium light segmented control (replaces the heavy dark block) */
+.bext-seg { display:inline-flex; background:var(--p-color-bg-surface-secondary,#f3f5f8); border:1px solid var(--p-color-border-subdued,#eef0f4); border-radius:11px; padding:4px; gap:2px; }
+.bext-seg button { border:0; background:none; font:inherit; font-size:13px; font-weight:560; padding:7px 18px; border-radius:8px; color:var(--p-color-text-secondary,#5b6472); cursor:pointer; transition:.13s; }
+.bext-seg button.on { background:var(--p-color-bg-surface,#fff); color:var(--p-color-text,#14161c); box-shadow:0 1px 2px rgba(17,20,28,.10); }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -19,13 +19,6 @@
   background:#fff; box-shadow:0 1px 2px rgba(17,20,28,.28); transition:left .18s ease; }
 .bext-switch.on .bext-switch-knob { left:15px; }
 
-/* unified favicon tile — every logo sits on the same white rounded surface */
-.bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
-  border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
-.bext-tile.sm { width:30px; height:30px; border-radius:8px; }
-
-.bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
-  color:var(--p-color-text-secondary,#9aa2b1); }
 .bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }
 .bext-info:hover { opacity:1; }
 .bext-info .Polaris-Icon { width:15px; height:15px; margin:0; }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -7,7 +7,6 @@
 .bext-row:first-child { border-top:0; }
 .bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
 .bext-row.off { opacity:.6; }
-.bext-grow { flex:1; min-width:0; }
 
 /* lightweight theme-aware toggle (Polaris ships no native switch in this version) */
 .bext-switch { position:relative; flex:0 0 auto; width:30px; height:18px; border:0; padding:0; appearance:none;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -19,6 +19,10 @@
   background:#fff; box-shadow:0 1px 2px rgba(17,20,28,.28); transition:left .18s ease; }
 .bext-switch.on .bext-switch-knob { left:15px; }
 
+/* unified favicon tile — every logo sits on the same small white rounded surface */
+.bext-tile { width:34px; height:34px; border-radius:9px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
+  border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
+
 .bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }
 .bext-info:hover { opacity:1; }
 .bext-info .Polaris-Icon { width:15px; height:15px; margin:0; }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -22,26 +22,10 @@
   background:#fff; box-shadow:0 1px 2px rgba(17,20,28,.28); transition:left .18s ease; }
 .bext-switch.on .bext-switch-knob { left:15px; }
 
-.bext-summary { display:flex; align-items:center; gap:16px; margin-top:7px; }
-.bext-summary .k { display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--p-color-text-secondary,#5b6472); }
-.bext-summary .k b { color:var(--p-color-text,#14161c); font-weight:640; font-variant-numeric:tabular-nums; }
-.bext-summary .d { width:7px; height:7px; border-radius:50%; }
-.bext-summary .d.on { background:var(--p-color-bg-fill-success,#1f9d55); }
-.bext-summary .d.off { background:var(--p-color-icon-disabled,#98a1b0); }
-
 /* unified favicon tile — every logo sits on the same white rounded surface */
 .bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
   border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
 .bext-tile.sm { width:30px; height:30px; border-radius:8px; }
-
-/* loading skeleton bars */
-.bext-sk { height:16px; border-radius:6px; background:linear-gradient(90deg,var(--p-color-bg-surface-secondary,#f3f5f8) 25%,var(--p-color-bg-surface-hover,#f6f7fa) 37%,var(--p-color-bg-surface-secondary,#f3f5f8) 63%); background-size:400% 100%; animation:bextsh 1.3s ease infinite; }
-.bext-sk-avatar { width:36px; height:36px; border-radius:9px; }
-.bext-sk-title { width:130px; }
-.bext-sk-sub { width:80px; height:11px; margin-top:7px; }
-.bext-sk-switch { width:70px; height:14px; }
-@keyframes bextsh { 0%{background-position:100% 0} 100%{background-position:-100% 0} }
-@media (prefers-reduced-motion:reduce){ .bext-sk{ animation:none } }
 
 .bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
   color:var(--p-color-text-secondary,#9aa2b1); }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -1,6 +1,14 @@
-/* Browser Extension settings — the list is the product-standard GithubSimpleTable; only these few
-   behaviours have no Polaris prop/component: the custom toggle, the unified favicon tile, the title
-   info icon, and the modal text-color fix. Uses Polaris tokens so light/dark both track the theme. */
+/* Browser Extension settings — scoped styles for behaviours Polaris props can't express
+   (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
+   both track the theme. */
+
+/* white list card lifted off the page background; container border/radius come from Box props */
+.bext-list { box-shadow:0 1px 2px rgba(17,20,28,.04), 0 4px 16px rgba(17,20,28,.05); }
+/* rows: spacing via Box padding; only the divider, hover and disabled dim have no Polaris prop */
+.bext-row { border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .12s; }
+.bext-row:first-child { border-top:0; }
+.bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
+.bext-row.off { opacity:.55; }
 
 /* lightweight theme-aware toggle (Polaris ships no native switch in this version) */
 .bext-switch { position:relative; flex:0 0 auto; width:30px; height:18px; border:0; padding:0; appearance:none;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -2,15 +2,12 @@
    (hover-reveal, row hover, status dot, custom toggle). Uses Polaris tokens so light/dark
    both track the theme. */
 
-.bext-list { border:1px solid var(--p-color-border,#e9ebf1); border-radius:14px; overflow:hidden;
-  background:var(--p-color-bg-surface,#fff); box-shadow:0 1px 2px rgba(17,20,28,.04),0 4px 18px rgba(17,20,28,.05); }
 .bext-row { display:flex; align-items:center; gap:14px; padding:13px 16px;
   border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
 .bext-row:first-child { border-top:0; }
 .bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
 .bext-row.off { opacity:.6; }
 .bext-grow { flex:1; min-width:0; }
-.bext-filter { width:230px; }
 
 /* lightweight theme-aware toggle (Polaris ships no native switch in this version) */
 .bext-switch { position:relative; flex:0 0 auto; width:30px; height:18px; border:0; padding:0; appearance:none;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.css
@@ -27,16 +27,7 @@
 .bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }
 .bext-info:hover { opacity:1; }
 .bext-info .Polaris-Icon { width:15px; height:15px; margin:0; }
-.bext-pick { display:flex; align-items:center; gap:13px; padding:10px 10px; border-radius:12px; cursor:pointer; border:1px solid transparent; transition:background .1s; }
-.bext-pick:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
-.bext-pick.sel { background:var(--p-color-bg-surface-selected,#f1f1fd); border-color:var(--p-color-border-emphasis,#cfcef6); }
-.bext-chk { width:22px; height:22px; border-radius:7px; border:1.5px solid var(--p-color-border-strong,#dfe2ea); flex:0 0 auto; display:grid; place-items:center; color:#fff; font-size:12px; transition:.12s; }
-.bext-pick.sel .bext-chk { background:var(--p-color-bg-fill-brand,#5b5bd6); border-color:var(--p-color-bg-fill-brand,#5b5bd6); }
 /* custom-host form: force the product's default text color (base Polaris Text/labels inherit a themed
    green in this modal); keep subdued/critical variants intact. */
 .bext-form .Polaris-Choice__Label,
 .bext-form .Polaris-Text--root:not(.Polaris-Text--subdued):not(.Polaris-Text--critical) { color: var(--text-default, #202223); }
-/* premium light segmented control (replaces the heavy dark block) */
-.bext-seg { display:inline-flex; background:var(--p-color-bg-surface-secondary,#f3f5f8); border:1px solid var(--p-color-border-subdued,#eef0f4); border-radius:11px; padding:4px; gap:2px; }
-.bext-seg button { border:0; background:none; font:inherit; font-size:13px; font-weight:560; padding:7px 18px; border-radius:8px; color:var(--p-color-text-secondary,#5b6472); cursor:pointer; transition:.13s; }
-.bext-seg button.on { background:var(--p-color-bg-surface,#fff); color:var(--p-color-text,#14161c); box-shadow:0 1px 2px rgba(17,20,28,.10); }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -78,13 +78,8 @@ function BrowserExtensionSettings() {
     const [cfgPage, setCfgPage] = useState(0);            // configured list pagination (10 / page)
     const [openMenuId, setOpenMenuId] = useState(null);   // which row's ⋯ menu is open
 
-    // unified "Add hosts" picker
+    // custom-host add/edit modal
     const [pickerOpen, setPickerOpen] = useState(false);
-    const [mode, setMode] = useState("akto");          // "akto" | "custom"
-    const [pickSearch, setPickSearch] = useState("");
-    const [pickVisible, setPickVisible] = useState(40);   // how many catalogue rows are rendered (grows on scroll)
-    const [selected, setSelected] = useState(() => new Set());   // hosts checked for bulk add
-    const [adding, setAdding] = useState(false);
     const [showAdv, setShowAdv] = useState(false);   // custom-form advanced section
     const [showExample, setShowExample] = useState(false);   // custom-form worked example
     const [form, setForm] = useState(EMPTY_FORM);
@@ -110,7 +105,6 @@ function BrowserExtensionSettings() {
 
     useEffect(() => { fetchAll(); }, [fetchAll]);
     useEffect(() => { setCfgPage(0); }, [cfgFilter]);   // jump back to page 1 on a new filter
-    useEffect(() => { setPickVisible(40); }, [pickSearch]);   // reset picker window on a new search
 
     const catalogueByHost = useMemo(() => {
         const map = {};
@@ -118,28 +112,37 @@ function BrowserExtensionSettings() {
         return map;
     }, [catalogue]);
 
-    const configuredHostSet = useMemo(
-        () => new Set(configured.map((c) => (c.host || "").toLowerCase())),
-        [configured]
-    );
-
-    const activeCount = useMemo(() => configured.filter((c) => c.active).length, [configured]);
-    const offCount = configured.length - activeCount;
-
     // sort by the Mongo id (hexId) ascending — top brands were given the oldest ids, so they lead
     const idOf = (c) => c?.hexId || "￿";
     const byId = (a, b) => idOf(a).localeCompare(idOf(b));
 
+    // Every catalogue host is ON by default; the account collection only stores what the user changed
+    // (an opt-out with active:false, or a custom host). The displayed list is common ⊕ account overlaid.
+    const mergedRows = useMemo(() => {
+        const overrideByHost = {};
+        configured.forEach((c) => { overrideByHost[(c.host || "").toLowerCase()] = c; });
+        const rows = [];
+        // catalogue hosts, in rank order — on unless the account opted this one out
+        catalogue.slice().sort(byId).forEach((cat) => {
+            const ov = overrideByHost[(cat.host || "").toLowerCase()];
+            rows.push({ ...cat, active: ov ? ov.active !== false : true, hexId: ov?.hexId || null, source: "catalogue" });
+        });
+        // account-only custom hosts (not in the catalogue) keep their own row
+        configured.forEach((c) => {
+            if (!catalogueByHost[(c.host || "").toLowerCase()]) rows.push({ ...c, active: c.active !== false, source: "custom" });
+        });
+        return rows;
+    }, [catalogue, configured, catalogueByHost]);
+
+    const totalCount = mergedRows.length;
+    const activeCount = useMemo(() => mergedRows.filter((r) => r.active).length, [mergedRows]);
+    const offCount = totalCount - activeCount;
+
     const visibleConfigured = useMemo(() => {
         const q = cfgFilter.trim().toLowerCase();
-        const list = q ? configured.filter((c) => (c.host || "").toLowerCase().includes(q)) : configured.slice();
-        // top brands follow the defined catalogue rank (ChatGPT, Claude, DeepSeek, Gemini, …)
-        return list.sort((a, b) => {
-            const ca = catalogueByHost[(a.host || "").toLowerCase()];
-            const cb = catalogueByHost[(b.host || "").toLowerCase()];
-            return idOf(ca).localeCompare(idOf(cb));
-        });
-    }, [configured, cfgFilter, catalogueByHost]);
+        if (!q) return mergedRows;
+        return mergedRows.filter((r) => (r.host || "").toLowerCase().includes(q) || (r.name || "").toLowerCase().includes(q));
+    }, [mergedRows, cfgFilter]);
 
     // paginate the configured list (10 / page)
     const cfgTotalPages = Math.max(1, Math.ceil(visibleConfigured.length / CONFIG_PAGE_SIZE));
@@ -168,37 +171,12 @@ function BrowserExtensionSettings() {
         });
     };
 
-    // ── picker (add / edit) ─────────────────────────────────────────────
-    const openPicker = (m = "akto") => {
-        setMode(m); setPickSearch(""); setPickVisible(40); setSelected(new Set()); setForm(EMPTY_FORM);
-        setEditingHexId(null); setFormErrors({}); setShowAdv(false); setShowExample(false); setPickerOpen(true);
-    };
-    const toggleSelected = (host) => {
-        setSelected((prev) => {
-            const next = new Set(prev);
-            next.has(host) ? next.delete(host) : next.add(host);
-            return next;
-        });
-    };
-    const addSelected = async () => {
-        const hosts = [...selected];
-        if (hosts.length === 0) return;
-        setAdding(true);
-        try {
-            for (const host of hosts) {
-                await api.setBrowserExtensionConfigActive(host, true);
-            }
-            func.setToast(true, false, `${hosts.length} host${hosts.length !== 1 ? "s" : ""} added`);
-            closePicker();
-            await fetchAll();
-        } catch (error) {
-            func.setToast(true, true, "Failed to add hosts");
-        } finally {
-            setAdding(false);
-        }
+    // ── custom-host add / edit modal ────────────────────────────────────
+    const openCustom = () => {
+        setForm(EMPTY_FORM); setEditingHexId(null); setFormErrors({});
+        setShowAdv(false); setShowExample(false); setPickerOpen(true);
     };
     const openEdit = (config) => {
-        setMode("custom");
         const asArr = (v) => (Array.isArray(v) ? v : v ? [v] : []);
         const promptPaths = asArr(config.path);
         const fmEntries = config.frameMatch ? Object.entries(config.frameMatch).map(([k, v]) => ({ k, v: String(v) })) : [];
@@ -219,7 +197,7 @@ function BrowserExtensionSettings() {
     };
     const closePicker = () => {
         setPickerOpen(false); setForm(EMPTY_FORM); setEditingHexId(null); setFormErrors({});
-        setShowAdv(false); setShowExample(false); setSelected(new Set()); setPickSearch("");
+        setShowAdv(false); setShowExample(false);
     };
     // form helpers for the repeatable array fields
     const setField = (k, v) => setForm((f) => ({ ...f, [k]: v }));
@@ -295,13 +273,13 @@ function BrowserExtensionSettings() {
     };
 
     const handleDownload = () => {
-        if (configured.length === 0) {
-            func.setToast(true, true, "No configured hosts to download");
+        if (mergedRows.length === 0) {
+            func.setToast(true, true, "No hosts to download");
             return;
         }
-        const rows = configured.map((c) => ({
+        const rows = mergedRows.map((c) => ({
             Host: c.host || "-",
-            Source: catalogueByHost[(c.host || "").toLowerCase()] ? "Akto" : "Custom",
+            Source: c.source === "custom" ? "Custom" : "Akto",
             Status: c.active ? "Active" : "Inactive",
             Paths: (c.paths || []).join(" & ") || "-",
         }));
@@ -325,38 +303,39 @@ function BrowserExtensionSettings() {
     );
 
     const configuredRow = (c) => {
-        const common = catalogueByHost[(c.host || "").toLowerCase()];
-        const isAkto = !!common;
+        const isCustom = c.source === "custom";
         const menuItems = [
-            ...(!isAkto ? [{ content: "Edit", onAction: () => { setOpenMenuId(null); openEdit(c); } }] : []),
+            { content: "Edit", onAction: () => { setOpenMenuId(null); openEdit(c); } },
             { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
         ];
         return (
-            <Box className="bext-row" key={c.hexId} style={{ opacity: c.active ? 1 : 0.6 }}>
-                {hostAvatar(c.host, common?.iconUrl)}
+            <Box className="bext-row" key={c.host} style={{ opacity: c.active ? 1 : 0.6 }}>
+                {hostAvatar(c.host, c.iconUrl)}
                 <Box className="bext-grow">
-                    <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
+                    <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
                     <Text variant="bodySm" color="subdued" truncate>
-                        {common?.name ? c.host : (isAkto ? "Akto" : ((c.paths || []).join(", ") || "Custom"))}
+                        {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
                     </Text>
                 </Box>
                 <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
-                    title={c.active ? "Disable" : "Enable"} />
-                <Popover
-                    active={openMenuId === c.hexId}
-                    onClose={() => setOpenMenuId(null)}
-                    preferredAlignment="right"
-                    activator={
-                        <Button
-                            plain
-                            icon={HorizontalDotsMinor}
-                            accessibilityLabel={`Actions for ${common?.name || c.host}`}
-                            onClick={() => setOpenMenuId(openMenuId === c.hexId ? null : c.hexId)}
-                        />
-                    }
-                >
-                    <ActionList actionRole="menuitem" items={menuItems} />
-                </Popover>
+                    title={c.active ? "Disable for this account" : "Enable"} />
+                {isCustom && (
+                    <Popover
+                        active={openMenuId === c.host}
+                        onClose={() => setOpenMenuId(null)}
+                        preferredAlignment="right"
+                        activator={
+                            <Button
+                                plain
+                                icon={HorizontalDotsMinor}
+                                accessibilityLabel={`Actions for ${c.name || c.host}`}
+                                onClick={() => setOpenMenuId(openMenuId === c.host ? null : c.host)}
+                            />
+                        }
+                    >
+                        <ActionList actionRole="menuitem" items={menuItems} />
+                    </Popover>
+                )}
             </Box>
         );
     };
@@ -365,46 +344,46 @@ function BrowserExtensionSettings() {
         <Box key="ext-configured">
             <HorizontalStack align="space-between" blockAlign="start">
                 <Box>
-                    <span className="bext-eyebrow">Configured</span>
-                    {!loading && configured.length > 0 && (
+                    <span className="bext-eyebrow">Inspected hosts</span>
+                    {!loading && totalCount > 0 && (
                         <Box className="bext-summary">
-                            <span className="k"><b>{configured.length}</b> host{configured.length !== 1 ? "s" : ""}</span>
+                            <span className="k"><b>{totalCount}</b> host{totalCount !== 1 ? "s" : ""}</span>
                             <span className="k"><span className="d" style={{ background: "var(--p-color-bg-fill-success, #1f9d55)" }} /><b>{activeCount}</b> active</span>
                             {offCount > 0 && <span className="k"><span className="d" style={{ background: "var(--p-color-icon-disabled, #98a1b0)" }} /><b>{offCount}</b> off</span>}
                         </Box>
                     )}
                 </Box>
-                {!loading && configured.length > 0 && (
+                {!loading && totalCount > 0 && (
                     <Box style={{ width: 230 }}>
                         <TextField
-                            labelHidden label="Filter configured" value={cfgFilter} onChange={setCfgFilter}
-                            placeholder="Filter configured…" prefix={<Icon source={SearchMinor} color="subdued" />}
+                            labelHidden label="Filter hosts" value={cfgFilter} onChange={setCfgFilter}
+                            placeholder="Filter hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
                             autoComplete="off" clearButton onClearButtonClick={() => setCfgFilter("")}
                         />
                     </Box>
                 )}
             </HorizontalStack>
             <Box paddingBlockStart="3">
-                {loading ? skeletonList : configured.length === 0 ? (
+                {loading ? skeletonList : totalCount === 0 ? (
                     <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" padding="10">
                         <VerticalStack gap="4" inlineAlign="center">
                             <Box background="bg-subdued" borderRadius="300" padding="3">
                                 <Icon source={SearchMinor} color="subdued" />
                             </Box>
                             <VerticalStack gap="1" inlineAlign="center">
-                                <Text variant="headingSm">No hosts configured yet</Text>
+                                <Text variant="headingSm">No hosts yet</Text>
                                 <Text alignment="center" color="subdued">
-                                    Add from Akto's supported catalogue below, or add your own custom host.
+                                    Akto's supported hosts load here automatically. You can also add your own custom host.
                                 </Text>
                             </VerticalStack>
-                            <Button primary onClick={() => openPicker("akto")}>Add hosts</Button>
+                            <Button primary onClick={openCustom}>Add custom host</Button>
                         </VerticalStack>
                     </Box>
                 ) : (
                     <VerticalStack gap="3">
                         <Box className="bext-list">
                             {visibleConfigured.length === 0
-                                ? <Box className="bext-row"><Text color="subdued">No configured hosts match “{cfgFilter}”.</Text></Box>
+                                ? <Box className="bext-row"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
                                 : pagedConfigured.map(configuredRow)}
                         </Box>
                         {visibleConfigured.length > CONFIG_PAGE_SIZE && (
@@ -426,94 +405,15 @@ function BrowserExtensionSettings() {
         </Box>
     );
 
-    // ── picker modal ────────────────────────────────────────────────────
-    // Catalogue minus already-configured hosts (added ones aren't shown), sorted top-first.
-    const availableCatalogue = catalogue.filter((c) => !configuredHostSet.has((c.host || "").toLowerCase()));
-    const pickQuery = pickSearch.trim().toLowerCase();
-    const pickFilteredAll = availableCatalogue
-        .filter((c) => !pickQuery || (c.host || "").toLowerCase().includes(pickQuery) || (c.name || "").toLowerCase().includes(pickQuery))
-        .slice()
-        .sort(byId);
-    // render a growing window so the list scrolls smoothly through everything
-    const pickFiltered = pickFilteredAll.slice(0, pickVisible);
-
-    const pickRow = (c) => {
-        const isSel = selected.has(c.host);
-        return (
-            <Box
-                className={`bext-pick ${isSel ? "sel" : ""}`} key={c.host}
-                role="checkbox" aria-checked={isSel} tabIndex={0}
-                onClick={() => toggleSelected(c.host)}
-                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSelected(c.host); } }}
-            >
-                <Box className="bext-chk">{isSel ? "✓" : ""}</Box>
-                {hostAvatar(c.host, c.iconUrl, "small")}
-                <Box style={{ flex: 1, minWidth: 0 }}>
-                    <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
-                    {c.name && <Text variant="bodySm" color="subdued" truncate>{c.host}</Text>}
-                </Box>
-            </Box>
-        );
-    };
-
+    // ── custom-host modal ───────────────────────────────────────────────
     const pickerModal = (
         <Modal
             key="ext-picker" open={pickerOpen} onClose={closePicker}
-            title={editingHexId ? "Edit host" : "Add hosts"}
-            primaryAction={mode === "custom"
-                ? { content: editingHexId ? "Save" : "Add config", onAction: saveCustom, loading: saving }
-                : { content: selected.size ? `Add ${selected.size}` : "Add", onAction: addSelected, disabled: selected.size === 0, loading: adding }}
-            secondaryActions={[{ content: mode === "custom" ? "Cancel" : "Done", onAction: closePicker }]}
+            title={editingHexId ? "Edit custom host" : "Add custom host"}
+            primaryAction={{ content: editingHexId ? "Save" : "Add config", onAction: saveCustom, loading: saving }}
+            secondaryActions={[{ content: "Cancel", onAction: closePicker }]}
         >
-            {!editingHexId && (
-                <Modal.Section>
-                    <Box className="bext-seg">
-                        <button className={mode === "akto" ? "on" : ""} onClick={() => setMode("akto")}>Akto catalogue</button>
-                        <button className={mode === "custom" ? "on" : ""} onClick={() => setMode("custom")}>Custom host</button>
-                    </Box>
-                </Modal.Section>
-            )}
             <Modal.Section>
-                {mode === "akto" ? (
-                    <VerticalStack gap="3">
-                        <TextField
-                            labelHidden label="Search supported hosts" value={pickSearch} onChange={setPickSearch}
-                            placeholder="Search supported hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
-                            autoComplete="off" clearButton onClearButtonClick={() => setPickSearch("")}
-                        />
-                        <HorizontalStack align="end" blockAlign="center">
-                            <Text variant="bodySm" color="subdued">
-                                {pickQuery
-                                    ? `${pickFilteredAll.length} ${pickFilteredAll.length === 1 ? "result" : "results"}`
-                                    : `${pickFilteredAll.length.toLocaleString()} supported hosts`}
-                            </Text>
-                        </HorizontalStack>
-                        {pickFiltered.length === 0 ? (
-                            <Box padding="6">
-                                <VerticalStack gap="3" inlineAlign="center">
-                                    <Text alignment="center" color="subdued">No supported host matches “{pickSearch.trim()}”.</Text>
-                                    {pickQuery && (
-                                        <Button onClick={() => { setForm({ ...EMPTY_FORM, host: pickSearch.trim() }); setFormErrors({}); setMode("custom"); }}>
-                                            {`＋ Add “${pickSearch.trim()}” as a custom host`}
-                                        </Button>
-                                    )}
-                                </VerticalStack>
-                            </Box>
-                        ) : (
-                            <Box
-                                style={{ maxHeight: "44vh", overflowY: "auto", margin: "0 -4px" }}
-                                onScroll={(e) => {
-                                    const el = e.currentTarget;
-                                    if (el.scrollHeight - el.scrollTop - el.clientHeight < 160) {
-                                        setPickVisible((v) => (v < pickFilteredAll.length ? v + 40 : v));
-                                    }
-                                }}
-                            >
-                                {pickFiltered.map(pickRow)}
-                            </Box>
-                        )}
-                    </VerticalStack>
-                ) : (
                     <Box className="form-class bext-form">
                     <Form onSubmit={saveCustom}>
                         <VerticalStack gap="4">
@@ -639,7 +539,6 @@ function BrowserExtensionSettings() {
                         </VerticalStack>
                     </Form>
                     </Box>
-                )}
             </Modal.Section>
         </Modal>
     );
@@ -658,8 +557,8 @@ function BrowserExtensionSettings() {
                 subtitle={"Choose which hosts the Akto extension inspects."}
                 isFirstPage={true}
                 fullWidth={false}
-                primaryAction={<Button primary onClick={() => openPicker("akto")}>Add hosts</Button>}
-                secondaryActions={<Button onClick={handleDownload} disabled={loading || configured.length === 0}>Download</Button>}
+                primaryAction={<Button primary onClick={openCustom}>Add custom host</Button>}
+                secondaryActions={<Button onClick={handleDownload} disabled={loading || mergedRows.length === 0}>Download</Button>}
                 components={[pickerModal, configuredSection]}
         />
     );

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-    ActionList, Avatar, Box, Button, Divider, Form, HorizontalStack, Icon,
-    Modal, Pagination, Popover, Text, TextField, Tooltip, VerticalStack,
+    ActionList, Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
+    Modal, Pagination, Popover, SkeletonBodyText, SkeletonThumbnail, Text, TextField, Tooltip, VerticalStack,
 } from "@shopify/polaris";
 import { SearchMinor, HorizontalDotsMinor, DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
@@ -284,12 +284,10 @@ function BrowserExtensionSettings() {
         <Box className="bext-list">
             {Array.from({ length: 5 }).map((_, i) => (
                 <Box className="bext-row" key={`sk-${i}`}>
-                    <Box className="bext-sk bext-sk-avatar" />
+                    <SkeletonThumbnail size="small" />
                     <Box className="bext-grow">
-                        <Box className="bext-sk bext-sk-title" />
-                        <Box className="bext-sk bext-sk-sub" />
+                        <SkeletonBodyText lines={2} />
                     </Box>
-                    <Box className="bext-sk bext-sk-switch" />
                 </Box>
             ))}
         </Box>
@@ -339,10 +337,12 @@ function BrowserExtensionSettings() {
                 <Box>
                     <span className="bext-eyebrow">Inspected hosts</span>
                     {!loading && totalCount > 0 && (
-                        <Box className="bext-summary">
-                            <span className="k"><b>{totalCount}</b> host{totalCount !== 1 ? "s" : ""}</span>
-                            <span className="k"><span className="d on" /><b>{activeCount}</b> active</span>
-                            {offCount > 0 && <span className="k"><span className="d off" /><b>{offCount}</b> off</span>}
+                        <Box paddingBlockStart="1">
+                            <HorizontalStack gap="2" blockAlign="center">
+                                <Text variant="bodySm" color="subdued">{totalCount} host{totalCount !== 1 ? "s" : ""}</Text>
+                                <Badge status="success">{`${activeCount} active`}</Badge>
+                                {offCount > 0 && <Badge>{`${offCount} off`}</Badge>}
+                            </HorizontalStack>
                         </Box>
                     )}
                 </Box>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -9,6 +9,7 @@ import Dropdown from "../../../components/layouts/Dropdown";
 import { sharedIconCacheService } from "../../../components/shared/CollectionIcon";
 import func from "@/util/func";
 import api from "../../guardrails/api";
+import "./BrowserExtensionSettings.css";
 
 const CONFIG_PAGE_SIZE = 10;   // configured hosts per page
 
@@ -29,52 +30,10 @@ const FORMAT_OPTIONS = {
     graphql: [["json", "JSON"]],
 };
 
-// Scoped styles for behaviours inline styles can't express (hover-reveal, row hover, status dot).
-// Uses Polaris tokens so light/dark both track the theme.
-const CSS = `
-.bext-list { border:1px solid var(--p-color-border,#e9ebf1); border-radius:14px; overflow:hidden;
-  background:var(--p-color-bg-surface,#fff); box-shadow:0 1px 2px rgba(17,20,28,.04),0 4px 18px rgba(17,20,28,.05); }
-.bext-row { display:flex; align-items:center; gap:14px; padding:13px 16px;
-  border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
-.bext-row:first-child { border-top:0; }
-.bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
-.bext-grow { flex:1; min-width:0; }
-.bext-switch:focus-visible { outline:2px solid var(--p-color-border-focus,#5b5bd6); outline-offset:2px; border-radius:999px; }
-.bext-summary { display:flex; align-items:center; gap:16px; margin-top:7px; }
-.bext-summary .k { display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--p-color-text-secondary,#5b6472); }
-.bext-summary .k b { color:var(--p-color-text,#14161c); font-weight:640; font-variant-numeric:tabular-nums; }
-.bext-summary .d { width:7px; height:7px; border-radius:50%; }
-/* unified favicon tile — every logo sits on the same white rounded surface */
-.bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
-  border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
-.bext-tile.sm { width:30px; height:30px; border-radius:8px; }
-.bext-sk { height:16px; border-radius:6px; background:linear-gradient(90deg,var(--p-color-bg-surface-secondary,#f3f5f8) 25%,var(--p-color-bg-surface-hover,#f6f7fa) 37%,var(--p-color-bg-surface-secondary,#f3f5f8) 63%); background-size:400% 100%; animation:bextsh 1.3s ease infinite; }
-@keyframes bextsh { 0%{background-position:100% 0} 100%{background-position:-100% 0} }
-@media (prefers-reduced-motion:reduce){ .bext-sk{ animation:none } }
-.bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
-  color:var(--p-color-text-secondary,#9aa2b1); }
-.bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }
-.bext-info:hover { opacity:1; }
-.bext-info .Polaris-Icon { width:15px; height:15px; margin:0; }
-.bext-pick { display:flex; align-items:center; gap:13px; padding:10px 10px; border-radius:12px; cursor:pointer; border:1px solid transparent; transition:background .1s; }
-.bext-pick:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
-.bext-pick.sel { background:var(--p-color-bg-surface-selected,#f1f1fd); border-color:var(--p-color-border-emphasis,#cfcef6); }
-.bext-chk { width:22px; height:22px; border-radius:7px; border:1.5px solid var(--p-color-border-strong,#dfe2ea); flex:0 0 auto; display:grid; place-items:center; color:#fff; font-size:12px; transition:.12s; }
-.bext-pick.sel .bext-chk { background:var(--p-color-bg-fill-brand,#5b5bd6); border-color:var(--p-color-bg-fill-brand,#5b5bd6); }
-/* custom-host form: force the product's default text color (base Polaris Text/labels inherit a themed
-   green in this modal); keep subdued/critical variants intact. */
-.bext-form .Polaris-Choice__Label,
-.bext-form .Polaris-Text--root:not(.Polaris-Text--subdued):not(.Polaris-Text--critical) { color: var(--text-default, #202223); }
-/* premium light segmented control (replaces the heavy dark block) */
-.bext-seg { display:inline-flex; background:var(--p-color-bg-surface-secondary,#f3f5f8); border:1px solid var(--p-color-border-subdued,#eef0f4); border-radius:11px; padding:4px; gap:2px; }
-.bext-seg button { border:0; background:none; font:inherit; font-size:13px; font-weight:560; padding:7px 18px; border-radius:8px; color:var(--p-color-text-secondary,#5b6472); cursor:pointer; transition:.13s; }
-.bext-seg button.on { background:var(--p-color-bg-surface,#fff); color:var(--p-color-text,#14161c); box-shadow:0 1px 2px rgba(17,20,28,.10); }
-`;
-
 // Lightweight, theme-aware toggle (Polaris ships no native switch in this version).
 function Switch({ active, onChange, title }) {
     return (
-        <div
+        <Box
             className="bext-switch"
             role="switch" aria-checked={active} aria-label={title} tabIndex={0} title={title}
             onClick={onChange}
@@ -86,11 +45,11 @@ function Switch({ active, onChange, title }) {
                 boxShadow: active ? "none" : "inset 0 0 0 1px var(--p-color-border, #e0e2e8)",
             }}
         >
-            <div style={{
+            <Box style={{
                 position: "absolute", top: 3, left: active ? 15 : 3, width: 12, height: 12, borderRadius: "50%",
                 background: "#fff", boxShadow: "0 1px 2px rgba(17,20,28,.28)", transition: "left .18s ease",
             }} />
-        </div>
+        </Box>
     );
 }
 
@@ -277,17 +236,17 @@ function BrowserExtensionSettings() {
             <VerticalStack gap="2">
                 {form[key].map((val, i) => (
                     <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                        <div style={{ flex: 1, minWidth: 0 }}>
+                        <Box style={{ flex: 1, minWidth: 0 }}>
                             <TextField labelHidden label={`${label} ${i + 1}`} value={val}
                                 onChange={(v) => setArrItem(key, i, v)} placeholder={placeholder} autoComplete="off" monospaced />
-                        </div>
+                        </Box>
                         {form[key].length > 1 && (
                             <Button plain icon={DeleteMinor} accessibilityLabel="Remove" onClick={() => rmArrItem(key, i)} />
                         )}
                     </HorizontalStack>
                 ))}
             </VerticalStack>
-            <div><Button plain onClick={() => addArrItem(key)}>{addLabel}</Button></div>
+            <Box><Button plain onClick={() => addArrItem(key)}>{addLabel}</Button></Box>
             {error && <Text variant="bodySm" color="critical">{error}</Text>}
             {helpText && <Text variant="bodySm" color="subdued">{helpText}</Text>}
         </VerticalStack>
@@ -350,18 +309,18 @@ function BrowserExtensionSettings() {
 
     // ── configured section ──────────────────────────────────────────────
     const skeletonList = (
-        <div className="bext-list">
+        <Box className="bext-list">
             {Array.from({ length: 5 }).map((_, i) => (
-                <div className="bext-row" key={`sk-${i}`}>
-                    <div className="bext-sk" style={{ width: 36, height: 36, borderRadius: 9 }} />
-                    <div className="bext-grow">
-                        <div className="bext-sk" style={{ width: 130 }} />
-                        <div className="bext-sk" style={{ width: 80, height: 11, marginTop: 7 }} />
-                    </div>
-                    <div className="bext-sk" style={{ width: 70, height: 14 }} />
-                </div>
+                <Box className="bext-row" key={`sk-${i}`}>
+                    <Box className="bext-sk" style={{ width: 36, height: 36, borderRadius: 9 }} />
+                    <Box className="bext-grow">
+                        <Box className="bext-sk" style={{ width: 130 }} />
+                        <Box className="bext-sk" style={{ width: 80, height: 11, marginTop: 7 }} />
+                    </Box>
+                    <Box className="bext-sk" style={{ width: 70, height: 14 }} />
+                </Box>
             ))}
-        </div>
+        </Box>
     );
 
     const configuredRow = (c) => {
@@ -372,14 +331,14 @@ function BrowserExtensionSettings() {
             { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
         ];
         return (
-            <div className="bext-row" key={c.hexId} style={{ opacity: c.active ? 1 : 0.6 }}>
+            <Box className="bext-row" key={c.hexId} style={{ opacity: c.active ? 1 : 0.6 }}>
                 {hostAvatar(c.host, common?.iconUrl)}
-                <div className="bext-grow">
+                <Box className="bext-grow">
                     <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
                     <Text variant="bodySm" color="subdued" truncate>
                         {common?.name ? c.host : (isAkto ? "Akto" : ((c.paths || []).join(", ") || "Custom"))}
                     </Text>
-                </div>
+                </Box>
                 <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
                     title={c.active ? "Disable" : "Enable"} />
                 <Popover
@@ -397,31 +356,31 @@ function BrowserExtensionSettings() {
                 >
                     <ActionList actionRole="menuitem" items={menuItems} />
                 </Popover>
-            </div>
+            </Box>
         );
     };
 
     const configuredSection = (
-        <div key="ext-configured">
+        <Box key="ext-configured">
             <HorizontalStack align="space-between" blockAlign="start">
-                <div>
+                <Box>
                     <span className="bext-eyebrow">Configured</span>
                     {!loading && configured.length > 0 && (
-                        <div className="bext-summary">
+                        <Box className="bext-summary">
                             <span className="k"><b>{configured.length}</b> host{configured.length !== 1 ? "s" : ""}</span>
                             <span className="k"><span className="d" style={{ background: "var(--p-color-bg-fill-success, #1f9d55)" }} /><b>{activeCount}</b> active</span>
                             {offCount > 0 && <span className="k"><span className="d" style={{ background: "var(--p-color-icon-disabled, #98a1b0)" }} /><b>{offCount}</b> off</span>}
-                        </div>
+                        </Box>
                     )}
-                </div>
+                </Box>
                 {!loading && configured.length > 0 && (
-                    <div style={{ width: 230 }}>
+                    <Box style={{ width: 230 }}>
                         <TextField
                             labelHidden label="Filter configured" value={cfgFilter} onChange={setCfgFilter}
                             placeholder="Filter configured…" prefix={<Icon source={SearchMinor} color="subdued" />}
                             autoComplete="off" clearButton onClearButtonClick={() => setCfgFilter("")}
                         />
-                    </div>
+                    </Box>
                 )}
             </HorizontalStack>
             <Box paddingBlockStart="3">
@@ -442,11 +401,11 @@ function BrowserExtensionSettings() {
                     </Box>
                 ) : (
                     <VerticalStack gap="3">
-                        <div className="bext-list">
+                        <Box className="bext-list">
                             {visibleConfigured.length === 0
-                                ? <div className="bext-row"><Text color="subdued">No configured hosts match “{cfgFilter}”.</Text></div>
+                                ? <Box className="bext-row"><Text color="subdued">No configured hosts match “{cfgFilter}”.</Text></Box>
                                 : pagedConfigured.map(configuredRow)}
-                        </div>
+                        </Box>
                         {visibleConfigured.length > CONFIG_PAGE_SIZE && (
                             <Box paddingBlockStart="1">
                                 <HorizontalStack align="center" blockAlign="center" gap="4">
@@ -463,7 +422,7 @@ function BrowserExtensionSettings() {
                     </VerticalStack>
                 )}
             </Box>
-        </div>
+        </Box>
     );
 
     // ── picker modal ────────────────────────────────────────────────────
@@ -480,19 +439,19 @@ function BrowserExtensionSettings() {
     const pickRow = (c) => {
         const isSel = selected.has(c.host);
         return (
-            <div
+            <Box
                 className={`bext-pick ${isSel ? "sel" : ""}`} key={c.host}
                 role="checkbox" aria-checked={isSel} tabIndex={0}
                 onClick={() => toggleSelected(c.host)}
                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSelected(c.host); } }}
             >
-                <div className="bext-chk">{isSel ? "✓" : ""}</div>
+                <Box className="bext-chk">{isSel ? "✓" : ""}</Box>
                 {hostAvatar(c.host, c.iconUrl, "small")}
-                <div style={{ flex: 1, minWidth: 0 }}>
+                <Box style={{ flex: 1, minWidth: 0 }}>
                     <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
                     {c.name && <Text variant="bodySm" color="subdued" truncate>{c.host}</Text>}
-                </div>
-            </div>
+                </Box>
+            </Box>
         );
     };
 
@@ -507,10 +466,10 @@ function BrowserExtensionSettings() {
         >
             {!editingHexId && (
                 <Modal.Section>
-                    <div className="bext-seg">
+                    <Box className="bext-seg">
                         <button className={mode === "akto" ? "on" : ""} onClick={() => setMode("akto")}>Akto catalogue</button>
                         <button className={mode === "custom" ? "on" : ""} onClick={() => setMode("custom")}>Custom host</button>
-                    </div>
+                    </Box>
                 </Modal.Section>
             )}
             <Modal.Section>
@@ -540,7 +499,7 @@ function BrowserExtensionSettings() {
                                 </VerticalStack>
                             </Box>
                         ) : (
-                            <div
+                            <Box
                                 style={{ maxHeight: "44vh", overflowY: "auto", margin: "0 -4px" }}
                                 onScroll={(e) => {
                                     const el = e.currentTarget;
@@ -550,11 +509,11 @@ function BrowserExtensionSettings() {
                                 }}
                             >
                                 {pickFiltered.map(pickRow)}
-                            </div>
+                            </Box>
                         )}
                     </VerticalStack>
                 ) : (
-                    <div className="form-class bext-form">
+                    <Box className="form-class bext-form">
                     <Form onSubmit={saveCustom}>
                         <VerticalStack gap="4">
                             {!editingHexId && (
@@ -607,16 +566,16 @@ function BrowserExtensionSettings() {
 
                             {form.transport === "http" && (
                                 <HorizontalStack gap="4" wrap={false}>
-                                    <div style={{ flex: 1 }}>
+                                    <Box style={{ flex: 1 }}>
                                         <Dropdown id="bext-method" label="Method"
                                             menuItems={["POST", "GET", "PUT", "PATCH"].map((m) => ({ label: m, value: m }))}
                                             initial={form.method} selected={(v) => setField("method", v)} />
-                                    </div>
-                                    <div style={{ flex: 1 }}>
+                                    </Box>
+                                    <Box style={{ flex: 1 }}>
                                         <Dropdown id="bext-format-http" label="Body format"
                                             menuItems={FORMAT_OPTIONS.http.map(([v, l]) => ({ label: l, value: v }))}
                                             initial={form.format} selected={(v) => setField("format", v)} />
-                                    </div>
+                                    </Box>
                                 </HorizontalStack>
                             )}
 
@@ -632,13 +591,13 @@ function BrowserExtensionSettings() {
                                         <VerticalStack gap="2">
                                             {form.frameMatch.map((row, i) => (
                                                 <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                                                    <div style={{ flex: 1, minWidth: 0 }}>
+                                                    <Box style={{ flex: 1, minWidth: 0 }}>
                                                         <TextField labelHidden label={`key ${i}`} value={row.k} onChange={(v) => setFmItem(i, "k", v)} placeholder="event" autoComplete="off" monospaced />
-                                                    </div>
+                                                    </Box>
                                                     <Text>=</Text>
-                                                    <div style={{ flex: 1, minWidth: 0 }}>
+                                                    <Box style={{ flex: 1, minWidth: 0 }}>
                                                         <TextField labelHidden label={`value ${i}`} value={row.v} onChange={(v) => setFmItem(i, "v", v)} placeholder="send" autoComplete="off" monospaced />
-                                                    </div>
+                                                    </Box>
                                                     {form.frameMatch.length > 1 && (
                                                         <Button plain icon={DeleteMinor} accessibilityLabel="Remove" onClick={() => rmArrItem("frameMatch", i)} />
                                                     )}
@@ -678,16 +637,14 @@ function BrowserExtensionSettings() {
                             )}
                         </VerticalStack>
                     </Form>
-                    </div>
+                    </Box>
                 )}
             </Modal.Section>
         </Modal>
     );
 
     return (
-        <>
-            <style>{CSS}</style>
-            <PageWithMultipleCards
+        <PageWithMultipleCards
                 title={"Browser Extension"}
                 titleMetadata={
                     <Tooltip
@@ -703,8 +660,7 @@ function BrowserExtensionSettings() {
                 primaryAction={<Button primary onClick={() => openPicker("akto")}>Add hosts</Button>}
                 secondaryActions={<Button onClick={handleDownload} disabled={loading || configured.length === 0}>Download</Button>}
                 components={[pickerModal, configuredSection]}
-            />
-        </>
+        />
     );
 }
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -280,9 +280,9 @@ function BrowserExtensionSettings() {
 
     // ── configured section ──────────────────────────────────────────────
     const skeletonList = (
-        <VerticalStack gap="2">
+        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
             {Array.from({ length: 5 }).map((_, i) => (
-                <Box key={`sk-${i}`} background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" paddingBlock="3" paddingInline="4">
+                <Box className="bext-row" key={`sk-${i}`} paddingBlock="4" paddingInline="5">
                     <HorizontalStack gap="3" blockAlign="center" wrap={false}>
                         <SkeletonThumbnail size="small" />
                         <Box width="100%" minWidth="0">
@@ -291,7 +291,7 @@ function BrowserExtensionSettings() {
                     </HorizontalStack>
                 </Box>
             ))}
-        </VerticalStack>
+        </Box>
     );
 
     const configuredRow = (c) => {
@@ -301,8 +301,7 @@ function BrowserExtensionSettings() {
             { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
         ];
         return (
-            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host}
-                background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" paddingBlock="3" paddingInline="4">
+            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host} paddingBlock="4" paddingInline="5">
                 <HorizontalStack gap="3" blockAlign="center" wrap={false}>
                     {hostAvatar(c.host, c.iconUrl)}
                     <Box width="100%" minWidth="0">
@@ -336,7 +335,7 @@ function BrowserExtensionSettings() {
     };
 
     const configuredSection = (
-        <Box key="ext-configured">
+        <Box key="ext-configured" maxWidth="880px">
             <HorizontalStack align="space-between" blockAlign="start">
                 <Box>
                     <Text variant="headingSm" as="h3">Inspected hosts</Text>
@@ -378,9 +377,11 @@ function BrowserExtensionSettings() {
                     </Box>
                 ) : (
                     <VerticalStack gap="3">
-                        {visibleConfigured.length === 0
-                            ? <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" padding="4"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
-                            : <VerticalStack gap="2">{pagedConfigured.map(configuredRow)}</VerticalStack>}
+                        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
+                            {visibleConfigured.length === 0
+                                ? <Box paddingBlock="4" paddingInline="5"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
+                                : pagedConfigured.map(configuredRow)}
+                        </Box>
                         {visibleConfigured.length > CONFIG_PAGE_SIZE && (
                             <Box paddingBlockStart="1">
                                 <HorizontalStack align="center" blockAlign="center" gap="4">

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -208,7 +208,7 @@ function BrowserExtensionSettings() {
     const rmArrItem = (k, i) => setForm((f) => ({ ...f, [k]: f[k].length > 1 ? f[k].filter((_, j) => j !== i) : f[k] }));
     const setFmItem = (i, key, val) => setForm((f) => ({ ...f, frameMatch: f.frameMatch.map((x, j) => (j === i ? { ...x, [key]: val } : x)) }));
 
-    // renders a labelled list of monospaced text inputs with add/remove (paths, prompt paths, operations)
+    // renders a labelled list of text inputs with add/remove (paths, prompt paths, operations)
     const renderRepeatable = (key, { label, sub, placeholder, helpText, addLabel, error }) => (
         <VerticalStack gap="1">
             <Text variant="bodyMd" fontWeight="semibold">
@@ -219,7 +219,7 @@ function BrowserExtensionSettings() {
                     <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
                         <Box style={{ flex: 1, minWidth: 0 }}>
                             <TextField labelHidden label={`${label} ${i + 1}`} value={val}
-                                onChange={(v) => setArrItem(key, i, v)} placeholder={placeholder} autoComplete="off" monospaced />
+                                onChange={(v) => setArrItem(key, i, v)} placeholder={placeholder} autoComplete="off" />
                         </Box>
                         {form[key].length > 1 && (
                             <Button plain icon={DeleteMinor} accessibilityLabel="Remove" onClick={() => rmArrItem(key, i)} />
@@ -450,7 +450,7 @@ function BrowserExtensionSettings() {
                             )}
                             <TextField
                                 label="Host" value={form.host} onChange={(v) => setField("host", v)}
-                                placeholder="chat.example.com" error={formErrors.host} autoComplete="off" monospaced
+                                placeholder="chat.example.com" error={formErrors.host} autoComplete="off"
                                 helpText="The domain the chat UI runs on — no https:// or path."
                                 disabled={!!editingHexId}
                             />
@@ -495,11 +495,11 @@ function BrowserExtensionSettings() {
                                             {form.frameMatch.map((row, i) => (
                                                 <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
                                                     <Box style={{ flex: 1, minWidth: 0 }}>
-                                                        <TextField labelHidden label={`key ${i}`} value={row.k} onChange={(v) => setFmItem(i, "k", v)} placeholder="event" autoComplete="off" monospaced />
+                                                        <TextField labelHidden label={`key ${i}`} value={row.k} onChange={(v) => setFmItem(i, "k", v)} placeholder="event" autoComplete="off" />
                                                     </Box>
                                                     <Text>=</Text>
                                                     <Box style={{ flex: 1, minWidth: 0 }}>
-                                                        <TextField labelHidden label={`value ${i}`} value={row.v} onChange={(v) => setFmItem(i, "v", v)} placeholder="send" autoComplete="off" monospaced />
+                                                        <TextField labelHidden label={`value ${i}`} value={row.v} onChange={(v) => setFmItem(i, "v", v)} placeholder="send" autoComplete="off" />
                                                     </Box>
                                                     {form.frameMatch.length > 1 && (
                                                         <Button plain icon={DeleteMinor} accessibilityLabel="Remove" onClick={() => rmArrItem("frameMatch", i)} />
@@ -533,9 +533,9 @@ function BrowserExtensionSettings() {
                                         menuItems={[{ label: "None", value: "none" }, { label: "SSE", value: "sse" }, { label: "JSON", value: "json" }, { label: "Nested-envelope", value: "nested-envelope" }]}
                                         initial={form.responseFormat} selected={(v) => setField("responseFormat", v)} />
                                     <TextField label="Response path" value={form.responsePath} onChange={(v) => setField("responsePath", v)}
-                                        placeholder="choices[*].delta.content" autoComplete="off" monospaced helpText="Where the AI answer is in the response." />
+                                        placeholder="choices[*].delta.content" autoComplete="off" helpText="Where the AI answer is in the response." />
                                     <TextField label="Model path" value={form.modelPath} onChange={(v) => setField("modelPath", v)}
-                                        placeholder="model" autoComplete="off" monospaced helpText="Where the model name is." />
+                                        placeholder="model" autoComplete="off" helpText="Where the model name is." />
                                 </VerticalStack>
                             )}
                         </VerticalStack>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -106,33 +106,35 @@ function BrowserExtensionSettings() {
     useEffect(() => { fetchAll(); }, [fetchAll]);
     useEffect(() => { setCfgPage(0); }, [cfgFilter]);   // jump back to page 1 on a new filter
 
-    const catalogueByHost = useMemo(() => {
-        const map = {};
-        catalogue.forEach((c) => { map[(c.host || "").toLowerCase()] = c; });
-        return map;
-    }, [catalogue]);
-
     // sort by the Mongo id (hexId) ascending — top brands were given the oldest ids, so they lead
     const idOf = (c) => c?.hexId || "￿";
     const byId = (a, b) => idOf(a).localeCompare(idOf(b));
 
     // Every catalogue host is ON by default; the account collection only stores what the user changed
-    // (an opt-out with active:false, or a custom host). The displayed list is common ⊕ account overlaid.
+    // (an opt-out with active:false, or a custom host). The displayed list is common ⊕ account overlaid:
+    // each host appears exactly once, and the account row's `active` always wins over the default.
     const mergedRows = useMemo(() => {
         const overrideByHost = {};
         configured.forEach((c) => { overrideByHost[(c.host || "").toLowerCase()] = c; });
+        const seen = new Set();
         const rows = [];
         // catalogue hosts, in rank order — on unless the account opted this one out
         catalogue.slice().sort(byId).forEach((cat) => {
-            const ov = overrideByHost[(cat.host || "").toLowerCase()];
+            const key = (cat.host || "").toLowerCase();
+            if (!key || seen.has(key)) return;   // never list the same host twice
+            seen.add(key);
+            const ov = overrideByHost[key];
             rows.push({ ...cat, active: ov ? ov.active !== false : true, hexId: ov?.hexId || null, source: "catalogue" });
         });
-        // account-only custom hosts (not in the catalogue) keep their own row
+        // account-only custom hosts (any host not already shown from the catalogue)
         configured.forEach((c) => {
-            if (!catalogueByHost[(c.host || "").toLowerCase()]) rows.push({ ...c, active: c.active !== false, source: "custom" });
+            const key = (c.host || "").toLowerCase();
+            if (!key || seen.has(key)) return;
+            seen.add(key);
+            rows.push({ ...c, active: c.active !== false, source: "custom" });
         });
         return rows;
-    }, [catalogue, configured, catalogueByHost]);
+    }, [catalogue, configured]);
 
     const totalCount = mergedRows.length;
     const activeCount = useMemo(() => mergedRows.filter((r) => r.active).length, [mergedRows]);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-    ActionList, Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
+    ActionList, Avatar, Box, Button, Divider, Form, HorizontalStack, Icon,
     Modal, Pagination, Popover, Text, TextField, Tooltip, VerticalStack,
 } from "@shopify/polaris";
 import { SearchMinor, HorizontalDotsMinor, DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
@@ -143,9 +143,10 @@ function BrowserExtensionSettings() {
         const key = (host || "").toLowerCase();
         return !!catalogueByHost[key] && !stableHosts.has(key);
     };
-    const betaBadge = (host) => isBeta(host) && (
+    // Beta is shown as the same subtle info icon used near the page title (no loud badge).
+    const betaInfo = (host) => isBeta(host) && (
         <Tooltip content={BETA_TOOLTIP} dismissOnMouseOut>
-            <Badge status="attention">Beta</Badge>
+            <span className="bext-info"><Icon source={InfoMinor} color="subdued" /></span>
         </Tooltip>
     );
 
@@ -355,7 +356,7 @@ function BrowserExtensionSettings() {
                 <Box className="bext-grow">
                     <HorizontalStack gap="2" blockAlign="center">
                         <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
-                        {betaBadge(c.host)}
+                        {betaInfo(c.host)}
                     </HorizontalStack>
                     <Text variant="bodySm" color="subdued" truncate>
                         {common?.name ? c.host : (isAkto ? "Akto" : ((c.paths || []).join(", ") || "Custom"))}
@@ -472,7 +473,7 @@ function BrowserExtensionSettings() {
                 <Box style={{ flex: 1, minWidth: 0 }}>
                     <HorizontalStack gap="2" blockAlign="center">
                         <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
-                        {betaBadge(c.host)}
+                        {betaInfo(c.host)}
                     </HorizontalStack>
                     {c.name && <Text variant="bodySm" color="subdued" truncate>{c.host}</Text>}
                 </Box>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -34,21 +34,12 @@ const FORMAT_OPTIONS = {
 function Switch({ active, onChange, title }) {
     return (
         <Box
-            className="bext-switch"
+            className={`bext-switch ${active ? "on" : ""}`}
             role="switch" aria-checked={active} aria-label={title} tabIndex={0} title={title}
             onClick={onChange}
             onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(); } }}
-            style={{
-                width: 30, height: 18, borderRadius: 999, cursor: "pointer", position: "relative", flex: "0 0 auto",
-                transition: "background .18s ease",
-                background: active ? "var(--p-color-bg-fill-brand, #5a5ad6)" : "var(--p-color-bg-fill-tertiary, #e6e8ee)",
-                boxShadow: active ? "none" : "inset 0 0 0 1px var(--p-color-border, #e0e2e8)",
-            }}
         >
-            <Box style={{
-                position: "absolute", top: 3, left: active ? 15 : 3, width: 12, height: 12, borderRadius: "50%",
-                background: "#fff", boxShadow: "0 1px 2px rgba(17,20,28,.28)", transition: "left .18s ease",
-            }} />
+            <Box as="span" className="bext-switch-knob" />
         </Box>
     );
 }
@@ -217,7 +208,7 @@ function BrowserExtensionSettings() {
             <VerticalStack gap="2">
                 {form[key].map((val, i) => (
                     <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                        <Box style={{ flex: 1, minWidth: 0 }}>
+                        <Box className="bext-grow">
                             <TextField labelHidden label={`${label} ${i + 1}`} value={val}
                                 onChange={(v) => setArrItem(key, i, v)} placeholder={placeholder} autoComplete="off" />
                         </Box>
@@ -293,12 +284,12 @@ function BrowserExtensionSettings() {
         <Box className="bext-list">
             {Array.from({ length: 5 }).map((_, i) => (
                 <Box className="bext-row" key={`sk-${i}`}>
-                    <Box className="bext-sk" style={{ width: 36, height: 36, borderRadius: 9 }} />
+                    <Box className="bext-sk bext-sk-avatar" />
                     <Box className="bext-grow">
-                        <Box className="bext-sk" style={{ width: 130 }} />
-                        <Box className="bext-sk" style={{ width: 80, height: 11, marginTop: 7 }} />
+                        <Box className="bext-sk bext-sk-title" />
+                        <Box className="bext-sk bext-sk-sub" />
                     </Box>
-                    <Box className="bext-sk" style={{ width: 70, height: 14 }} />
+                    <Box className="bext-sk bext-sk-switch" />
                 </Box>
             ))}
         </Box>
@@ -311,7 +302,7 @@ function BrowserExtensionSettings() {
             { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
         ];
         return (
-            <Box className="bext-row" key={c.host} style={{ opacity: c.active ? 1 : 0.6 }}>
+            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host}>
                 {hostAvatar(c.host, c.iconUrl)}
                 <Box className="bext-grow">
                     <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
@@ -350,13 +341,13 @@ function BrowserExtensionSettings() {
                     {!loading && totalCount > 0 && (
                         <Box className="bext-summary">
                             <span className="k"><b>{totalCount}</b> host{totalCount !== 1 ? "s" : ""}</span>
-                            <span className="k"><span className="d" style={{ background: "var(--p-color-bg-fill-success, #1f9d55)" }} /><b>{activeCount}</b> active</span>
-                            {offCount > 0 && <span className="k"><span className="d" style={{ background: "var(--p-color-icon-disabled, #98a1b0)" }} /><b>{offCount}</b> off</span>}
+                            <span className="k"><span className="d on" /><b>{activeCount}</b> active</span>
+                            {offCount > 0 && <span className="k"><span className="d off" /><b>{offCount}</b> off</span>}
                         </Box>
                     )}
                 </Box>
                 {!loading && totalCount > 0 && (
-                    <Box style={{ width: 230 }}>
+                    <Box className="bext-filter">
                         <TextField
                             labelHidden label="Filter hosts" value={cfgFilter} onChange={setCfgFilter}
                             placeholder="Filter hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
@@ -469,12 +460,12 @@ function BrowserExtensionSettings() {
 
                             {form.transport === "http" && (
                                 <HorizontalStack gap="4" wrap={false}>
-                                    <Box style={{ flex: 1 }}>
+                                    <Box className="bext-grow">
                                         <Dropdown id="bext-method" label="Method"
                                             menuItems={["POST", "GET", "PUT", "PATCH"].map((m) => ({ label: m, value: m }))}
                                             initial={form.method} selected={(v) => setField("method", v)} />
                                     </Box>
-                                    <Box style={{ flex: 1 }}>
+                                    <Box className="bext-grow">
                                         <Dropdown id="bext-format-http" label="Body format"
                                             menuItems={FORMAT_OPTIONS.http.map(([v, l]) => ({ label: l, value: v }))}
                                             initial={form.format} selected={(v) => setField("format", v)} />
@@ -494,11 +485,11 @@ function BrowserExtensionSettings() {
                                         <VerticalStack gap="2">
                                             {form.frameMatch.map((row, i) => (
                                                 <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                                                    <Box style={{ flex: 1, minWidth: 0 }}>
+                                                    <Box className="bext-grow">
                                                         <TextField labelHidden label={`key ${i}`} value={row.k} onChange={(v) => setFmItem(i, "k", v)} placeholder="event" autoComplete="off" />
                                                     </Box>
                                                     <Text>=</Text>
-                                                    <Box style={{ flex: 1, minWidth: 0 }}>
+                                                    <Box className="bext-grow">
                                                         <TextField labelHidden label={`value ${i}`} value={row.v} onChange={(v) => setFmItem(i, "v", v)} placeholder="send" autoComplete="off" />
                                                     </Box>
                                                     {form.frameMatch.length > 1 && (

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -203,7 +203,7 @@ function BrowserExtensionSettings() {
             <VerticalStack gap="2">
                 {form[key].map((val, i) => (
                     <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                        <Box className="bext-grow">
+                        <Box width="100%" minWidth="0">
                             <TextField labelHidden label={`${label} ${i + 1}`} value={val}
                                 onChange={(v) => setArrItem(key, i, v)} placeholder={placeholder} autoComplete="off" />
                         </Box>
@@ -280,7 +280,7 @@ function BrowserExtensionSettings() {
             {Array.from({ length: 5 }).map((_, i) => (
                 <Box className="bext-row" key={`sk-${i}`}>
                     <SkeletonThumbnail size="small" />
-                    <Box className="bext-grow">
+                    <Box width="100%" minWidth="0">
                         <SkeletonBodyText lines={2} />
                     </Box>
                 </Box>
@@ -297,7 +297,7 @@ function BrowserExtensionSettings() {
         return (
             <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host}>
                 {hostAvatar(c.host, c.iconUrl)}
-                <Box className="bext-grow">
+                <Box width="100%" minWidth="0">
                     <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
                     <Text variant="bodySm" color="subdued" truncate>
                         {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
@@ -455,12 +455,12 @@ function BrowserExtensionSettings() {
 
                             {form.transport === "http" && (
                                 <HorizontalStack gap="4" wrap={false}>
-                                    <Box className="bext-grow">
+                                    <Box width="100%" minWidth="0">
                                         <Dropdown id="bext-method" label="Method"
                                             menuItems={["POST", "GET", "PUT", "PATCH"].map((m) => ({ label: m, value: m }))}
                                             initial={form.method} selected={(v) => setField("method", v)} />
                                     </Box>
-                                    <Box className="bext-grow">
+                                    <Box width="100%" minWidth="0">
                                         <Dropdown id="bext-format-http" label="Body format"
                                             menuItems={FORMAT_OPTIONS.http.map(([v, l]) => ({ label: l, value: v }))}
                                             initial={form.format} selected={(v) => setField("format", v)} />
@@ -480,11 +480,11 @@ function BrowserExtensionSettings() {
                                         <VerticalStack gap="2">
                                             {form.frameMatch.map((row, i) => (
                                                 <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                                                    <Box className="bext-grow">
+                                                    <Box width="100%" minWidth="0">
                                                         <TextField labelHidden label={`key ${i}`} value={row.k} onChange={(v) => setFmItem(i, "k", v)} placeholder="event" autoComplete="off" />
                                                     </Box>
                                                     <Text>=</Text>
-                                                    <Box className="bext-grow">
+                                                    <Box width="100%" minWidth="0">
                                                         <TextField labelHidden label={`value ${i}`} value={row.v} onChange={(v) => setFmItem(i, "v", v)} placeholder="send" autoComplete="off" />
                                                     </Box>
                                                     {form.frameMatch.length > 1 && (

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -12,8 +12,6 @@ import api from "../../guardrails/api";
 import "./BrowserExtensionSettings.css";
 
 const CONFIG_PAGE_SIZE = 10;   // configured hosts per page
-const STABLE_COUNT = 5;        // top N ranked hosts are GA; every other supported host is beta
-const BETA_TOOLTIP = "Beta — support for this host is still experimental and may change.";
 
 // full config-driven custom-host form (mirrors the extension's monitoring-config schema)
 const EMPTY_FORM = {
@@ -131,24 +129,6 @@ function BrowserExtensionSettings() {
     // sort by the Mongo id (hexId) ascending — top brands were given the oldest ids, so they lead
     const idOf = (c) => c?.hexId || "￿";
     const byId = (a, b) => idOf(a).localeCompare(idOf(b));
-
-    // The top STABLE_COUNT ranked hosts are GA; every other supported host is beta. Derived from
-    // rank so there is no per-document flag to maintain (see removed `tag`).
-    const stableHosts = useMemo(
-        () => new Set(catalogue.slice().sort(byId).slice(0, STABLE_COUNT).map((c) => (c.host || "").toLowerCase())),
-        [catalogue]
-    );
-    // A supported (catalogue) host beyond the top STABLE_COUNT is beta; custom hosts carry no badge.
-    const isBeta = (host) => {
-        const key = (host || "").toLowerCase();
-        return !!catalogueByHost[key] && !stableHosts.has(key);
-    };
-    // Beta is shown as the same subtle info icon used near the page title (no loud badge).
-    const betaInfo = (host) => isBeta(host) && (
-        <Tooltip content={BETA_TOOLTIP} dismissOnMouseOut>
-            <span className="bext-info"><Icon source={InfoMinor} color="subdued" /></span>
-        </Tooltip>
-    );
 
     const visibleConfigured = useMemo(() => {
         const q = cfgFilter.trim().toLowerCase();
@@ -354,10 +334,7 @@ function BrowserExtensionSettings() {
             <Box className="bext-row" key={c.hexId} style={{ opacity: c.active ? 1 : 0.6 }}>
                 {hostAvatar(c.host, common?.iconUrl)}
                 <Box className="bext-grow">
-                    <HorizontalStack gap="2" blockAlign="center">
-                        <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
-                        {betaInfo(c.host)}
-                    </HorizontalStack>
+                    <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
                     <Text variant="bodySm" color="subdued" truncate>
                         {common?.name ? c.host : (isAkto ? "Akto" : ((c.paths || []).join(", ") || "Custom"))}
                     </Text>
@@ -471,10 +448,7 @@ function BrowserExtensionSettings() {
                 <Box className="bext-chk">{isSel ? "✓" : ""}</Box>
                 {hostAvatar(c.host, c.iconUrl, "small")}
                 <Box style={{ flex: 1, minWidth: 0 }}>
-                    <HorizontalStack gap="2" blockAlign="center">
-                        <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
-                        {betaInfo(c.host)}
-                    </HorizontalStack>
+                    <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
                     {c.name && <Text variant="bodySm" color="subdued" truncate>{c.host}</Text>}
                 </Box>
             </Box>
@@ -674,7 +648,7 @@ function BrowserExtensionSettings() {
                 title={"Browser Extension"}
                 titleMetadata={
                     <Tooltip
-                        content="Before v1.0.61 the extension supported only ChatGPT, Grok, Claude, Gemini, Copilot and DeepSeek. From v1.0.61 onwards every host configured here is supported."
+                        content="Before v1.0.61 the extension supported only ChatGPT, Grok, Claude, Gemini, Copilot and DeepSeek. From v1.0.61 every configured host is inspected — the top 5 are generally available, and every other supported host is in beta and may change."
                         dismissOnMouseOut
                     >
                         <span className="bext-info"><Icon source={InfoMinor} color="subdued" /></span>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -280,9 +280,9 @@ function BrowserExtensionSettings() {
 
     // ── configured section ──────────────────────────────────────────────
     const skeletonList = (
-        <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
+        <VerticalStack gap="2">
             {Array.from({ length: 5 }).map((_, i) => (
-                <Box className="bext-row" key={`sk-${i}`} paddingBlock="3" paddingInline="4">
+                <Box key={`sk-${i}`} background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" paddingBlock="3" paddingInline="4">
                     <HorizontalStack gap="3" blockAlign="center" wrap={false}>
                         <SkeletonThumbnail size="small" />
                         <Box width="100%" minWidth="0">
@@ -291,7 +291,7 @@ function BrowserExtensionSettings() {
                     </HorizontalStack>
                 </Box>
             ))}
-        </Box>
+        </VerticalStack>
     );
 
     const configuredRow = (c) => {
@@ -301,7 +301,8 @@ function BrowserExtensionSettings() {
             { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
         ];
         return (
-            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host} paddingBlock="3" paddingInline="4">
+            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host}
+                background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" paddingBlock="3" paddingInline="4">
                 <HorizontalStack gap="3" blockAlign="center" wrap={false}>
                     {hostAvatar(c.host, c.iconUrl)}
                     <Box width="100%" minWidth="0">
@@ -377,11 +378,9 @@ function BrowserExtensionSettings() {
                     </Box>
                 ) : (
                     <VerticalStack gap="3">
-                        <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
-                            {visibleConfigured.length === 0
-                                ? <Box className="bext-row"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
-                                : pagedConfigured.map(configuredRow)}
-                        </Box>
+                        {visibleConfigured.length === 0
+                            ? <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" padding="4"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
+                            : <VerticalStack gap="2">{pagedConfigured.map(configuredRow)}</VerticalStack>}
                         {visibleConfigured.length > CONFIG_PAGE_SIZE && (
                             <Box paddingBlockStart="1">
                                 <HorizontalStack align="center" blockAlign="center" gap="4">

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -51,9 +51,13 @@ function faviconFor(host, iconUrl) {
     return host ? sharedIconCacheService.getFaviconUrl(host) : undefined;
 }
 
-// A square Polaris Avatar shows the favicon and falls back to the host's initials if it fails.
+// Every favicon sits inside a unified white rounded tile so light/dark logos read evenly.
 function hostAvatar(host, iconUrl) {
-    return <Avatar size="medium" shape="square" source={faviconFor(host, iconUrl) || undefined} name={host} />;
+    return (
+        <span className="bext-tile">
+            <Avatar size="extraSmall" shape="square" source={faviconFor(host, iconUrl) || undefined} name={host} />
+        </span>
+    );
 }
 
 function BrowserExtensionSettings() {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-    ActionList, Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
-    Modal, Pagination, Popover, SkeletonBodyText, SkeletonThumbnail, Text, TextField, Tooltip, VerticalStack,
+    ActionList, Avatar, Box, Button, Divider, Form, HorizontalStack, Icon,
+    Modal, Pagination, Popover, Text, TextField, Tooltip, VerticalStack,
 } from "@shopify/polaris";
 import { SearchMinor, HorizontalDotsMinor, DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
@@ -52,9 +52,10 @@ function faviconFor(host, iconUrl) {
 }
 
 // Every favicon sits inside a unified white rounded tile so light/dark logos read evenly.
-function hostAvatar(host, iconUrl) {
+function hostAvatar(host, iconUrl, size = "small") {
+    const sm = size === "extraSmall";
     return (
-        <span className="bext-tile">
+        <span className={`bext-tile ${sm ? "sm" : ""}`}>
             <Avatar size="extraSmall" shape="square" source={faviconFor(host, iconUrl) || undefined} name={host} />
         </span>
     );
@@ -207,7 +208,7 @@ function BrowserExtensionSettings() {
             <VerticalStack gap="2">
                 {form[key].map((val, i) => (
                     <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                        <Box width="100%" minWidth="0">
+                        <Box className="bext-grow">
                             <TextField labelHidden label={`${label} ${i + 1}`} value={val}
                                 onChange={(v) => setArrItem(key, i, v)} placeholder={placeholder} autoComplete="off" />
                         </Box>
@@ -280,15 +281,15 @@ function BrowserExtensionSettings() {
 
     // ── configured section ──────────────────────────────────────────────
     const skeletonList = (
-        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
+        <Box className="bext-list">
             {Array.from({ length: 5 }).map((_, i) => (
-                <Box className="bext-row" key={`sk-${i}`} paddingBlock="4" paddingInline="5">
-                    <HorizontalStack gap="3" blockAlign="center" wrap={false}>
-                        <SkeletonThumbnail size="small" />
-                        <Box width="100%" minWidth="0">
-                            <SkeletonBodyText lines={2} />
-                        </Box>
-                    </HorizontalStack>
+                <Box className="bext-row" key={`sk-${i}`}>
+                    <Box className="bext-sk bext-sk-avatar" />
+                    <Box className="bext-grow">
+                        <Box className="bext-sk bext-sk-title" />
+                        <Box className="bext-sk bext-sk-sub" />
+                    </Box>
+                    <Box className="bext-sk bext-sk-switch" />
                 </Box>
             ))}
         </Box>
@@ -301,56 +302,52 @@ function BrowserExtensionSettings() {
             { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
         ];
         return (
-            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host} paddingBlock="4" paddingInline="5">
-                <HorizontalStack gap="3" blockAlign="center" wrap={false}>
-                    {hostAvatar(c.host, c.iconUrl)}
-                    <Box width="100%" minWidth="0">
-                        <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
-                        <Text variant="bodySm" color="subdued" truncate>
-                            {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
-                        </Text>
-                    </Box>
-                    <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
-                        title={c.active ? "Disable for this account" : "Enable"} />
-                    {isCustom && (
-                        <Popover
-                            active={openMenuId === c.host}
-                            onClose={() => setOpenMenuId(null)}
-                            preferredAlignment="right"
-                            activator={
-                                <Button
-                                    plain
-                                    icon={HorizontalDotsMinor}
-                                    accessibilityLabel={`Actions for ${c.name || c.host}`}
-                                    onClick={() => setOpenMenuId(openMenuId === c.host ? null : c.host)}
-                                />
-                            }
-                        >
-                            <ActionList actionRole="menuitem" items={menuItems} />
-                        </Popover>
-                    )}
-                </HorizontalStack>
+            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host}>
+                {hostAvatar(c.host, c.iconUrl)}
+                <Box className="bext-grow">
+                    <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
+                    <Text variant="bodySm" color="subdued" truncate>
+                        {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
+                    </Text>
+                </Box>
+                <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
+                    title={c.active ? "Disable for this account" : "Enable"} />
+                {isCustom && (
+                    <Popover
+                        active={openMenuId === c.host}
+                        onClose={() => setOpenMenuId(null)}
+                        preferredAlignment="right"
+                        activator={
+                            <Button
+                                plain
+                                icon={HorizontalDotsMinor}
+                                accessibilityLabel={`Actions for ${c.name || c.host}`}
+                                onClick={() => setOpenMenuId(openMenuId === c.host ? null : c.host)}
+                            />
+                        }
+                    >
+                        <ActionList actionRole="menuitem" items={menuItems} />
+                    </Popover>
+                )}
             </Box>
         );
     };
 
     const configuredSection = (
-        <Box key="ext-configured" maxWidth="880px">
+        <Box key="ext-configured">
             <HorizontalStack align="space-between" blockAlign="start">
                 <Box>
-                    <Text variant="headingSm" as="h3">Inspected hosts</Text>
+                    <span className="bext-eyebrow">Inspected hosts</span>
                     {!loading && totalCount > 0 && (
-                        <Box paddingBlockStart="1">
-                            <HorizontalStack gap="2" blockAlign="center">
-                                <Text variant="bodySm" color="subdued">{totalCount} host{totalCount !== 1 ? "s" : ""}</Text>
-                                <Badge status="success">{`${activeCount} active`}</Badge>
-                                {offCount > 0 && <Badge>{`${offCount} off`}</Badge>}
-                            </HorizontalStack>
+                        <Box className="bext-summary">
+                            <span className="k"><b>{totalCount}</b> host{totalCount !== 1 ? "s" : ""}</span>
+                            <span className="k"><span className="d on" /><b>{activeCount}</b> active</span>
+                            {offCount > 0 && <span className="k"><span className="d off" /><b>{offCount}</b> off</span>}
                         </Box>
                     )}
                 </Box>
                 {!loading && totalCount > 0 && (
-                    <Box width="230px">
+                    <Box className="bext-filter">
                         <TextField
                             labelHidden label="Filter hosts" value={cfgFilter} onChange={setCfgFilter}
                             placeholder="Filter hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
@@ -377,9 +374,9 @@ function BrowserExtensionSettings() {
                     </Box>
                 ) : (
                     <VerticalStack gap="3">
-                        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
+                        <Box className="bext-list">
                             {visibleConfigured.length === 0
-                                ? <Box paddingBlock="4" paddingInline="5"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
+                                ? <Box className="bext-row"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
                                 : pagedConfigured.map(configuredRow)}
                         </Box>
                         {visibleConfigured.length > CONFIG_PAGE_SIZE && (
@@ -463,12 +460,12 @@ function BrowserExtensionSettings() {
 
                             {form.transport === "http" && (
                                 <HorizontalStack gap="4" wrap={false}>
-                                    <Box width="100%" minWidth="0">
+                                    <Box className="bext-grow">
                                         <Dropdown id="bext-method" label="Method"
                                             menuItems={["POST", "GET", "PUT", "PATCH"].map((m) => ({ label: m, value: m }))}
                                             initial={form.method} selected={(v) => setField("method", v)} />
                                     </Box>
-                                    <Box width="100%" minWidth="0">
+                                    <Box className="bext-grow">
                                         <Dropdown id="bext-format-http" label="Body format"
                                             menuItems={FORMAT_OPTIONS.http.map(([v, l]) => ({ label: l, value: v }))}
                                             initial={form.format} selected={(v) => setField("format", v)} />
@@ -488,11 +485,11 @@ function BrowserExtensionSettings() {
                                         <VerticalStack gap="2">
                                             {form.frameMatch.map((row, i) => (
                                                 <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
-                                                    <Box width="100%" minWidth="0">
+                                                    <Box className="bext-grow">
                                                         <TextField labelHidden label={`key ${i}`} value={row.k} onChange={(v) => setFmItem(i, "k", v)} placeholder="event" autoComplete="off" />
                                                     </Box>
                                                     <Text>=</Text>
-                                                    <Box width="100%" minWidth="0">
+                                                    <Box className="bext-grow">
                                                         <TextField labelHidden label={`value ${i}`} value={row.v} onChange={(v) => setFmItem(i, "v", v)} placeholder="send" autoComplete="off" />
                                                     </Box>
                                                     {form.frameMatch.length > 1 && (

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -52,10 +52,9 @@ function faviconFor(host, iconUrl) {
 }
 
 // Every favicon sits inside a unified white rounded tile so light/dark logos read evenly.
-function hostAvatar(host, iconUrl, size = "small") {
-    const sm = size === "extraSmall";
+function hostAvatar(host, iconUrl) {
     return (
-        <span className={`bext-tile ${sm ? "sm" : ""}`}>
+        <span className="bext-tile">
             <Avatar size="extraSmall" shape="square" source={faviconFor(host, iconUrl) || undefined} name={host} />
         </span>
     );

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,17 +1,17 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-    ActionList, Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
-    Modal, Pagination, Popover, SkeletonBodyText, SkeletonThumbnail, Text, TextField, Tooltip, VerticalStack,
+    Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
+    Modal, Text, TextField, Tooltip, VerticalStack,
 } from "@shopify/polaris";
-import { SearchMinor, HorizontalDotsMinor, DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
+import { DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
+import GithubSimpleTable from "../../../components/tables/GithubSimpleTable";
 import Dropdown from "../../../components/layouts/Dropdown";
 import { sharedIconCacheService } from "../../../components/shared/CollectionIcon";
 import func from "@/util/func";
 import api from "../../guardrails/api";
 import "./BrowserExtensionSettings.css";
 
-const CONFIG_PAGE_SIZE = 10;   // configured hosts per page
 
 // full config-driven custom-host form (mirrors the extension's monitoring-config schema)
 const EMPTY_FORM = {
@@ -64,9 +64,6 @@ function BrowserExtensionSettings() {
     const [configured, setConfigured] = useState([]);
     const [catalogue, setCatalogue] = useState([]);
     const [loading, setLoading] = useState(false);
-    const [cfgFilter, setCfgFilter] = useState("");
-    const [cfgPage, setCfgPage] = useState(0);            // configured list pagination (10 / page)
-    const [openMenuId, setOpenMenuId] = useState(null);   // which row's ⋯ menu is open
 
     // custom-host add/edit modal
     const [pickerOpen, setPickerOpen] = useState(false);
@@ -94,7 +91,6 @@ function BrowserExtensionSettings() {
     }, []);
 
     useEffect(() => { fetchAll(); }, [fetchAll]);
-    useEffect(() => { setCfgPage(0); }, [cfgFilter]);   // jump back to page 1 on a new filter
 
     // sort by the Mongo id (hexId) ascending — top brands were given the oldest ids, so they lead
     const idOf = (c) => c?.hexId || "￿";
@@ -129,18 +125,6 @@ function BrowserExtensionSettings() {
     const totalCount = mergedRows.length;
     const activeCount = useMemo(() => mergedRows.filter((r) => r.active).length, [mergedRows]);
     const offCount = totalCount - activeCount;
-
-    const visibleConfigured = useMemo(() => {
-        const q = cfgFilter.trim().toLowerCase();
-        if (!q) return mergedRows;
-        return mergedRows.filter((r) => (r.host || "").toLowerCase().includes(q) || (r.name || "").toLowerCase().includes(q));
-    }, [mergedRows, cfgFilter]);
-
-    // paginate the configured list (10 / page)
-    const cfgTotalPages = Math.max(1, Math.ceil(visibleConfigured.length / CONFIG_PAGE_SIZE));
-    const cfgPageSafe = Math.min(cfgPage, cfgTotalPages - 1);
-    const cfgStart = cfgPageSafe * CONFIG_PAGE_SIZE;
-    const pagedConfigured = visibleConfigured.slice(cfgStart, cfgStart + CONFIG_PAGE_SIZE);
 
     // ── write actions ───────────────────────────────────────────────────
     const toggleConfigured = async (host, nextActive) => {
@@ -279,124 +263,64 @@ function BrowserExtensionSettings() {
     };
 
     // ── configured section ──────────────────────────────────────────────
-    const skeletonList = (
-        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
-            {Array.from({ length: 5 }).map((_, i) => (
-                <Box className="bext-row" key={`sk-${i}`} paddingBlock="4" paddingInline="5">
-                    <HorizontalStack gap="3" blockAlign="center" wrap={false}>
-                        <SkeletonThumbnail size="small" />
-                        <Box width="100%" minWidth="0">
-                            <SkeletonBodyText lines={2} />
-                        </Box>
-                    </HorizontalStack>
-                </Box>
-            ))}
-        </Box>
-    );
+    // ── configured section — the product-standard table (search + pagination built in) ──
+    const tableHeaders = [
+        { text: "Host", value: "hostComp", itemOrder: 1 },
+        { text: "Domain", value: "domain", itemOrder: 2 },
+        { text: "Status", value: "statusComp", itemOrder: 3 },
+    ];
+    const tableResourceName = { singular: "host", plural: "hosts" };
 
-    const configuredRow = (c) => {
-        const isCustom = c.source === "custom";
-        const menuItems = [
-            { content: "Edit", onAction: () => { setOpenMenuId(null); openEdit(c); } },
-            { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
-        ];
-        return (
-            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host} paddingBlock="4" paddingInline="5">
-                <HorizontalStack gap="3" blockAlign="center" wrap={false}>
-                    {hostAvatar(c.host, c.iconUrl)}
-                    <Box width="100%" minWidth="0">
-                        <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
-                        <Text variant="bodySm" color="subdued" truncate>
-                            {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
-                        </Text>
-                    </Box>
-                    <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
-                        title={c.active ? "Disable for this account" : "Enable"} />
-                    {isCustom && (
-                        <Popover
-                            active={openMenuId === c.host}
-                            onClose={() => setOpenMenuId(null)}
-                            preferredAlignment="right"
-                            activator={
-                                <Button
-                                    plain
-                                    icon={HorizontalDotsMinor}
-                                    accessibilityLabel={`Actions for ${c.name || c.host}`}
-                                    onClick={() => setOpenMenuId(openMenuId === c.host ? null : c.host)}
-                                />
-                            }
-                        >
-                            <ActionList actionRole="menuitem" items={menuItems} />
-                        </Popover>
-                    )}
-                </HorizontalStack>
-            </Box>
-        );
+    // each row keeps its plain fields (host/name are what search matches) plus JSX cells; the search
+    // helper skips React elements, so the avatar/toggle cells are safe.
+    const tableData = useMemo(() => mergedRows.map((c) => ({
+        ...c,
+        id: c.host,
+        domain: c.host,
+        hostComp: (
+            <HorizontalStack gap="3" blockAlign="center" wrap={false}>
+                {hostAvatar(c.host, c.iconUrl)}
+                <Text fontWeight="medium">{c.name || c.host}</Text>
+            </HorizontalStack>
+        ),
+        statusComp: (
+            <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
+                title={c.active ? "Disable for this account" : "Enable"} />
+        ),
+    })), [mergedRows]);
+
+    // only account-added custom hosts can be edited/removed; catalogue hosts are toggled via the switch
+    const getRowActions = (item) => {
+        if (item.source !== "custom") return [];
+        return [{ items: [
+            { content: "Edit", onAction: () => openEdit(item) },
+            { content: "Remove", destructive: true, onAction: () => removeConfigured(item.host, item.hexId) },
+        ] }];
     };
 
     const configuredSection = (
-        <Box key="ext-configured" maxWidth="880px">
-            <HorizontalStack align="space-between" blockAlign="start">
-                <Box>
-                    <Text variant="headingSm" as="h3">Inspected hosts</Text>
-                    {!loading && totalCount > 0 && (
-                        <Box paddingBlockStart="1">
-                            <HorizontalStack gap="2" blockAlign="center">
-                                <Text variant="bodySm" color="subdued">{totalCount} host{totalCount !== 1 ? "s" : ""}</Text>
-                                <Badge status="success">{`${activeCount} active`}</Badge>
-                                {offCount > 0 && <Badge>{`${offCount} off`}</Badge>}
-                            </HorizontalStack>
-                        </Box>
-                    )}
-                </Box>
+        <Box key="ext-configured">
+            <VerticalStack gap="1">
+                <Text variant="headingSm" as="h3">Inspected hosts</Text>
                 {!loading && totalCount > 0 && (
-                    <Box width="230px">
-                        <TextField
-                            labelHidden label="Filter hosts" value={cfgFilter} onChange={setCfgFilter}
-                            placeholder="Filter hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
-                            autoComplete="off" clearButton onClearButtonClick={() => setCfgFilter("")}
-                        />
-                    </Box>
+                    <HorizontalStack gap="2" blockAlign="center">
+                        <Text variant="bodySm" color="subdued">{totalCount} host{totalCount !== 1 ? "s" : ""}</Text>
+                        <Badge status="success">{`${activeCount} active`}</Badge>
+                        {offCount > 0 && <Badge>{`${offCount} off`}</Badge>}
+                    </HorizontalStack>
                 )}
-            </HorizontalStack>
+            </VerticalStack>
             <Box paddingBlockStart="3">
-                {loading ? skeletonList : totalCount === 0 ? (
-                    <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" padding="10">
-                        <VerticalStack gap="4" inlineAlign="center">
-                            <Box background="bg-subdued" borderRadius="300" padding="3">
-                                <Icon source={SearchMinor} color="subdued" />
-                            </Box>
-                            <VerticalStack gap="1" inlineAlign="center">
-                                <Text variant="headingSm">No hosts yet</Text>
-                                <Text alignment="center" color="subdued">
-                                    Akto's supported hosts load here automatically. You can also add your own custom host.
-                                </Text>
-                            </VerticalStack>
-                            <Button primary onClick={openCustom}>Add custom host</Button>
-                        </VerticalStack>
-                    </Box>
-                ) : (
-                    <VerticalStack gap="3">
-                        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
-                            {visibleConfigured.length === 0
-                                ? <Box paddingBlock="4" paddingInline="5"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
-                                : pagedConfigured.map(configuredRow)}
-                        </Box>
-                        {visibleConfigured.length > CONFIG_PAGE_SIZE && (
-                            <Box paddingBlockStart="1">
-                                <HorizontalStack align="center" blockAlign="center" gap="4">
-                                    <Pagination
-                                        hasPrevious={cfgPageSafe > 0}
-                                        onPrevious={() => setCfgPage((p) => Math.max(0, p - 1))}
-                                        hasNext={cfgPageSafe < cfgTotalPages - 1}
-                                        onNext={() => setCfgPage((p) => Math.min(cfgTotalPages - 1, p + 1))}
-                                        label={`${cfgStart + 1}–${Math.min(cfgStart + CONFIG_PAGE_SIZE, visibleConfigured.length)} of ${visibleConfigured.length}`}
-                                    />
-                                </HorizontalStack>
-                            </Box>
-                        )}
-                    </VerticalStack>
-                )}
+                <GithubSimpleTable
+                    key="ext-table"
+                    data={tableData}
+                    resourceName={tableResourceName}
+                    headers={tableHeaders}
+                    loading={loading}
+                    getActions={getRowActions}
+                    hasRowActions={true}
+                    pageLimit={10}
+                />
             </Box>
         </Box>
     );

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,121 +1,699 @@
-import { useState, useEffect } from "react";
-import { Avatar, Badge, Button, HorizontalStack, Text } from "@shopify/polaris";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+    ActionList, Avatar, Box, Button, Divider, Form, HorizontalStack, Icon,
+    Modal, Pagination, Popover, Text, TextField, VerticalStack,
+} from "@shopify/polaris";
+import { SearchMinor, HorizontalDotsMinor, DeleteMinor } from "@shopify/polaris-icons";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
-import GithubSimpleTable from "../../../components/tables/GithubSimpleTable";
+import Dropdown from "../../../components/layouts/Dropdown";
+import { sharedIconCacheService } from "../../../components/shared/CollectionIcon";
 import func from "@/util/func";
 import api from "../../guardrails/api";
 
-const resourceName = {
-    singular: "config",
-    plural: "configs",
+const CONFIG_PAGE_SIZE = 10;   // configured hosts per page
+
+// full config-driven custom-host form (mirrors the extension's monitoring-config schema)
+const EMPTY_FORM = {
+    host: "", active: true, transport: "http",
+    method: "POST", format: "json",
+    paths: [""],            // request URL paths to intercept
+    promptPaths: [""],      // candidate paths to the prompt in the body (first match wins)
+    operations: [""],       // graphql only
+    frameMatch: [{ k: "", v: "" }],   // websocket only
+    responseFormat: "none", responsePath: "", modelPath: "",
+};
+// body-format options per transport
+const FORMAT_OPTIONS = {
+    http: [["json", "JSON"], ["form", "Form-encoded"], ["sse", "SSE stream"], ["connect-rpc", "Connect-RPC"], ["socket.io", "Socket.IO"], ["nested-envelope", "Nested-envelope"]],
+    websocket: [["ws-frame", "WS frame (JSON)"], ["dgw", "DGW (protobuf)"], ["socket.io", "Socket.IO"]],
+    graphql: [["json", "JSON"]],
 };
 
-const headings = [
-    { text: "Host", value: "hostComp", title: "Host" },
-    { text: "Status", value: "statusComp", title: "Status", filterKey: "status", showFilter: true },
-];
+// Scoped styles for behaviours inline styles can't express (hover-reveal, row hover, status dot).
+// Uses Polaris tokens so light/dark both track the theme.
+const CSS = `
+.bext-list { border:1px solid var(--p-color-border,#e9ebf1); border-radius:14px; overflow:hidden;
+  background:var(--p-color-bg-surface,#fff); box-shadow:0 1px 2px rgba(17,20,28,.04),0 4px 18px rgba(17,20,28,.05); }
+.bext-row { display:flex; align-items:center; gap:14px; padding:13px 16px;
+  border-top:1px solid var(--p-color-border-subdued,#eef0f4); transition:background .1s; }
+.bext-row:first-child { border-top:0; }
+.bext-row:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
+.bext-grow { flex:1; min-width:0; }
+.bext-switch:focus-visible { outline:2px solid var(--p-color-border-focus,#5b5bd6); outline-offset:2px; border-radius:999px; }
+.bext-summary { display:flex; align-items:center; gap:16px; margin-top:7px; }
+.bext-summary .k { display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--p-color-text-secondary,#5b6472); }
+.bext-summary .k b { color:var(--p-color-text,#14161c); font-weight:640; font-variant-numeric:tabular-nums; }
+.bext-summary .d { width:7px; height:7px; border-radius:50%; }
+/* unified favicon tile — every logo sits on the same white rounded surface */
+.bext-tile { width:38px; height:38px; border-radius:10px; flex:0 0 auto; background:var(--p-color-bg-surface,#fff);
+  border:1px solid var(--p-color-border,#e9ebf1); display:grid; place-items:center; box-shadow:0 1px 2px rgba(17,20,28,.06); overflow:hidden; }
+.bext-tile.sm { width:30px; height:30px; border-radius:8px; }
+.bext-sk { height:16px; border-radius:6px; background:linear-gradient(90deg,var(--p-color-bg-surface-secondary,#f3f5f8) 25%,var(--p-color-bg-surface-hover,#f6f7fa) 37%,var(--p-color-bg-surface-secondary,#f3f5f8) 63%); background-size:400% 100%; animation:bextsh 1.3s ease infinite; }
+@keyframes bextsh { 0%{background-position:100% 0} 100%{background-position:-100% 0} }
+@media (prefers-reduced-motion:reduce){ .bext-sk{ animation:none } }
+.bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
+  color:var(--p-color-text-secondary,#9aa2b1); }
+.bext-pick { display:flex; align-items:center; gap:13px; padding:10px 10px; border-radius:12px; cursor:pointer; border:1px solid transparent; transition:background .1s; }
+.bext-pick:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
+.bext-pick.sel { background:var(--p-color-bg-surface-selected,#f1f1fd); border-color:var(--p-color-border-emphasis,#cfcef6); }
+.bext-chk { width:22px; height:22px; border-radius:7px; border:1.5px solid var(--p-color-border-strong,#dfe2ea); flex:0 0 auto; display:grid; place-items:center; color:#fff; font-size:12px; transition:.12s; }
+.bext-pick.sel .bext-chk { background:var(--p-color-bg-fill-brand,#5b5bd6); border-color:var(--p-color-bg-fill-brand,#5b5bd6); }
+/* custom-host form: force the product's default text color (base Polaris Text/labels inherit a themed
+   green in this modal); keep subdued/critical variants intact. */
+.bext-form .Polaris-Choice__Label,
+.bext-form .Polaris-Text--root:not(.Polaris-Text--subdued):not(.Polaris-Text--critical) { color: var(--text-default, #202223); }
+/* premium light segmented control (replaces the heavy dark block) */
+.bext-seg { display:inline-flex; background:var(--p-color-bg-surface-secondary,#f3f5f8); border:1px solid var(--p-color-border-subdued,#eef0f4); border-radius:11px; padding:4px; gap:2px; }
+.bext-seg button { border:0; background:none; font:inherit; font-size:13px; font-weight:560; padding:7px 18px; border-radius:8px; color:var(--p-color-text-secondary,#5b6472); cursor:pointer; transition:.13s; }
+.bext-seg button.on { background:var(--p-color-bg-surface,#fff); color:var(--p-color-text,#14161c); box-shadow:0 1px 2px rgba(17,20,28,.10); }
+`;
 
-const sortOptions = [
-    { label: "Host", value: "host asc", directionLabel: "A-Z", sortKey: "host", columnIndex: 1 },
-    { label: "Host", value: "host desc", directionLabel: "Z-A", sortKey: "host", columnIndex: 1 },
-];
+// Lightweight, theme-aware toggle (Polaris ships no native switch in this version).
+function Switch({ active, onChange, title }) {
+    return (
+        <div
+            className="bext-switch"
+            role="switch" aria-checked={active} aria-label={title} tabIndex={0} title={title}
+            onClick={onChange}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(); } }}
+            style={{
+                width: 30, height: 18, borderRadius: 999, cursor: "pointer", position: "relative", flex: "0 0 auto",
+                transition: "background .18s ease",
+                background: active ? "var(--p-color-bg-fill-brand, #5a5ad6)" : "var(--p-color-bg-fill-tertiary, #e6e8ee)",
+                boxShadow: active ? "none" : "inset 0 0 0 1px var(--p-color-border, #e0e2e8)",
+            }}
+        >
+            <div style={{
+                position: "absolute", top: 3, left: active ? 15 : 3, width: 12, height: 12, borderRadius: "50%",
+                background: "#fff", boxShadow: "0 1px 2px rgba(17,20,28,.28)", transition: "left .18s ease",
+            }} />
+        </div>
+    );
+}
 
-const PAGE_LIMIT = 50;
+// Prefer a stored icon_url; otherwise derive the site's real favicon from its host (host == domain).
+// Avatar falls back to the host's initials if the favicon fails to load.
+function faviconFor(host, iconUrl) {
+    if (iconUrl) return iconUrl;
+    return host ? sharedIconCacheService.getFaviconUrl(host) : undefined;
+}
+
+// Every favicon sits inside a unified white rounded tile so light/dark logos read evenly.
+function hostAvatar(host, iconUrl, size = "small") {
+    const sm = size === "extraSmall";
+    return (
+        <span className={`bext-tile ${sm ? "sm" : ""}`}>
+            <Avatar size="extraSmall" shape="square" source={faviconFor(host, iconUrl) || undefined} name={host} />
+        </span>
+    );
+}
 
 function BrowserExtensionSettings() {
-    const [configs, setConfigs] = useState([]);
-    const [rawConfigs, setRawConfigs] = useState([]);
+    const [configured, setConfigured] = useState([]);
+    const [catalogue, setCatalogue] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [cfgFilter, setCfgFilter] = useState("");
+    const [cfgPage, setCfgPage] = useState(0);            // configured list pagination (10 / page)
+    const [openMenuId, setOpenMenuId] = useState(null);   // which row's ⋯ menu is open
 
-    useEffect(() => {
-        fetchConfigs();
-    }, []);
+    // unified "Add hosts" picker
+    const [pickerOpen, setPickerOpen] = useState(false);
+    const [mode, setMode] = useState("akto");          // "akto" | "custom"
+    const [pickSearch, setPickSearch] = useState("");
+    const [pickVisible, setPickVisible] = useState(40);   // how many catalogue rows are rendered (grows on scroll)
+    const [selected, setSelected] = useState(() => new Set());   // hosts checked for bulk add
+    const [adding, setAdding] = useState(false);
+    const [showAdv, setShowAdv] = useState(false);   // custom-form advanced section
+    const [showExample, setShowExample] = useState(false);   // custom-form worked example
+    const [form, setForm] = useState(EMPTY_FORM);
+    const [editingHexId, setEditingHexId] = useState(null);
+    const [formErrors, setFormErrors] = useState({});
+    const [saving, setSaving] = useState(false);
 
-    const fetchConfigs = async () => {
+    const fetchAll = useCallback(async () => {
         setLoading(true);
         try {
-            const response = await api.fetchBrowserExtensionConfigsCommon();
-            if (response && response.browserExtensionConfigsCommon) {
-                setRawConfigs(response.browserExtensionConfigsCommon);
-                const formatted = response.browserExtensionConfigsCommon.map((config, index) => {
-                    const isBeta = (config.tag || "").toLowerCase() === "beta";
-                    const status = config.active ? "Active" : "Inactive";
-                    return {
-                        id: config.hexId || `${config.host}-${index}`,
-                        host: config.host,
-                        status,
-                        hostComp: (
-                            <HorizontalStack gap="2" blockAlign="center">
-                                <Avatar size="extraSmall" shape="square" source={config.iconUrl || undefined} name={config.host} />
-                                <Text variant="bodyMd">{config.host}</Text>
-                                {isBeta && <Badge size="small" status="info">Beta</Badge>}
-                            </HorizontalStack>
-                        ),
-                        statusComp: (
-                            <Badge tone={config.active ? "success" : undefined} size="small">
-                                {status}
-                            </Badge>
-                        ),
-                    };
-                });
-                setConfigs(formatted);
-            } else {
-                setRawConfigs([]);
-                setConfigs([]);
-            }
+            const [accountResp, commonResp] = await Promise.all([
+                api.fetchBrowserExtensionConfigs(),
+                api.fetchBrowserExtensionConfigsCommon(),
+            ]);
+            setConfigured(accountResp?.browserExtensionConfigs || []);
+            setCatalogue(commonResp?.browserExtensionConfigsCommon || []);
         } catch (error) {
             func.setToast(true, true, "Failed to load browser extension configs");
         } finally {
             setLoading(false);
         }
+    }, []);
+
+    useEffect(() => { fetchAll(); }, [fetchAll]);
+    useEffect(() => { setCfgPage(0); }, [cfgFilter]);   // jump back to page 1 on a new filter
+    useEffect(() => { setPickVisible(40); }, [pickSearch]);   // reset picker window on a new search
+
+    const catalogueByHost = useMemo(() => {
+        const map = {};
+        catalogue.forEach((c) => { map[(c.host || "").toLowerCase()] = c; });
+        return map;
+    }, [catalogue]);
+
+    const configuredHostSet = useMemo(
+        () => new Set(configured.map((c) => (c.host || "").toLowerCase())),
+        [configured]
+    );
+
+    const activeCount = useMemo(() => configured.filter((c) => c.active).length, [configured]);
+    const offCount = configured.length - activeCount;
+
+    // sort by the Mongo id (hexId) ascending — top brands were given the oldest ids, so they lead
+    const idOf = (c) => c?.hexId || "￿";
+    const byId = (a, b) => idOf(a).localeCompare(idOf(b));
+
+    const visibleConfigured = useMemo(() => {
+        const q = cfgFilter.trim().toLowerCase();
+        const list = q ? configured.filter((c) => (c.host || "").toLowerCase().includes(q)) : configured.slice();
+        // top brands follow the defined catalogue rank (ChatGPT, Claude, DeepSeek, Gemini, …)
+        return list.sort((a, b) => {
+            const ca = catalogueByHost[(a.host || "").toLowerCase()];
+            const cb = catalogueByHost[(b.host || "").toLowerCase()];
+            return idOf(ca).localeCompare(idOf(cb));
+        });
+    }, [configured, cfgFilter, catalogueByHost]);
+
+    // paginate the configured list (10 / page)
+    const cfgTotalPages = Math.max(1, Math.ceil(visibleConfigured.length / CONFIG_PAGE_SIZE));
+    const cfgPageSafe = Math.min(cfgPage, cfgTotalPages - 1);
+    const cfgStart = cfgPageSafe * CONFIG_PAGE_SIZE;
+    const pagedConfigured = visibleConfigured.slice(cfgStart, cfgStart + CONFIG_PAGE_SIZE);
+
+    // ── write actions ───────────────────────────────────────────────────
+    const toggleConfigured = async (host, nextActive) => {
+        try {
+            await api.setBrowserExtensionConfigActive(host, nextActive);
+            await fetchAll();
+        } catch (error) {
+            func.setToast(true, true, "Failed to update host");
+        }
+    };
+    const removeConfigured = (host, hexId) => {
+        func.showConfirmationModal(`Remove ${host} from configured hosts?`, "Remove", async () => {
+            try {
+                await api.deleteBrowserExtensionConfigs([hexId]);
+                func.setToast(true, false, `${host} removed`);
+                await fetchAll();
+            } catch (error) {
+                func.setToast(true, true, "Failed to remove host");
+            }
+        });
     };
 
-    const disambiguateLabel = (key, value) => {
-        return func.convertToDisambiguateLabelObj(value, null, 2);
+    // ── picker (add / edit) ─────────────────────────────────────────────
+    const openPicker = (m = "akto") => {
+        setMode(m); setPickSearch(""); setPickVisible(40); setSelected(new Set()); setForm(EMPTY_FORM);
+        setEditingHexId(null); setFormErrors({}); setShowAdv(false); setShowExample(false); setPickerOpen(true);
+    };
+    const toggleSelected = (host) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            next.has(host) ? next.delete(host) : next.add(host);
+            return next;
+        });
+    };
+    const addSelected = async () => {
+        const hosts = [...selected];
+        if (hosts.length === 0) return;
+        setAdding(true);
+        try {
+            for (const host of hosts) {
+                await api.setBrowserExtensionConfigActive(host, true);
+            }
+            func.setToast(true, false, `${hosts.length} host${hosts.length !== 1 ? "s" : ""} added`);
+            setSelected(new Set());
+            await fetchAll();
+        } catch (error) {
+            func.setToast(true, true, "Failed to add hosts");
+        } finally {
+            setAdding(false);
+        }
+    };
+    const openEdit = (config) => {
+        setMode("custom");
+        const asArr = (v) => (Array.isArray(v) ? v : v ? [v] : []);
+        const promptPaths = asArr(config.path);
+        const fmEntries = config.frameMatch ? Object.entries(config.frameMatch).map(([k, v]) => ({ k, v: String(v) })) : [];
+        setForm({
+            host: config.host || "", active: config.active !== false,
+            transport: config.transport || "http",
+            method: config.method || "POST",
+            format: config.format || (config.transport === "websocket" ? "ws-frame" : "json"),
+            paths: (config.paths && config.paths.length) ? [...config.paths] : [""],
+            promptPaths: promptPaths.length ? promptPaths : [""],
+            operations: (config.operations && config.operations.length) ? [...config.operations] : [""],
+            frameMatch: fmEntries.length ? fmEntries : [{ k: "", v: "" }],
+            responseFormat: config.responseFormat || "none",
+            responsePath: asArr(config.responsePath)[0] || "",
+            modelPath: asArr(config.modelPath)[0] || "",
+        });
+        setEditingHexId(config.hexId); setFormErrors({}); setShowAdv(!!config.responseFormat); setPickerOpen(true);
+    };
+    const closePicker = () => {
+        setPickerOpen(false); setForm(EMPTY_FORM); setEditingHexId(null); setFormErrors({}); setShowAdv(false); setShowExample(false);
+    };
+    // form helpers for the repeatable array fields
+    const setField = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+    const setArrItem = (k, i, v) => setForm((f) => ({ ...f, [k]: f[k].map((x, j) => (j === i ? v : x)) }));
+    const addArrItem = (k, blank = "") => setForm((f) => ({ ...f, [k]: [...f[k], blank] }));
+    const rmArrItem = (k, i) => setForm((f) => ({ ...f, [k]: f[k].length > 1 ? f[k].filter((_, j) => j !== i) : f[k] }));
+    const setFmItem = (i, key, val) => setForm((f) => ({ ...f, frameMatch: f.frameMatch.map((x, j) => (j === i ? { ...x, [key]: val } : x)) }));
+
+    // renders a labelled list of monospaced text inputs with add/remove (paths, prompt paths, operations)
+    const renderRepeatable = (key, { label, sub, placeholder, helpText, addLabel, error }) => (
+        <VerticalStack gap="1">
+            <Text variant="bodyMd" fontWeight="semibold">
+                {label}{sub && <Text as="span" color="subdued"> {sub}</Text>}
+            </Text>
+            <VerticalStack gap="2">
+                {form[key].map((val, i) => (
+                    <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <TextField labelHidden label={`${label} ${i + 1}`} value={val}
+                                onChange={(v) => setArrItem(key, i, v)} placeholder={placeholder} autoComplete="off" monospaced />
+                        </div>
+                        {form[key].length > 1 && (
+                            <Button plain icon={DeleteMinor} accessibilityLabel="Remove" onClick={() => rmArrItem(key, i)} />
+                        )}
+                    </HorizontalStack>
+                ))}
+            </VerticalStack>
+            <div><Button plain onClick={() => addArrItem(key)}>{addLabel}</Button></div>
+            {error && <Text variant="bodySm" color="critical">{error}</Text>}
+            {helpText && <Text variant="bodySm" color="subdued">{helpText}</Text>}
+        </VerticalStack>
+    );
+
+    const saveCustom = async () => {
+        const host = form.host.trim();
+        const paths = form.paths.map((p) => p.trim()).filter(Boolean);
+        const promptPaths = form.promptPaths.map((p) => p.trim()).filter(Boolean);
+        const errors = {};
+        if (!host) errors.host = "Host is required";
+        if (paths.length === 0) errors.paths = "At least one request path is required";
+        if (Object.keys(errors).length > 0) { setFormErrors(errors); return; }
+
+        const payload = { host, active: form.active, paths, transport: form.transport };
+        if (form.transport === "http") { payload.method = form.method; payload.format = form.format; }
+        else if (form.transport === "websocket") {
+            payload.format = form.format;
+            const fm = {};
+            form.frameMatch.forEach(({ k, v }) => { if (k.trim() && v.trim()) fm[k.trim()] = v.trim(); });
+            if (Object.keys(fm).length) payload.frameMatch = fm;
+        } else if (form.transport === "graphql") {
+            payload.format = "json";
+            const ops = form.operations.map((o) => o.trim()).filter(Boolean);
+            if (ops.length) payload.operations = ops;
+        }
+        if (promptPaths.length) payload.path = promptPaths;
+        if (form.responseFormat && form.responseFormat !== "none") {
+            payload.responseFormat = form.responseFormat;
+            if (form.responsePath.trim()) payload.responsePath = [form.responsePath.trim()];
+            if (form.modelPath.trim()) payload.modelPath = [form.modelPath.trim()];
+        }
+
+        setSaving(true);
+        try {
+            await api.saveBrowserExtensionConfig(payload, editingHexId || undefined);
+            func.setToast(true, false, `Config ${editingHexId ? "updated" : "added"} successfully`);
+            closePicker();
+            await fetchAll();
+        } catch (error) {
+            func.setToast(true, true, "Failed to save config");
+        } finally {
+            setSaving(false);
+        }
     };
 
-    // Build flat rows (arrays joined so they don't break CSV columns) and reuse func.downloadAsCSV.
     const handleDownload = () => {
-        if (rawConfigs.length === 0) {
-            func.setToast(true, true, "No configs to download");
+        if (configured.length === 0) {
+            func.setToast(true, true, "No configured hosts to download");
             return;
         }
-        const rows = rawConfigs.map((config) => ({
-            Host: config.host || "-",
-            Transport: config.transport || "-",
-            Method: config.method || "-",
-            Operations: (config.operations || []).join(" & ") || "-",
-            Paths: (config.paths || []).join(" & ") || "-",
-            Format: config.format || "-",
-            IconUrl: config.iconUrl || "-",
+        const rows = configured.map((c) => ({
+            Host: c.host || "-",
+            Source: catalogueByHost[(c.host || "").toLowerCase()] ? "Akto" : "Custom",
+            Status: c.active ? "Active" : "Inactive",
+            Paths: (c.paths || []).join(" & ") || "-",
         }));
         func.downloadAsCSV(rows, { name: "browser_extension_configs" });
     };
 
-    const configTable = (
-        <GithubSimpleTable
-            key="ext-common-configs"
-            resourceName={resourceName}
-            useNewRow={true}
-            headers={headings}
-            headings={headings}
-            data={configs}
-            pageLimit={PAGE_LIMIT}
-            sortOptions={sortOptions}
-            disambiguateLabel={disambiguateLabel}
-            loading={loading}
-            showFooter={false}
-        />
+    // ── configured section ──────────────────────────────────────────────
+    const skeletonList = (
+        <div className="bext-list">
+            {Array.from({ length: 5 }).map((_, i) => (
+                <div className="bext-row" key={`sk-${i}`}>
+                    <div className="bext-sk" style={{ width: 36, height: 36, borderRadius: 9 }} />
+                    <div className="bext-grow">
+                        <div className="bext-sk" style={{ width: 130 }} />
+                        <div className="bext-sk" style={{ width: 80, height: 11, marginTop: 7 }} />
+                    </div>
+                    <div className="bext-sk" style={{ width: 70, height: 14 }} />
+                </div>
+            ))}
+        </div>
+    );
+
+    const configuredRow = (c) => {
+        const common = catalogueByHost[(c.host || "").toLowerCase()];
+        const isAkto = !!common;
+        const menuItems = [
+            ...(!isAkto ? [{ content: "Edit", onAction: () => { setOpenMenuId(null); openEdit(c); } }] : []),
+            { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
+        ];
+        return (
+            <div className="bext-row" key={c.hexId} style={{ opacity: c.active ? 1 : 0.6 }}>
+                {hostAvatar(c.host, common?.iconUrl)}
+                <div className="bext-grow">
+                    <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
+                    <Text variant="bodySm" color="subdued" truncate>
+                        {common?.name ? c.host : (isAkto ? "Akto" : ((c.paths || []).join(", ") || "Custom"))}
+                    </Text>
+                </div>
+                <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
+                    title={c.active ? "Disable" : "Enable"} />
+                <Popover
+                    active={openMenuId === c.hexId}
+                    onClose={() => setOpenMenuId(null)}
+                    preferredAlignment="right"
+                    activator={
+                        <Button
+                            plain
+                            icon={HorizontalDotsMinor}
+                            accessibilityLabel={`Actions for ${common?.name || c.host}`}
+                            onClick={() => setOpenMenuId(openMenuId === c.hexId ? null : c.hexId)}
+                        />
+                    }
+                >
+                    <ActionList actionRole="menuitem" items={menuItems} />
+                </Popover>
+            </div>
+        );
+    };
+
+    const configuredSection = (
+        <div key="ext-configured">
+            <HorizontalStack align="space-between" blockAlign="start">
+                <div>
+                    <span className="bext-eyebrow">Configured</span>
+                    {!loading && configured.length > 0 && (
+                        <div className="bext-summary">
+                            <span className="k"><b>{configured.length}</b> host{configured.length !== 1 ? "s" : ""}</span>
+                            <span className="k"><span className="d" style={{ background: "var(--p-color-bg-fill-success, #1f9d55)" }} /><b>{activeCount}</b> active</span>
+                            {offCount > 0 && <span className="k"><span className="d" style={{ background: "var(--p-color-icon-disabled, #98a1b0)" }} /><b>{offCount}</b> off</span>}
+                        </div>
+                    )}
+                </div>
+                {!loading && configured.length > 0 && (
+                    <div style={{ width: 230 }}>
+                        <TextField
+                            labelHidden label="Filter configured" value={cfgFilter} onChange={setCfgFilter}
+                            placeholder="Filter configured…" prefix={<Icon source={SearchMinor} color="subdued" />}
+                            autoComplete="off" clearButton onClearButtonClick={() => setCfgFilter("")}
+                        />
+                    </div>
+                )}
+            </HorizontalStack>
+            <Box paddingBlockStart="3">
+                {loading ? skeletonList : configured.length === 0 ? (
+                    <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" padding="10">
+                        <VerticalStack gap="4" inlineAlign="center">
+                            <Box background="bg-subdued" borderRadius="300" padding="3">
+                                <Icon source={SearchMinor} color="subdued" />
+                            </Box>
+                            <VerticalStack gap="1" inlineAlign="center">
+                                <Text variant="headingSm">No hosts configured yet</Text>
+                                <Text alignment="center" color="subdued">
+                                    Add from Akto's supported catalogue below, or add your own custom host.
+                                </Text>
+                            </VerticalStack>
+                            <Button primary onClick={() => openPicker("akto")}>Add hosts</Button>
+                        </VerticalStack>
+                    </Box>
+                ) : (
+                    <VerticalStack gap="3">
+                        <div className="bext-list">
+                            {visibleConfigured.length === 0
+                                ? <div className="bext-row"><Text color="subdued">No configured hosts match “{cfgFilter}”.</Text></div>
+                                : pagedConfigured.map(configuredRow)}
+                        </div>
+                        {visibleConfigured.length > CONFIG_PAGE_SIZE && (
+                            <Box paddingBlockStart="1">
+                                <HorizontalStack align="center" blockAlign="center" gap="4">
+                                    <Pagination
+                                        hasPrevious={cfgPageSafe > 0}
+                                        onPrevious={() => setCfgPage((p) => Math.max(0, p - 1))}
+                                        hasNext={cfgPageSafe < cfgTotalPages - 1}
+                                        onNext={() => setCfgPage((p) => Math.min(cfgTotalPages - 1, p + 1))}
+                                        label={`${cfgStart + 1}–${Math.min(cfgStart + CONFIG_PAGE_SIZE, visibleConfigured.length)} of ${visibleConfigured.length}`}
+                                    />
+                                </HorizontalStack>
+                            </Box>
+                        )}
+                    </VerticalStack>
+                )}
+            </Box>
+        </div>
+    );
+
+    // ── picker modal ────────────────────────────────────────────────────
+    // Catalogue minus already-configured hosts (added ones aren't shown), sorted top-first.
+    const availableCatalogue = catalogue.filter((c) => !configuredHostSet.has((c.host || "").toLowerCase()));
+    const pickQuery = pickSearch.trim().toLowerCase();
+    const pickFilteredAll = availableCatalogue
+        .filter((c) => !pickQuery || (c.host || "").toLowerCase().includes(pickQuery) || (c.name || "").toLowerCase().includes(pickQuery))
+        .slice()
+        .sort(byId);
+    // render a growing window so the list scrolls smoothly through everything
+    const pickFiltered = pickFilteredAll.slice(0, pickVisible);
+
+    const pickRow = (c) => {
+        const isSel = selected.has(c.host);
+        return (
+            <div
+                className={`bext-pick ${isSel ? "sel" : ""}`} key={c.host}
+                role="checkbox" aria-checked={isSel} tabIndex={0}
+                onClick={() => toggleSelected(c.host)}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSelected(c.host); } }}
+            >
+                <div className="bext-chk">{isSel ? "✓" : ""}</div>
+                {hostAvatar(c.host, c.iconUrl, "small")}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
+                    {c.name && <Text variant="bodySm" color="subdued" truncate>{c.host}</Text>}
+                </div>
+            </div>
+        );
+    };
+
+    const pickerModal = (
+        <Modal
+            key="ext-picker" open={pickerOpen} onClose={closePicker}
+            title={editingHexId ? "Edit host" : "Add hosts"}
+            primaryAction={mode === "custom"
+                ? { content: editingHexId ? "Save" : "Add config", onAction: saveCustom, loading: saving }
+                : { content: selected.size ? `Add ${selected.size}` : "Add", onAction: addSelected, disabled: selected.size === 0, loading: adding }}
+            secondaryActions={[{ content: mode === "custom" ? "Cancel" : "Done", onAction: closePicker }]}
+        >
+            {!editingHexId && (
+                <Modal.Section>
+                    <div className="bext-seg">
+                        <button className={mode === "akto" ? "on" : ""} onClick={() => setMode("akto")}>Akto catalogue</button>
+                        <button className={mode === "custom" ? "on" : ""} onClick={() => setMode("custom")}>Custom host</button>
+                    </div>
+                </Modal.Section>
+            )}
+            <Modal.Section>
+                {mode === "akto" ? (
+                    <VerticalStack gap="3">
+                        <TextField
+                            labelHidden label="Search supported hosts" value={pickSearch} onChange={setPickSearch}
+                            placeholder="Search supported hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
+                            autoComplete="off" clearButton onClearButtonClick={() => setPickSearch("")}
+                        />
+                        <HorizontalStack align="end" blockAlign="center">
+                            <Text variant="bodySm" color="subdued">
+                                {pickQuery
+                                    ? `${pickFilteredAll.length} ${pickFilteredAll.length === 1 ? "result" : "results"}`
+                                    : `${pickFilteredAll.length.toLocaleString()} supported hosts`}
+                            </Text>
+                        </HorizontalStack>
+                        {pickFiltered.length === 0 ? (
+                            <Box padding="6">
+                                <VerticalStack gap="3" inlineAlign="center">
+                                    <Text alignment="center" color="subdued">No supported host matches “{pickSearch.trim()}”.</Text>
+                                    {pickQuery && (
+                                        <Button onClick={() => { setForm({ ...EMPTY_FORM, host: pickSearch.trim() }); setFormErrors({}); setMode("custom"); }}>
+                                            {`＋ Add “${pickSearch.trim()}” as a custom host`}
+                                        </Button>
+                                    )}
+                                </VerticalStack>
+                            </Box>
+                        ) : (
+                            <div
+                                style={{ maxHeight: "44vh", overflowY: "auto", margin: "0 -4px" }}
+                                onScroll={(e) => {
+                                    const el = e.currentTarget;
+                                    if (el.scrollHeight - el.scrollTop - el.clientHeight < 160) {
+                                        setPickVisible((v) => (v < pickFilteredAll.length ? v + 40 : v));
+                                    }
+                                }}
+                            >
+                                {pickFiltered.map(pickRow)}
+                            </div>
+                        )}
+                    </VerticalStack>
+                ) : (
+                    <div className="form-class bext-form">
+                    <Form onSubmit={saveCustom}>
+                        <VerticalStack gap="4">
+                            {!editingHexId && (
+                                <Box background="bg-surface-secondary" borderRadius="200" padding="3">
+                                    <VerticalStack gap="2">
+                                        <HorizontalStack align="space-between" blockAlign="center" gap="2">
+                                            <Text variant="bodySm" color="subdued">Not sure what to enter? See a worked example.</Text>
+                                            <Button plain disclosure={showExample ? "up" : "down"} onClick={() => setShowExample((s) => !s)}>
+                                                {showExample ? "Hide example" : "See an example"}
+                                            </Button>
+                                        </HorizontalStack>
+                                        {showExample && (
+                                            <VerticalStack gap="2">
+                                                <Text variant="bodySm" fontWeight="semibold">Example — ChatGPT (chatgpt.com)</Text>
+                                                <Text variant="bodySm" color="subdued">
+                                                    When you send a message on ChatGPT, the site makes this request — each field below maps to a part of it:
+                                                </Text>
+                                                <VerticalStack gap="1">
+                                                    <Text variant="bodySm"><b>Host</b> → <code>chatgpt.com</code> — the domain the chat runs on.</Text>
+                                                    <Text variant="bodySm"><b>Transport</b> → HTTP · <b>Method</b> → POST · <b>Body format</b> → JSON.</Text>
+                                                    <Text variant="bodySm"><b>Request path</b> → <code>/backend-api/conversation</code> — the network call fired when you hit send.</Text>
+                                                    <Text variant="bodySm"><b>Prompt location</b> → <code>messages[-1].content.parts</code> — where your typed text sits inside that request's JSON body.</Text>
+                                                </VerticalStack>
+                                                <Text variant="bodySm" color="subdued">
+                                                    Tip: open DevTools → Network, send one message on the site, find the request, and read its payload to fill these in.
+                                                </Text>
+                                            </VerticalStack>
+                                        )}
+                                    </VerticalStack>
+                                </Box>
+                            )}
+                            <TextField
+                                label="Host" value={form.host} onChange={(v) => setField("host", v)}
+                                placeholder="chat.example.com" error={formErrors.host} autoComplete="off" monospaced
+                                helpText="The domain the chat UI runs on — no https:// or path."
+                                disabled={!!editingHexId}
+                            />
+                            <Dropdown
+                                id="bext-transport" label="Transport"
+                                menuItems={[{ label: "HTTP", value: "http" }, { label: "WebSocket", value: "websocket" }, { label: "GraphQL", value: "graphql" }]}
+                                initial={form.transport}
+                                selected={(v) => setForm((f) => ({ ...f, transport: v, format: FORMAT_OPTIONS[v][0][0] }))}
+                            />
+
+                            {renderRepeatable("paths", {
+                                label: "Request paths", placeholder: "/api/chat",
+                                helpText: "Request URLs to intercept. Wildcards ok: /api/*, /threads/*/messages.",
+                                addLabel: "＋ Add path", error: formErrors.paths,
+                            })}
+
+                            {form.transport === "http" && (
+                                <HorizontalStack gap="4" wrap={false}>
+                                    <div style={{ flex: 1 }}>
+                                        <Dropdown id="bext-method" label="Method"
+                                            menuItems={["POST", "GET", "PUT", "PATCH"].map((m) => ({ label: m, value: m }))}
+                                            initial={form.method} selected={(v) => setField("method", v)} />
+                                    </div>
+                                    <div style={{ flex: 1 }}>
+                                        <Dropdown id="bext-format-http" label="Body format"
+                                            menuItems={FORMAT_OPTIONS.http.map(([v, l]) => ({ label: l, value: v }))}
+                                            initial={form.format} selected={(v) => setField("format", v)} />
+                                    </div>
+                                </HorizontalStack>
+                            )}
+
+                            {form.transport === "websocket" && (
+                                <>
+                                    <Dropdown id="bext-format-ws" label="Frame format"
+                                        menuItems={FORMAT_OPTIONS.websocket.map(([v, l]) => ({ label: l, value: v }))}
+                                        initial={form.format} selected={(v) => setField("format", v)} />
+                                    <VerticalStack gap="1">
+                                        <Text variant="bodyMd" fontWeight="semibold">
+                                            Frame match <Text as="span" color="subdued">— which frame carries the prompt</Text>
+                                        </Text>
+                                        <VerticalStack gap="2">
+                                            {form.frameMatch.map((row, i) => (
+                                                <HorizontalStack key={i} gap="2" wrap={false} blockAlign="center">
+                                                    <div style={{ flex: 1, minWidth: 0 }}>
+                                                        <TextField labelHidden label={`key ${i}`} value={row.k} onChange={(v) => setFmItem(i, "k", v)} placeholder="event" autoComplete="off" monospaced />
+                                                    </div>
+                                                    <Text>=</Text>
+                                                    <div style={{ flex: 1, minWidth: 0 }}>
+                                                        <TextField labelHidden label={`value ${i}`} value={row.v} onChange={(v) => setFmItem(i, "v", v)} placeholder="send" autoComplete="off" monospaced />
+                                                    </div>
+                                                    {form.frameMatch.length > 1 && (
+                                                        <Button plain icon={DeleteMinor} accessibilityLabel="Remove" onClick={() => rmArrItem("frameMatch", i)} />
+                                                    )}
+                                                </HorizontalStack>
+                                            ))}
+                                        </VerticalStack>
+                                        <Box paddingBlockStart="2"><Button plain onClick={() => addArrItem("frameMatch", { k: "", v: "" })}>＋ Add condition</Button></Box>
+                                    </VerticalStack>
+                                </>
+                            )}
+
+                            {form.transport === "graphql" && renderRepeatable("operations", {
+                                label: "Operations", sub: "— which GraphQL ops to gate",
+                                placeholder: "sendMessageMutation", addLabel: "＋ Add operation",
+                            })}
+
+                            {renderRepeatable("promptPaths", {
+                                label: "Prompt location", placeholder: "messages[-1].content",
+                                helpText: "Where the user's prompt sits in the body (JSONPath-ish). First matching path wins.",
+                                addLabel: "＋ Add fallback path",
+                            })}
+
+                            <Divider />
+                            <Button plain disclosure={showAdv ? "up" : "down"} onClick={() => setShowAdv((s) => !s)}>
+                                Advanced — response &amp; model
+                            </Button>
+                            {showAdv && (
+                                <VerticalStack gap="4">
+                                    <Dropdown id="bext-response-format" label="Response format"
+                                        menuItems={[{ label: "None", value: "none" }, { label: "SSE", value: "sse" }, { label: "JSON", value: "json" }, { label: "Nested-envelope", value: "nested-envelope" }]}
+                                        initial={form.responseFormat} selected={(v) => setField("responseFormat", v)} />
+                                    <TextField label="Response path" value={form.responsePath} onChange={(v) => setField("responsePath", v)}
+                                        placeholder="choices[*].delta.content" autoComplete="off" monospaced helpText="Where the AI answer is in the response." />
+                                    <TextField label="Model path" value={form.modelPath} onChange={(v) => setField("modelPath", v)}
+                                        placeholder="model" autoComplete="off" monospaced helpText="Where the model name is." />
+                                </VerticalStack>
+                            )}
+                        </VerticalStack>
+                    </Form>
+                    </div>
+                )}
+            </Modal.Section>
+        </Modal>
     );
 
     return (
-        <PageWithMultipleCards
-            title={"Browser Extension"}
-            subtitle={"Available in Extension v1.0.61 and later"}
-            isFirstPage={true}
-            primaryAction={<Button primary onClick={handleDownload} disabled={loading || rawConfigs.length === 0}>Download</Button>}
-            components={[configTable]}
-        />
+        <>
+            <style>{CSS}</style>
+            <PageWithMultipleCards
+                title={"Browser Extension"}
+                subtitle={"Choose which hosts the Akto extension inspects. Available in v1.0.61 and later."}
+                isFirstPage={true}
+                fullWidth={false}
+                primaryAction={<Button primary onClick={() => openPicker("akto")}>Add hosts</Button>}
+                secondaryActions={<Button onClick={handleDownload} disabled={loading || configured.length === 0}>Download</Button>}
+                components={[pickerModal, configuredSection]}
+            />
+        </>
     );
 }
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-    ActionList, Avatar, Box, Button, Divider, Form, HorizontalStack, Icon,
+    ActionList, Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
     Modal, Pagination, Popover, Text, TextField, Tooltip, VerticalStack,
 } from "@shopify/polaris";
 import { SearchMinor, HorizontalDotsMinor, DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
@@ -12,6 +12,8 @@ import api from "../../guardrails/api";
 import "./BrowserExtensionSettings.css";
 
 const CONFIG_PAGE_SIZE = 10;   // configured hosts per page
+const STABLE_COUNT = 5;        // top N ranked hosts are GA; every other supported host is beta
+const BETA_TOOLTIP = "Beta — support for this host is still experimental and may change.";
 
 // full config-driven custom-host form (mirrors the extension's monitoring-config schema)
 const EMPTY_FORM = {
@@ -129,6 +131,23 @@ function BrowserExtensionSettings() {
     // sort by the Mongo id (hexId) ascending — top brands were given the oldest ids, so they lead
     const idOf = (c) => c?.hexId || "￿";
     const byId = (a, b) => idOf(a).localeCompare(idOf(b));
+
+    // The top STABLE_COUNT ranked hosts are GA; every other supported host is beta. Derived from
+    // rank so there is no per-document flag to maintain (see removed `tag`).
+    const stableHosts = useMemo(
+        () => new Set(catalogue.slice().sort(byId).slice(0, STABLE_COUNT).map((c) => (c.host || "").toLowerCase())),
+        [catalogue]
+    );
+    // A supported (catalogue) host beyond the top STABLE_COUNT is beta; custom hosts carry no badge.
+    const isBeta = (host) => {
+        const key = (host || "").toLowerCase();
+        return !!catalogueByHost[key] && !stableHosts.has(key);
+    };
+    const betaBadge = (host) => isBeta(host) && (
+        <Tooltip content={BETA_TOOLTIP} dismissOnMouseOut>
+            <Badge status="attention">Beta</Badge>
+        </Tooltip>
+    );
 
     const visibleConfigured = useMemo(() => {
         const q = cfgFilter.trim().toLowerCase();
@@ -334,7 +353,10 @@ function BrowserExtensionSettings() {
             <Box className="bext-row" key={c.hexId} style={{ opacity: c.active ? 1 : 0.6 }}>
                 {hostAvatar(c.host, common?.iconUrl)}
                 <Box className="bext-grow">
-                    <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
+                    <HorizontalStack gap="2" blockAlign="center">
+                        <Text variant="bodyMd" fontWeight="medium" truncate>{common?.name || c.host}</Text>
+                        {betaBadge(c.host)}
+                    </HorizontalStack>
                     <Text variant="bodySm" color="subdued" truncate>
                         {common?.name ? c.host : (isAkto ? "Akto" : ((c.paths || []).join(", ") || "Custom"))}
                     </Text>
@@ -448,7 +470,10 @@ function BrowserExtensionSettings() {
                 <Box className="bext-chk">{isSel ? "✓" : ""}</Box>
                 {hostAvatar(c.host, c.iconUrl, "small")}
                 <Box style={{ flex: 1, minWidth: 0 }}>
-                    <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
+                    <HorizontalStack gap="2" blockAlign="center">
+                        <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
+                        {betaBadge(c.host)}
+                    </HorizontalStack>
                     {c.name && <Text variant="bodySm" color="subdued" truncate>{c.host}</Text>}
                 </Box>
             </Box>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
     ActionList, Avatar, Box, Button, Divider, Form, HorizontalStack, Icon,
-    Modal, Pagination, Popover, Text, TextField, VerticalStack,
+    Modal, Pagination, Popover, Text, TextField, Tooltip, VerticalStack,
 } from "@shopify/polaris";
-import { SearchMinor, HorizontalDotsMinor, DeleteMinor } from "@shopify/polaris-icons";
+import { SearchMinor, HorizontalDotsMinor, DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
 import Dropdown from "../../../components/layouts/Dropdown";
 import { sharedIconCacheService } from "../../../components/shared/CollectionIcon";
@@ -53,6 +53,9 @@ const CSS = `
 @media (prefers-reduced-motion:reduce){ .bext-sk{ animation:none } }
 .bext-eyebrow { font-size:11px; font-weight:660; letter-spacing:.09em; text-transform:uppercase;
   color:var(--p-color-text-secondary,#9aa2b1); }
+.bext-info { display:inline-flex; width:15px; height:15px; cursor:help; opacity:.7; }
+.bext-info:hover { opacity:1; }
+.bext-info .Polaris-Icon { width:15px; height:15px; margin:0; }
 .bext-pick { display:flex; align-items:center; gap:13px; padding:10px 10px; border-radius:12px; cursor:pointer; border:1px solid transparent; transition:background .1s; }
 .bext-pick:hover { background:var(--p-color-bg-surface-hover,#f6f7fa); }
 .bext-pick.sel { background:var(--p-color-bg-surface-selected,#f1f1fd); border-color:var(--p-color-border-emphasis,#cfcef6); }
@@ -686,7 +689,15 @@ function BrowserExtensionSettings() {
             <style>{CSS}</style>
             <PageWithMultipleCards
                 title={"Browser Extension"}
-                subtitle={"Choose which hosts the Akto extension inspects. Available in v1.0.61 and later."}
+                titleMetadata={
+                    <Tooltip
+                        content="Before v1.0.61 the extension supported only ChatGPT, Grok, Claude, Gemini, Copilot and DeepSeek. From v1.0.61 onwards every host configured here is supported."
+                        dismissOnMouseOut
+                    >
+                        <span className="bext-info"><Icon source={InfoMinor} color="subdued" /></span>
+                    </Tooltip>
+                }
+                subtitle={"Choose which hosts the Akto extension inspects."}
                 isFirstPage={true}
                 fullWidth={false}
                 primaryAction={<Button primary onClick={() => openPicker("akto")}>Add hosts</Button>}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -281,7 +281,7 @@ function BrowserExtensionSettings() {
 
     // ── configured section ──────────────────────────────────────────────
     const skeletonList = (
-        <Box className="bext-list">
+        <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
             {Array.from({ length: 5 }).map((_, i) => (
                 <Box className="bext-row" key={`sk-${i}`}>
                     <SkeletonThumbnail size="small" />
@@ -347,7 +347,7 @@ function BrowserExtensionSettings() {
                     )}
                 </Box>
                 {!loading && totalCount > 0 && (
-                    <Box className="bext-filter">
+                    <Box width="230px">
                         <TextField
                             labelHidden label="Filter hosts" value={cfgFilter} onChange={setCfgFilter}
                             placeholder="Filter hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
@@ -374,7 +374,7 @@ function BrowserExtensionSettings() {
                     </Box>
                 ) : (
                     <VerticalStack gap="3">
-                        <Box className="bext-list">
+                        <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
                             {visibleConfigured.length === 0
                                 ? <Box className="bext-row"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
                                 : pagedConfigured.map(configuredRow)}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -278,11 +278,13 @@ function BrowserExtensionSettings() {
     const skeletonList = (
         <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
             {Array.from({ length: 5 }).map((_, i) => (
-                <Box className="bext-row" key={`sk-${i}`}>
-                    <SkeletonThumbnail size="small" />
-                    <Box width="100%" minWidth="0">
-                        <SkeletonBodyText lines={2} />
-                    </Box>
+                <Box className="bext-row" key={`sk-${i}`} paddingBlock="3" paddingInline="4">
+                    <HorizontalStack gap="3" blockAlign="center" wrap={false}>
+                        <SkeletonThumbnail size="small" />
+                        <Box width="100%" minWidth="0">
+                            <SkeletonBodyText lines={2} />
+                        </Box>
+                    </HorizontalStack>
                 </Box>
             ))}
         </Box>
@@ -295,33 +297,35 @@ function BrowserExtensionSettings() {
             { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
         ];
         return (
-            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host}>
-                {hostAvatar(c.host, c.iconUrl)}
-                <Box width="100%" minWidth="0">
-                    <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
-                    <Text variant="bodySm" color="subdued" truncate>
-                        {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
-                    </Text>
-                </Box>
-                <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
-                    title={c.active ? "Disable for this account" : "Enable"} />
-                {isCustom && (
-                    <Popover
-                        active={openMenuId === c.host}
-                        onClose={() => setOpenMenuId(null)}
-                        preferredAlignment="right"
-                        activator={
-                            <Button
-                                plain
-                                icon={HorizontalDotsMinor}
-                                accessibilityLabel={`Actions for ${c.name || c.host}`}
-                                onClick={() => setOpenMenuId(openMenuId === c.host ? null : c.host)}
-                            />
-                        }
-                    >
-                        <ActionList actionRole="menuitem" items={menuItems} />
-                    </Popover>
-                )}
+            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host} paddingBlock="3" paddingInline="4">
+                <HorizontalStack gap="3" blockAlign="center" wrap={false}>
+                    {hostAvatar(c.host, c.iconUrl)}
+                    <Box width="100%" minWidth="0">
+                        <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
+                        <Text variant="bodySm" color="subdued" truncate>
+                            {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
+                        </Text>
+                    </Box>
+                    <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
+                        title={c.active ? "Disable for this account" : "Enable"} />
+                    {isCustom && (
+                        <Popover
+                            active={openMenuId === c.host}
+                            onClose={() => setOpenMenuId(null)}
+                            preferredAlignment="right"
+                            activator={
+                                <Button
+                                    plain
+                                    icon={HorizontalDotsMinor}
+                                    accessibilityLabel={`Actions for ${c.name || c.host}`}
+                                    onClick={() => setOpenMenuId(openMenuId === c.host ? null : c.host)}
+                                />
+                            }
+                        >
+                            <ActionList actionRole="menuitem" items={menuItems} />
+                        </Popover>
+                    )}
+                </HorizontalStack>
             </Box>
         );
     };

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -1,17 +1,17 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-    Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
-    Modal, Text, TextField, Tooltip, VerticalStack,
+    ActionList, Avatar, Badge, Box, Button, Divider, Form, HorizontalStack, Icon,
+    Modal, Pagination, Popover, SkeletonBodyText, SkeletonThumbnail, Text, TextField, Tooltip, VerticalStack,
 } from "@shopify/polaris";
-import { DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
+import { SearchMinor, HorizontalDotsMinor, DeleteMinor, InfoMinor } from "@shopify/polaris-icons";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
-import GithubSimpleTable from "../../../components/tables/GithubSimpleTable";
 import Dropdown from "../../../components/layouts/Dropdown";
 import { sharedIconCacheService } from "../../../components/shared/CollectionIcon";
 import func from "@/util/func";
 import api from "../../guardrails/api";
 import "./BrowserExtensionSettings.css";
 
+const CONFIG_PAGE_SIZE = 10;   // configured hosts per page
 
 // full config-driven custom-host form (mirrors the extension's monitoring-config schema)
 const EMPTY_FORM = {
@@ -64,6 +64,9 @@ function BrowserExtensionSettings() {
     const [configured, setConfigured] = useState([]);
     const [catalogue, setCatalogue] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [cfgFilter, setCfgFilter] = useState("");
+    const [cfgPage, setCfgPage] = useState(0);            // configured list pagination (10 / page)
+    const [openMenuId, setOpenMenuId] = useState(null);   // which row's ⋯ menu is open
 
     // custom-host add/edit modal
     const [pickerOpen, setPickerOpen] = useState(false);
@@ -91,6 +94,7 @@ function BrowserExtensionSettings() {
     }, []);
 
     useEffect(() => { fetchAll(); }, [fetchAll]);
+    useEffect(() => { setCfgPage(0); }, [cfgFilter]);   // jump back to page 1 on a new filter
 
     // sort by the Mongo id (hexId) ascending — top brands were given the oldest ids, so they lead
     const idOf = (c) => c?.hexId || "￿";
@@ -125,6 +129,18 @@ function BrowserExtensionSettings() {
     const totalCount = mergedRows.length;
     const activeCount = useMemo(() => mergedRows.filter((r) => r.active).length, [mergedRows]);
     const offCount = totalCount - activeCount;
+
+    const visibleConfigured = useMemo(() => {
+        const q = cfgFilter.trim().toLowerCase();
+        if (!q) return mergedRows;
+        return mergedRows.filter((r) => (r.host || "").toLowerCase().includes(q) || (r.name || "").toLowerCase().includes(q));
+    }, [mergedRows, cfgFilter]);
+
+    // paginate the configured list (10 / page)
+    const cfgTotalPages = Math.max(1, Math.ceil(visibleConfigured.length / CONFIG_PAGE_SIZE));
+    const cfgPageSafe = Math.min(cfgPage, cfgTotalPages - 1);
+    const cfgStart = cfgPageSafe * CONFIG_PAGE_SIZE;
+    const pagedConfigured = visibleConfigured.slice(cfgStart, cfgStart + CONFIG_PAGE_SIZE);
 
     // ── write actions ───────────────────────────────────────────────────
     const toggleConfigured = async (host, nextActive) => {
@@ -263,64 +279,124 @@ function BrowserExtensionSettings() {
     };
 
     // ── configured section ──────────────────────────────────────────────
-    // ── configured section — the product-standard table (search + pagination built in) ──
-    const tableHeaders = [
-        { text: "Host", value: "hostComp", itemOrder: 1 },
-        { text: "Domain", value: "domain", itemOrder: 2 },
-        { text: "Status", value: "statusComp", itemOrder: 3 },
-    ];
-    const tableResourceName = { singular: "host", plural: "hosts" };
+    const skeletonList = (
+        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
+            {Array.from({ length: 5 }).map((_, i) => (
+                <Box className="bext-row" key={`sk-${i}`} paddingBlock="4" paddingInline="5">
+                    <HorizontalStack gap="3" blockAlign="center" wrap={false}>
+                        <SkeletonThumbnail size="small" />
+                        <Box width="100%" minWidth="0">
+                            <SkeletonBodyText lines={2} />
+                        </Box>
+                    </HorizontalStack>
+                </Box>
+            ))}
+        </Box>
+    );
 
-    // each row keeps its plain fields (host/name are what search matches) plus JSX cells; the search
-    // helper skips React elements, so the avatar/toggle cells are safe.
-    const tableData = useMemo(() => mergedRows.map((c) => ({
-        ...c,
-        id: c.host,
-        domain: c.host,
-        hostComp: (
-            <HorizontalStack gap="3" blockAlign="center" wrap={false}>
-                {hostAvatar(c.host, c.iconUrl)}
-                <Text fontWeight="medium">{c.name || c.host}</Text>
-            </HorizontalStack>
-        ),
-        statusComp: (
-            <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
-                title={c.active ? "Disable for this account" : "Enable"} />
-        ),
-    })), [mergedRows]);
-
-    // only account-added custom hosts can be edited/removed; catalogue hosts are toggled via the switch
-    const getRowActions = (item) => {
-        if (item.source !== "custom") return [];
-        return [{ items: [
-            { content: "Edit", onAction: () => openEdit(item) },
-            { content: "Remove", destructive: true, onAction: () => removeConfigured(item.host, item.hexId) },
-        ] }];
+    const configuredRow = (c) => {
+        const isCustom = c.source === "custom";
+        const menuItems = [
+            { content: "Edit", onAction: () => { setOpenMenuId(null); openEdit(c); } },
+            { content: "Remove", destructive: true, onAction: () => { setOpenMenuId(null); removeConfigured(c.host, c.hexId); } },
+        ];
+        return (
+            <Box className={`bext-row ${c.active ? "" : "off"}`} key={c.host} paddingBlock="4" paddingInline="5">
+                <HorizontalStack gap="3" blockAlign="center" wrap={false}>
+                    {hostAvatar(c.host, c.iconUrl)}
+                    <Box width="100%" minWidth="0">
+                        <Text variant="bodyMd" fontWeight="medium" truncate>{c.name || c.host}</Text>
+                        <Text variant="bodySm" color="subdued" truncate>
+                            {c.name ? c.host : (isCustom ? ((c.paths || []).join(", ") || "Custom") : "Akto")}
+                        </Text>
+                    </Box>
+                    <Switch active={c.active} onChange={() => toggleConfigured(c.host, !c.active)}
+                        title={c.active ? "Disable for this account" : "Enable"} />
+                    {isCustom && (
+                        <Popover
+                            active={openMenuId === c.host}
+                            onClose={() => setOpenMenuId(null)}
+                            preferredAlignment="right"
+                            activator={
+                                <Button
+                                    plain
+                                    icon={HorizontalDotsMinor}
+                                    accessibilityLabel={`Actions for ${c.name || c.host}`}
+                                    onClick={() => setOpenMenuId(openMenuId === c.host ? null : c.host)}
+                                />
+                            }
+                        >
+                            <ActionList actionRole="menuitem" items={menuItems} />
+                        </Popover>
+                    )}
+                </HorizontalStack>
+            </Box>
+        );
     };
 
     const configuredSection = (
-        <Box key="ext-configured">
-            <VerticalStack gap="1">
-                <Text variant="headingSm" as="h3">Inspected hosts</Text>
+        <Box key="ext-configured" maxWidth="880px">
+            <HorizontalStack align="space-between" blockAlign="start">
+                <Box>
+                    <Text variant="headingSm" as="h3">Inspected hosts</Text>
+                    {!loading && totalCount > 0 && (
+                        <Box paddingBlockStart="1">
+                            <HorizontalStack gap="2" blockAlign="center">
+                                <Text variant="bodySm" color="subdued">{totalCount} host{totalCount !== 1 ? "s" : ""}</Text>
+                                <Badge status="success">{`${activeCount} active`}</Badge>
+                                {offCount > 0 && <Badge>{`${offCount} off`}</Badge>}
+                            </HorizontalStack>
+                        </Box>
+                    )}
+                </Box>
                 {!loading && totalCount > 0 && (
-                    <HorizontalStack gap="2" blockAlign="center">
-                        <Text variant="bodySm" color="subdued">{totalCount} host{totalCount !== 1 ? "s" : ""}</Text>
-                        <Badge status="success">{`${activeCount} active`}</Badge>
-                        {offCount > 0 && <Badge>{`${offCount} off`}</Badge>}
-                    </HorizontalStack>
+                    <Box width="230px">
+                        <TextField
+                            labelHidden label="Filter hosts" value={cfgFilter} onChange={setCfgFilter}
+                            placeholder="Filter hosts…" prefix={<Icon source={SearchMinor} color="subdued" />}
+                            autoComplete="off" clearButton onClearButtonClick={() => setCfgFilter("")}
+                        />
+                    </Box>
                 )}
-            </VerticalStack>
+            </HorizontalStack>
             <Box paddingBlockStart="3">
-                <GithubSimpleTable
-                    key="ext-table"
-                    data={tableData}
-                    resourceName={tableResourceName}
-                    headers={tableHeaders}
-                    loading={loading}
-                    getActions={getRowActions}
-                    hasRowActions={true}
-                    pageLimit={10}
-                />
+                {loading ? skeletonList : totalCount === 0 ? (
+                    <Box background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" padding="10">
+                        <VerticalStack gap="4" inlineAlign="center">
+                            <Box background="bg-subdued" borderRadius="300" padding="3">
+                                <Icon source={SearchMinor} color="subdued" />
+                            </Box>
+                            <VerticalStack gap="1" inlineAlign="center">
+                                <Text variant="headingSm">No hosts yet</Text>
+                                <Text alignment="center" color="subdued">
+                                    Akto's supported hosts load here automatically. You can also add your own custom host.
+                                </Text>
+                            </VerticalStack>
+                            <Button primary onClick={openCustom}>Add custom host</Button>
+                        </VerticalStack>
+                    </Box>
+                ) : (
+                    <VerticalStack gap="3">
+                        <Box className="bext-list" background="bg-surface" borderColor="border" borderWidth="1" borderRadius="300" overflowX="hidden">
+                            {visibleConfigured.length === 0
+                                ? <Box paddingBlock="4" paddingInline="5"><Text color="subdued">No hosts match “{cfgFilter}”.</Text></Box>
+                                : pagedConfigured.map(configuredRow)}
+                        </Box>
+                        {visibleConfigured.length > CONFIG_PAGE_SIZE && (
+                            <Box paddingBlockStart="1">
+                                <HorizontalStack align="center" blockAlign="center" gap="4">
+                                    <Pagination
+                                        hasPrevious={cfgPageSafe > 0}
+                                        onPrevious={() => setCfgPage((p) => Math.max(0, p - 1))}
+                                        hasNext={cfgPageSafe < cfgTotalPages - 1}
+                                        onNext={() => setCfgPage((p) => Math.min(cfgTotalPages - 1, p + 1))}
+                                        label={`${cfgStart + 1}–${Math.min(cfgStart + CONFIG_PAGE_SIZE, visibleConfigured.length)} of ${visibleConfigured.length}`}
+                                    />
+                                </HorizontalStack>
+                            </Box>
+                        )}
+                    </VerticalStack>
+                )}
             </Box>
         </Box>
     );

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -189,7 +189,7 @@ function BrowserExtensionSettings() {
                 await api.setBrowserExtensionConfigActive(host, true);
             }
             func.setToast(true, false, `${hosts.length} host${hosts.length !== 1 ? "s" : ""} added`);
-            setSelected(new Set());
+            closePicker();
             await fetchAll();
         } catch (error) {
             func.setToast(true, true, "Failed to add hosts");
@@ -218,7 +218,8 @@ function BrowserExtensionSettings() {
         setEditingHexId(config.hexId); setFormErrors({}); setShowAdv(!!config.responseFormat); setPickerOpen(true);
     };
     const closePicker = () => {
-        setPickerOpen(false); setForm(EMPTY_FORM); setEditingHexId(null); setFormErrors({}); setShowAdv(false); setShowExample(false);
+        setPickerOpen(false); setForm(EMPTY_FORM); setEditingHexId(null); setFormErrors({});
+        setShowAdv(false); setShowExample(false); setSelected(new Set()); setPickSearch("");
     };
     // form helpers for the repeatable array fields
     const setField = (k, v) => setForm((f) => ({ ...f, [k]: v }));

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/browser_extension/BrowserExtensionSettings.jsx
@@ -51,14 +51,9 @@ function faviconFor(host, iconUrl) {
     return host ? sharedIconCacheService.getFaviconUrl(host) : undefined;
 }
 
-// Every favicon sits inside a unified white rounded tile so light/dark logos read evenly.
-function hostAvatar(host, iconUrl, size = "small") {
-    const sm = size === "extraSmall";
-    return (
-        <span className={`bext-tile ${sm ? "sm" : ""}`}>
-            <Avatar size="extraSmall" shape="square" source={faviconFor(host, iconUrl) || undefined} name={host} />
-        </span>
-    );
+// A square Polaris Avatar shows the favicon and falls back to the host's initials if it fails.
+function hostAvatar(host, iconUrl) {
+    return <Avatar size="medium" shape="square" source={faviconFor(host, iconUrl) || undefined} name={host} />;
 }
 
 function BrowserExtensionSettings() {
@@ -335,7 +330,7 @@ function BrowserExtensionSettings() {
         <Box key="ext-configured">
             <HorizontalStack align="space-between" blockAlign="start">
                 <Box>
-                    <span className="bext-eyebrow">Inspected hosts</span>
+                    <Text variant="headingSm" as="h3">Inspected hosts</Text>
                     {!loading && totalCount > 0 && (
                         <Box paddingBlockStart="1">
                             <HorizontalStack gap="2" blockAlign="center">

--- a/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigCommonDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigCommonDao.java
@@ -7,7 +7,9 @@ import com.mongodb.client.model.Filters;
 import org.bson.Document;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Reads the shared browser extension config collection from the common DB.
@@ -30,8 +32,9 @@ public class BrowserExtensionConfigCommonDao extends CommonContextDao<Document> 
         return Document.class;
     }
 
+    // Sorted by _id ascending: top brands were seeded with the oldest _ids, so they always lead.
     public List<BrowserExtensionConfigCommon> findAllConfigs() {
-        return toConfigs(instance.findAll(new BasicDBObject()));
+        return toConfigs(instance.findAll(new BasicDBObject(), 0, 0, new BasicDBObject("_id", 1)));
     }
 
     /**
@@ -53,6 +56,42 @@ public class BrowserExtensionConfigCommonDao extends CommonContextDao<Document> 
                 configs.add(config);
             }
         }
-        return configs;
+        return dedupeByHost(configs);
+    }
+
+    /**
+     * The common collection has no unique index on host, so the same host can be listed multiple times.
+     * Collapse duplicates by normalized host, preferring an active entry over an inactive one and the
+     * richer document (more paths/operations) on ties, so the dashboard never shows duplicate rows.
+     */
+    private static List<BrowserExtensionConfigCommon> dedupeByHost(List<BrowserExtensionConfigCommon> configs) {
+        Map<String, BrowserExtensionConfigCommon> byHost = new LinkedHashMap<>();
+        for (BrowserExtensionConfigCommon config : configs) {
+            String key = config.getHost().trim().toLowerCase();
+            BrowserExtensionConfigCommon existing = byHost.get(key);
+            if (existing == null || isRicher(config, existing)) {
+                byHost.put(key, config);
+            }
+        }
+        return new ArrayList<>(byHost.values());
+    }
+
+    private static boolean isRicher(BrowserExtensionConfigCommon candidate, BrowserExtensionConfigCommon existing) {
+        // an active entry always wins over an inactive one for the same host
+        if (candidate.isActive() != existing.isActive()) {
+            return candidate.isActive();
+        }
+        return detailScore(candidate) > detailScore(existing);
+    }
+
+    private static int detailScore(BrowserExtensionConfigCommon config) {
+        int score = 0;
+        if (config.getPaths() != null) {
+            score += config.getPaths().size();
+        }
+        if (config.getOperations() != null) {
+            score += config.getOperations().size();
+        }
+        return score;
     }
 }

--- a/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigCommonDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigCommonDao.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Reads the shared browser extension config collection from the common DB.
@@ -42,6 +43,25 @@ public class BrowserExtensionConfigCommonDao extends CommonContextDao<Document> 
      */
     public List<BrowserExtensionConfigCommon> findActiveConfigs() {
         return toConfigs(instance.findAll(Filters.ne(BrowserExtensionConfigCommon.ACTIVE, false)));
+    }
+
+    /**
+     * Raw catalogue document for a host (case-insensitive), or null. Returned as a schema-loose
+     * {@link Document} so the caller can copy every extraction field the extension needs - including
+     * ones not modelled on the DTO (identity, triggerFrame, modelHeader, …) - into an account row.
+     */
+    public Document findRawByHost(String host) {
+        if (host == null) {
+            return null;
+        }
+        String normalized = host.trim();
+        Document doc = instance.getMCollection().find(Filters.eq(BrowserExtensionConfigCommon.HOST, normalized)).first();
+        if (doc == null) {
+            doc = instance.getMCollection()
+                    .find(Filters.regex(BrowserExtensionConfigCommon.HOST, "^" + Pattern.quote(normalized) + "$", "i"))
+                    .first();
+        }
+        return doc;
     }
 
     private List<BrowserExtensionConfigCommon> toConfigs(List<Document> docs) {

--- a/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigDao.java
@@ -1,14 +1,8 @@
 package com.akto.dao;
 
 import com.akto.dto.BrowserExtensionConfig;
-import com.akto.dto.BrowserExtensionConfigCommon;
 import com.mongodb.BasicDBObject;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
 
-import org.bson.Document;
-
-import java.util.ArrayList;
 import java.util.List;
 
 public class BrowserExtensionConfigDao extends AccountsContextDao<BrowserExtensionConfig> {
@@ -26,27 +20,7 @@ public class BrowserExtensionConfigDao extends AccountsContextDao<BrowserExtensi
         return BrowserExtensionConfig.class;
     }
 
-    /**
-     * The account collection now carries the same rich, per-site extraction config the extension
-     * supports (copied from the common catalogue), whose {@code path}/{@code modelPath}/
-     * {@code responsePath} fields are polymorphic - a single json path or a list. The pojo codec
-     * can't decode those, so documents are read raw and mapped via
-     * {@link BrowserExtensionConfigCommon#fromDocument}, exactly like the common catalogue read.
-     */
-    public List<BrowserExtensionConfigCommon> findAllSortedByCreatedTimestamp(int skip, int limit) {
-        MongoCollection<Document> coll = getMCollection(getDBName(), getCollName(), Document.class);
-        List<BrowserExtensionConfigCommon> configs = new ArrayList<>();
-        try (MongoCursor<Document> cursor = coll.find()
-                .sort(new BasicDBObject(BrowserExtensionConfig.CREATED_TIMESTAMP, -1))
-                .skip(skip).limit(limit).cursor()) {
-            while (cursor.hasNext()) {
-                BrowserExtensionConfigCommon config = BrowserExtensionConfigCommon.fromDocument(cursor.next());
-                // host is mandatory, so a document without it is not usable
-                if (config != null) {
-                    configs.add(config);
-                }
-            }
-        }
-        return configs;
+    public List<BrowserExtensionConfig> findAllConfigs() {
+        return instance.findAll(new BasicDBObject());
     }
 }

--- a/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/BrowserExtensionConfigDao.java
@@ -1,8 +1,14 @@
 package com.akto.dao;
 
 import com.akto.dto.BrowserExtensionConfig;
+import com.akto.dto.BrowserExtensionConfigCommon;
 import com.mongodb.BasicDBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 
+import org.bson.Document;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public class BrowserExtensionConfigDao extends AccountsContextDao<BrowserExtensionConfig> {
@@ -20,9 +26,27 @@ public class BrowserExtensionConfigDao extends AccountsContextDao<BrowserExtensi
         return BrowserExtensionConfig.class;
     }
 
-    public List<BrowserExtensionConfig> findAllSortedByCreatedTimestamp(int skip, int limit) {
-        BasicDBObject sort = new BasicDBObject();
-        sort.put(BrowserExtensionConfig.CREATED_TIMESTAMP, -1);
-        return instance.findAll(new BasicDBObject(), skip, limit, sort);
+    /**
+     * The account collection now carries the same rich, per-site extraction config the extension
+     * supports (copied from the common catalogue), whose {@code path}/{@code modelPath}/
+     * {@code responsePath} fields are polymorphic - a single json path or a list. The pojo codec
+     * can't decode those, so documents are read raw and mapped via
+     * {@link BrowserExtensionConfigCommon#fromDocument}, exactly like the common catalogue read.
+     */
+    public List<BrowserExtensionConfigCommon> findAllSortedByCreatedTimestamp(int skip, int limit) {
+        MongoCollection<Document> coll = getMCollection(getDBName(), getCollName(), Document.class);
+        List<BrowserExtensionConfigCommon> configs = new ArrayList<>();
+        try (MongoCursor<Document> cursor = coll.find()
+                .sort(new BasicDBObject(BrowserExtensionConfig.CREATED_TIMESTAMP, -1))
+                .skip(skip).limit(limit).cursor()) {
+            while (cursor.hasNext()) {
+                BrowserExtensionConfigCommon config = BrowserExtensionConfigCommon.fromDocument(cursor.next());
+                // host is mandatory, so a document without it is not usable
+                if (config != null) {
+                    configs.add(config);
+                }
+            }
+        }
+        return configs;
     }
 }

--- a/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfig.java
+++ b/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfig.java
@@ -1,6 +1,7 @@
 package com.akto.dto;
 
 import java.util.List;
+import java.util.Map;
 
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.types.ObjectId;
@@ -27,6 +28,41 @@ public class BrowserExtensionConfig {
 
     public static final String ACTIVE = "active";
     private boolean active;
+
+    // ── config-driven monitoring fields (mirror the extension's monitoring-configs schema) ──
+    // how the chat send travels: "http" | "websocket" | "graphql"
+    public static final String TRANSPORT = "transport";
+    private String transport;
+
+    // HTTP method for http transport (POST/GET/…)
+    public static final String METHOD = "method";
+    private String method;
+
+    // body decoder: json | form | sse | ws-frame | dgw | connect-rpc | socket.io | nested-envelope
+    public static final String FORMAT = "format";
+    private String format;
+
+    // candidate paths to the user prompt in the request body (first match wins)
+    public static final String PATH = "path";
+    private List<String> path;
+
+    // GraphQL only: operation names that carry a send
+    public static final String OPERATIONS = "operations";
+    private List<String> operations;
+
+    // WebSocket only: key→value conditions selecting the prompt-bearing frame
+    public static final String FRAME_MATCH = "frameMatch";
+    private Map<String, String> frameMatch;
+
+    // optional response/model extraction
+    public static final String RESPONSE_FORMAT = "responseFormat";
+    private String responseFormat;
+
+    public static final String RESPONSE_PATH = "responsePath";
+    private List<String> responsePath;
+
+    public static final String MODEL_PATH = "modelPath";
+    private List<String> modelPath;
 
     public static final String CREATED_BY = "createdBy";
     private String createdBy;

--- a/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfig.java
+++ b/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfig.java
@@ -42,9 +42,10 @@ public class BrowserExtensionConfig {
     public static final String FORMAT = "format";
     private String format;
 
-    // candidate paths to the user prompt in the request body (first match wins)
+    // candidate path(s) to the user prompt in the request body (first match wins). Polymorphic:
+    // a single json path (String) or a list of them — stored/read as-is, so it is typed Object.
     public static final String PATH = "path";
-    private List<String> path;
+    private Object path;
 
     // GraphQL only: operation names that carry a send
     public static final String OPERATIONS = "operations";
@@ -58,11 +59,12 @@ public class BrowserExtensionConfig {
     public static final String RESPONSE_FORMAT = "responseFormat";
     private String responseFormat;
 
+    // like path, a single json path or a list of them
     public static final String RESPONSE_PATH = "responsePath";
-    private List<String> responsePath;
+    private Object responsePath;
 
     public static final String MODEL_PATH = "modelPath";
-    private List<String> modelPath;
+    private Object modelPath;
 
     public static final String CREATED_BY = "createdBy";
     private String createdBy;

--- a/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfig.java
+++ b/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfig.java
@@ -42,10 +42,10 @@ public class BrowserExtensionConfig {
     public static final String FORMAT = "format";
     private String format;
 
-    // candidate path(s) to the user prompt in the request body (first match wins). Polymorphic:
-    // a single json path (String) or a list of them — stored/read as-is, so it is typed Object.
+    // candidate paths to the user prompt in the request body (first match wins). Always stored as a
+    // list (single paths are normalized to a 1-element list), so it reads through the pojo codec.
     public static final String PATH = "path";
-    private Object path;
+    private List<String> path;
 
     // GraphQL only: operation names that carry a send
     public static final String OPERATIONS = "operations";
@@ -59,12 +59,11 @@ public class BrowserExtensionConfig {
     public static final String RESPONSE_FORMAT = "responseFormat";
     private String responseFormat;
 
-    // like path, a single json path or a list of them
     public static final String RESPONSE_PATH = "responsePath";
-    private Object responsePath;
+    private List<String> responsePath;
 
     public static final String MODEL_PATH = "modelPath";
-    private Object modelPath;
+    private List<String> modelPath;
 
     public static final String CREATED_BY = "createdBy";
     private String createdBy;

--- a/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
+++ b/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
@@ -77,6 +77,16 @@ public class BrowserExtensionConfigCommon {
     public static final String CATEGORIES = "categories";
     private List<String> categories;
 
+    public static final String RESPONSE_FORMAT = "responseFormat";
+    private String responseFormat;
+
+    // like path: a single json path or a list of candidate paths, mirrored as stored
+    public static final String RESPONSE_PATH = "responsePath";
+    private Object responsePath;
+
+    public static final String MODEL_PATH = "modelPath";
+    private Object modelPath;
+
     public String getHexId() {
         if (this.id != null) {
             return this.id.toHexString();
@@ -119,6 +129,9 @@ public class BrowserExtensionConfigCommon {
         config.tag = asString(doc.get(TAG));
         config.iconUrl = asString(doc.get(ICON_URL));
         config.categories = asStringList(doc.get(CATEGORIES));
+        config.responseFormat = asString(doc.get(RESPONSE_FORMAT));
+        config.responsePath = asPath(doc.get(RESPONSE_PATH));
+        config.modelPath = asPath(doc.get(MODEL_PATH));
 
         return config;
     }

--- a/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
+++ b/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
@@ -66,9 +66,6 @@ public class BrowserExtensionConfigCommon {
     public static final String FRAME_MATCH = "frameMatch";
     private Map<String, Object> frameMatch;
 
-    public static final String TAG = "tag";
-    private String tag;
-
     // stored as `icon_url` in the document, used as the host's icon
     public static final String ICON_URL = "icon_url";
     private String iconUrl;
@@ -126,7 +123,6 @@ public class BrowserExtensionConfigCommon {
         config.format = asString(doc.get(FORMAT));
         config.path = asPath(doc.get(PATH));
         config.frameMatch = asMap(doc.get(FRAME_MATCH));
-        config.tag = asString(doc.get(TAG));
         config.iconUrl = asString(doc.get(ICON_URL));
         config.categories = asStringList(doc.get(CATEGORIES));
         config.responseFormat = asString(doc.get(RESPONSE_FORMAT));

--- a/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
+++ b/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
@@ -36,6 +36,10 @@ public class BrowserExtensionConfigCommon {
     public static final String HOST = "host";
     private String host;
 
+    // optional friendly product name (e.g. "ChatGPT" for openai.com); falls back to host in the UI
+    public static final String NAME = "name";
+    private String name;
+
     public static final String ACTIVE = "active";
     // absent in the document means enabled
     private boolean active = true;
@@ -69,6 +73,10 @@ public class BrowserExtensionConfigCommon {
     public static final String ICON_URL = "icon_url";
     private String iconUrl;
 
+    // e.g. ["chat","code"] — used by the dashboard to filter the Add-hosts catalogue by type
+    public static final String CATEGORIES = "categories";
+    private List<String> categories;
+
     public String getHexId() {
         if (this.id != null) {
             return this.id.toHexString();
@@ -91,6 +99,7 @@ public class BrowserExtensionConfigCommon {
 
         BrowserExtensionConfigCommon config = new BrowserExtensionConfigCommon();
         config.host = host.trim();
+        config.name = asString(doc.get(NAME));
 
         Object id = doc.get("_id");
         if (id instanceof ObjectId) {
@@ -109,6 +118,7 @@ public class BrowserExtensionConfigCommon {
         config.frameMatch = asMap(doc.get(FRAME_MATCH));
         config.tag = asString(doc.get(TAG));
         config.iconUrl = asString(doc.get(ICON_URL));
+        config.categories = asStringList(doc.get(CATEGORIES));
 
         return config;
     }

--- a/libs/dao/src/test/java/com/akto/dto/TestBrowserExtensionConfigCommon.java
+++ b/libs/dao/src/test/java/com/akto/dto/TestBrowserExtensionConfigCommon.java
@@ -20,8 +20,7 @@ public class TestBrowserExtensionConfigCommon {
                 "'transport': 'http'," +
                 "'method': 'POST'," +
                 "'format': 'json'," +
-                "'path': 'messages[-1].content.parts'," +
-                "'tag': 'genai'" +
+                "'path': 'messages[-1].content.parts'" +
                 "}");
 
         BrowserExtensionConfigCommon config = BrowserExtensionConfigCommon.fromDocument(doc);
@@ -34,27 +33,6 @@ public class TestBrowserExtensionConfigCommon {
         assertEquals("POST", config.getMethod());
         assertEquals("json", config.getFormat());
         assertEquals("messages[-1].content.parts", config.getPath());
-        assertEquals("genai", config.getTag());
-    }
-
-    @Test
-    public void testTagIsOptional() {
-        Document doc = Document.parse("{ 'host': 'poe.com', 'active': true }");
-
-        BrowserExtensionConfigCommon config = BrowserExtensionConfigCommon.fromDocument(doc);
-
-        assertNotNull(config);
-        assertNull(config.getTag());
-    }
-
-    @Test
-    public void testNonStringTagIsIgnored() {
-        Document doc = new Document("host", "you.com").append("tag", Arrays.asList("genai"));
-
-        BrowserExtensionConfigCommon config = BrowserExtensionConfigCommon.fromDocument(doc);
-
-        assertNotNull(config);
-        assertNull(config.getTag());
     }
 
     @Test


### PR DESCRIPTION
## What

Revamps the **Browser Extension** settings page (`/dashboard/settings/browser-extension`) and makes account-level configs carry the full, config-driven extraction spec the extension consumes.

### Settings page (frontend)
- Deduplicated catalogue, "Configured" hosts list with pagination, per-row actions, and a host picker modal.
- Rich custom-host form (transport / format / prompt path / operations / frameMatch / response + model paths) with a worked example, built on the product's Polaris `Dropdown`.
- Version-support note moved into a small ⓘ tooltip beside the page title (via a new `titleMetadata` passthrough on `PageWithMultipleCards`).

### Config-driven account rows (backend)
- **Enable copies the spec**: `setBrowserExtensionConfigActive` now copies the whole catalogue document into the account row, so a toggled-on host becomes a full config-driven entry instead of bare `host + paths`. The copy is generic — everything flows through except account-owned fields (`_id, host, active`, audit) — so new extraction fields need no code change. Added `BrowserExtensionConfigCommonDao.findRawByHost`.
- **Tolerant read**: account rows now hold polymorphic fields (`path`/`modelPath`/`responsePath` can be a String or a List), which crashed the POJO-codec read and broke the page. The account read now uses the tolerant `BrowserExtensionConfigCommon.fromDocument` mapper (same pattern as the catalogue read); that DTO gained `responseFormat`/`responsePath`/`modelPath` so nothing is dropped.
- Dedup-by-host + `_id` sort on the catalogue so seeded top brands lead.

## Notes
- The public v2 read (PII strip) lives in the **database-abstractor** (separate checkout) and is tracked separately.
- Catalogue data is seeded from the extension's `monitoring-configs.js` as a one-time data step.

## Test
- Open `/dashboard/settings/browser-extension`: configured list loads (no duplicate rows), toggle on/off persists, add/edit custom host works, version tooltip renders.
- Toggling a supported host writes the full spec into the account row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)