### PR TITLE
Enhance Guardrail Policies and Device ID Resolution

### DIFF
--- a/apps/database-abstractor/src/main/java/com/akto/action/GuardrailPoliciesAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/GuardrailPoliciesAction.java
@@ -28,7 +28,7 @@ public class GuardrailPoliciesAction extends ActionSupport {
             this.guardrailPolicies = DbLayer.fetchGuardrailPolicies(updatedAfter, contextSource);
 
 
-            // Resolve targetTeams/targetRoles → device IDs fresh on every fetch.
+            // Resolve targetTeams/targetRoles/targetDeviceIds → device IDs fresh on every fetch.
             // applyToDeviceIds stays null when there's no targeting → apply to all devices.
             // When targeting is configured, applyToDeviceIds is always set to a (possibly empty) list →
             // apply ONLY to those ids; empty means 0 matches right now, i.e. apply to none.
@@ -36,11 +36,12 @@ public class GuardrailPoliciesAction extends ActionSupport {
             for (GuardrailPolicies p : this.guardrailPolicies) {
                 EnterpriseLicenseComplianceCatalog.applyToPolicy(p);
                 boolean hasTargeting = (p.getTargetTeams() != null && !p.getTargetTeams().isEmpty())
-                        || (p.getTargetRoles() != null && !p.getTargetRoles().isEmpty());
+                        || (p.getTargetRoles() != null && !p.getTargetRoles().isEmpty())
+                        || (p.getTargetDeviceIds() != null && !p.getTargetDeviceIds().isEmpty());
                 if (hasTargeting) {
                     try {
-                        p.setApplyToDeviceIds(DbLayer.findDeviceIdsByTeamsAndRoles(
-                                p.getTargetTeams(), p.getTargetRoles()));
+                        p.setApplyToDeviceIds(DbLayer.findDeviceIdsByTeamsRolesAndDeviceIds(
+                                p.getTargetTeams(), p.getTargetRoles(), p.getTargetDeviceIds()));
                     } catch (Exception e) {
                         loggerMaker.errorAndAddToDb("Error resolving device IDs for policy " + p.getHexId() + ": " + e.getMessage(), LogDb.DASHBOARD);
                         p.setApplyToDeviceIds(new java.util.ArrayList<>());

--- a/apps/database-abstractor/src/main/java/com/akto/action/GuardrailPoliciesAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/GuardrailPoliciesAction.java
@@ -27,21 +27,16 @@ public class GuardrailPoliciesAction extends ActionSupport {
         try {
             this.guardrailPolicies = DbLayer.fetchGuardrailPolicies(updatedAfter, contextSource);
 
-
-            // Resolve targetTeams/targetRoles/targetDeviceIds → device IDs fresh on every fetch.
-            // applyToDeviceIds stays null when there's no targeting → apply to all devices.
-            // When targeting is configured, applyToDeviceIds is always set to a (possibly empty) list →
-            // apply ONLY to those ids; empty means 0 matches right now, i.e. apply to none.
-            // Consumers must check for null vs. non-null, NOT list.isEmpty() alone.
+            // Resolve targetTags/targetDeviceIds → device IDs
             for (GuardrailPolicies p : this.guardrailPolicies) {
                 EnterpriseLicenseComplianceCatalog.applyToPolicy(p);
-                boolean hasTargeting = (p.getTargetTeams() != null && !p.getTargetTeams().isEmpty())
-                        || (p.getTargetRoles() != null && !p.getTargetRoles().isEmpty())
+                boolean hasTagTargeting = p.getTargetTags() != null && !p.getTargetTags().isEmpty();
+                boolean hasTargeting = hasTagTargeting
                         || (p.getTargetDeviceIds() != null && !p.getTargetDeviceIds().isEmpty());
                 if (hasTargeting) {
                     try {
-                        p.setApplyToDeviceIds(DbLayer.findDeviceIdsByTeamsRolesAndDeviceIds(
-                                p.getTargetTeams(), p.getTargetRoles(), p.getTargetDeviceIds()));
+                        p.setApplyToDeviceIds(DbLayer.findDeviceIdsByTags(
+                                p.getTargetTags(), p.getTargetDeviceIds()));
                     } catch (Exception e) {
                         loggerMaker.errorAndAddToDb("Error resolving device IDs for policy " + p.getHexId() + ": " + e.getMessage(), LogDb.DASHBOARD);
                         p.setApplyToDeviceIds(new java.util.ArrayList<>());

--- a/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
@@ -7,7 +7,9 @@ import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.Updates;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.bson.conversions.Bson;
 
 public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
@@ -51,10 +53,11 @@ public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
     }
 
     /**
-     * Returns the flat list of device IDs belonging to users that match any of the
-     * given teams or roles. Pass empty/null lists to get an empty result (not all devices).
+     * Returns the flat list of device IDs belonging to users that match any of the given
+     * teams/roles, optionally narrowed to (or substituted by) an explicit set of device IDs.
+     * Pass all-empty/null lists to get an empty result (not all devices).
      */
-    public List<String> findDeviceIdsByTeamsAndRoles(List<String> teams, List<String> roles) {
+    public List<String> findDeviceIdsByTeamsRolesAndDeviceIds(List<String> teams, List<String> roles, List<String> deviceIds) {
         List<Bson> conditions = new ArrayList<>();
         if (teams != null && !teams.isEmpty()) {
             conditions.add(Filters.or(
@@ -68,18 +71,33 @@ public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
                 Filters.and(Filters.ne(AgenticUsers.ROLE_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.SSO_USER_ROLE, roles))
             ));
         }
-        if (conditions.isEmpty()) {
+        boolean hasTeamOrRole = !conditions.isEmpty();
+        boolean hasDeviceIds = deviceIds != null && !deviceIds.isEmpty();
+        if (!hasTeamOrRole && !hasDeviceIds) {
             return new ArrayList<>();
         }
 
+        // Explicit device IDs come straight from a dropdown sourced off live device data at pick
+        // time — trust them directly rather than re-deriving through a team/role join.
+        if (!hasTeamOrRole) {
+            return new ArrayList<>(new HashSet<>(deviceIds));
+        }
+
         Bson userFilter = conditions.size() == 1 ? conditions.get(0) : Filters.and(conditions);
-        List<String> deviceIds = new ArrayList<>();
+        Set<String> teamRoleDeviceIds = new HashSet<>();
         for (AgenticUsers user : instance.findAll(userFilter)) {
             if (user.getDevices() != null) {
-                deviceIds.addAll(user.getDevices());
+                teamRoleDeviceIds.addAll(user.getDevices());
             }
         }
-        return deviceIds;
+
+        if (!hasDeviceIds) {
+            return new ArrayList<>(teamRoleDeviceIds);
+        }
+
+        // Both dimensions given — a device must satisfy the team/role match AND be explicitly picked.
+        teamRoleDeviceIds.retainAll(new HashSet<>(deviceIds));
+        return new ArrayList<>(teamRoleDeviceIds);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
@@ -1,103 +1,224 @@
 package com.akto.dao;
 
+import com.akto.dao.context.Context;
+import com.akto.dao.monitoring.ModuleInfoDao;
 import com.akto.dto.AgenticUsers;
-import com.mongodb.MongoCommandException;
+import com.akto.dto.DeviceTag;
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.FindOneAndUpdateOptions;
-import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.Updates;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import org.bson.conversions.Bson;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
     public static final AgentUsersDao instance = new AgentUsersDao();
+    private static final Logger logger = LoggerFactory.getLogger(AgentUsersDao.class);
+    private static final int MAX_TAGS_PER_SOURCE = 50;
 
     public void createIndicesIfAbsent() {
         MCollection.createIndexIfAbsent(getDBName(), getCollName(),
-            new String[]{AgenticUsers.TEAM_NAME, AgenticUsers.USER_ROLE}, false);
+            new String[]{AgenticUsers.USER_NAME}, false);
 
-    }
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+            new String[]{AgenticUsers.USER_EMAIL}, false);
 
-    public void upsertAgentUser(String userName, String teamName, String userRole, String device, int lastUpdatedAt) {
-        Bson userFilter = Filters.eq(AgenticUsers.USER_NAME, userName);
-        boolean hasTeam = teamName != null && !teamName.isEmpty();
-        boolean hasRole = userRole != null && !userRole.isEmpty();
-
-        List<Bson> updates = new ArrayList<>();
-        updates.add(Updates.setOnInsert(AgenticUsers.USER_NAME, userName));
-        updates.add(Updates.set(AgenticUsers.LAST_UPDATED_AT, lastUpdatedAt));
-        updates.add(Updates.addToSet(AgenticUsers.DEVICES, device));
-        if (hasTeam) updates.add(Updates.set(AgenticUsers.SSO_TEAM_NAME, teamName));
-        if (hasRole) updates.add(Updates.set(AgenticUsers.SSO_USER_ROLE, userRole));
-
-        try {
-            getMCollection().findOneAndUpdate(userFilter, Updates.combine(updates),
-                new FindOneAndUpdateOptions().upsert(true).returnDocument(ReturnDocument.AFTER));
-        } catch (MongoCommandException e) {
-            if (e.getErrorCode() != 11000) throw e;
-            getMCollection().updateOne(userFilter, Updates.combine(updates));
-        }
-
-        // Set effective fields only on first write (when not yet populated)
-        if (hasTeam)
-            getMCollection().updateOne(
-                Filters.and(userFilter, Filters.in(AgenticUsers.TEAM_NAME, null, "")),
-                Updates.set(AgenticUsers.TEAM_NAME, teamName));
-        if (hasRole)
-            getMCollection().updateOne(
-                Filters.and(userFilter, Filters.in(AgenticUsers.USER_ROLE, null, "")),
-                Updates.set(AgenticUsers.USER_ROLE, userRole));
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+            new String[]{AgenticUsers.DEVICE_TAGS + "." + DeviceTag.KEY,
+                    AgenticUsers.DEVICE_TAGS + "." + DeviceTag.VALUE}, false);
     }
 
     /**
-     * Returns the flat list of device IDs belonging to users that match any of the given
-     * teams/roles, optionally narrowed to (or substituted by) an explicit set of device IDs.
-     * Pass all-empty/null lists to get an empty result (not all devices).
+     * Full replace of a source's tags with the given key→values set — deleting any key not
+     * reported, so stale groups don't linger. Correct for SSO, which always reports the
+     * identity's *complete* current group membership on every login. Wrong for a dashboard edit,
+     * which only ever touches specific fields — see mergeDeviceTags for that case.
      */
-    public List<String> findDeviceIdsByTeamsRolesAndDeviceIds(List<String> teams, List<String> roles, List<String> deviceIds) {
+    public void upsertDeviceTags(String identityUserName, String source, Map<String, List<String>> keyValues, String lastUpdatedBy) {
+        writeDeviceTags(identityUserName, source, keyValues, lastUpdatedBy, t -> !source.equals(t.getSource()));
+    }
+
+    /**
+     * Only touches the keys present in keyValues — other tags from the same source are left
+     * alone. Used by the dashboard, where a single edit only ever sets specific fields, not the
+     * admin's complete tag set (unlike SSO, which always reports everything every login).
+     */
+    public void mergeDeviceTags(String identityUserName, String source, Map<String, List<String>> keyValues, String lastUpdatedBy) {
+        Set<String> touchedKeys = new HashSet<>();
+        for (String key : keyValues.keySet()) {
+            if (key != null && !key.trim().isEmpty()) touchedKeys.add(key.trim().toLowerCase());
+        }
+        writeDeviceTags(identityUserName, source, keyValues, lastUpdatedBy,
+                t -> !(source.equals(t.getSource()) && touchedKeys.contains(t.getKey())));
+    }
+
+    private void writeDeviceTags(String identityUserName, String source, Map<String, List<String>> keyValues,
+            String lastUpdatedBy, java.util.function.Predicate<DeviceTag> keepExisting) {
+        if (identityUserName == null || identityUserName.trim().isEmpty() || source == null || source.trim().isEmpty()) return;
+        int now = Context.now();
+
+        List<DeviceTag> newTags = new ArrayList<>();
+        outer:
+        for (Map.Entry<String, List<String>> entry : keyValues.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || key.trim().isEmpty() || entry.getValue() == null) continue;
+            for (String rawValue : entry.getValue()) {
+                if (rawValue == null || rawValue.trim().isEmpty()) continue;
+                if (newTags.size() >= MAX_TAGS_PER_SOURCE) {
+                    logger.warn("[{}] tag cap ({}) reached for {} — remaining values dropped", source, MAX_TAGS_PER_SOURCE, identityUserName);
+                    break outer;
+                }
+                newTags.add(new DeviceTag(key.trim().toLowerCase(), rawValue.trim().toLowerCase(), source, now, lastUpdatedBy));
+            }
+        }
+
+        // Baseline: any one doc already sharing this identity has the same deviceTags as its
+        // siblings — this method always writes them identically via updateMany below.
+        AgenticUsers existing = instance.findOne(Filters.eq(AgenticUsers.USER_NAME, identityUserName));
+        List<DeviceTag> existingTags = existing != null && existing.getDeviceTags() != null
+                ? existing.getDeviceTags() : Collections.emptyList();
+
+        List<DeviceTag> merged = existingTags.stream().filter(keepExisting).collect(Collectors.toCollection(ArrayList::new));
+        merged.addAll(newTags);
+
+        instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, identityUserName),
+                Updates.set(AgenticUsers.DEVICE_TAGS, merged));
+    }
+
+    /** Union of every doc matching username, email, or derived username — not first-tier-wins. */
+    private List<AgenticUsers> findAllIdentityMatches(String userName, String userEmail, String derivedUsername) {
+        List<Bson> identityMatchers = new ArrayList<>();
+        identityMatchers.add(Filters.eq(AgenticUsers.USER_NAME, userName));
+        if (userEmail != null && !userEmail.isEmpty()) {
+            identityMatchers.add(Filters.eq(AgenticUsers.USER_EMAIL, userEmail));
+        }
+        if (derivedUsername != null) {
+            identityMatchers.add(Filters.eq(AgenticUsers.USER_NAME, derivedUsername));
+        }
+        return instance.findAll(Filters.or(identityMatchers));
+    }
+
+    private static String deriveUsernameFromEmail(String email) {
+        if (email == null || email.isEmpty() || !email.contains("@")) return null;
+        String local = email.substring(0, email.indexOf('@')).trim();
+        return local.isEmpty() ? null : local;
+    }
+
+    /**
+     * Resolves this SSO identity (union-match across username/email/derived-username,
+     * canonicalizing every match onto the email-derived username so fragments converge over
+     * time), ensures a doc exists, and refreshes email/timestamp. Callers apply tags afterward
+     * via upsertDeviceTags using the returned canonical username.
+     */
+    public String syncSsoIdentity(String userName, String userEmail, String lastUpdatedBy) {
+        if (userName == null || userName.trim().isEmpty()) return null;
+        String trimmedName = userName.trim();
+        String trimmedEmail = userEmail == null ? "" : userEmail.trim();
+        String derivedUsername = deriveUsernameFromEmail(trimmedEmail);
+
+        List<AgenticUsers> matches = findAllIdentityMatches(trimmedName, trimmedEmail, derivedUsername);
+        String identityUserName = derivedUsername != null ? derivedUsername : trimmedName;
+
+        List<Bson> baseUpdates = Arrays.asList(
+                Updates.set(AgenticUsers.USER_NAME, identityUserName),
+                Updates.set(AgenticUsers.USER_EMAIL, trimmedEmail),
+                Updates.set(AgenticUsers.LAST_UPDATED_AT, Context.now()),
+                Updates.set(AgenticUsers.LAST_UPDATED_BY, lastUpdatedBy));
+        if (matches.isEmpty()) {
+            instance.updateOne(Filters.eq(AgenticUsers.USER_NAME, identityUserName), Updates.combine(baseUpdates));
+        } else {
+            List<String> matchedUsernames = matches.stream().map(AgenticUsers::getUserName).distinct().collect(Collectors.toList());
+            instance.updateMany(Filters.in(AgenticUsers.USER_NAME, matchedUsernames), Updates.combine(baseUpdates));
+        }
+        return identityUserName;
+    }
+
+    /**
+     * Exact-username lookup only — the dashboard always sends back the live device-reported
+     * username round-tripped from this DAO's own data, so broader matching (needed for SSO,
+     * where the caller only has an email) doesn't help here. Ensures a doc exists.
+     */
+    public String ensureDashboardIdentity(String userName, String userEmail, String lastUpdatedBy) {
+        if (userName == null || userName.trim().isEmpty()) return null;
+        String trimmedName = userName.trim();
+        String trimmedEmail = userEmail == null ? "" : userEmail.trim();
+
+        AgenticUsers existing = instance.findOne(Filters.eq(AgenticUsers.USER_NAME, trimmedName));
+        if (existing == null) {
+            AgenticUsers newUser = new AgenticUsers();
+            newUser.setUserName(trimmedName);
+            if (!trimmedEmail.isEmpty()) newUser.setUserEmail(trimmedEmail);
+            newUser.setLastUpdatedAt(Context.now());
+            newUser.setLastUpdatedBy(lastUpdatedBy);
+            instance.insertOne(newUser);
+        } else {
+            List<Bson> updates = new ArrayList<>();
+            updates.add(Updates.set(AgenticUsers.LAST_UPDATED_AT, Context.now()));
+            updates.add(Updates.set(AgenticUsers.LAST_UPDATED_BY, lastUpdatedBy));
+            if (!trimmedEmail.isEmpty()) updates.add(Updates.set(AgenticUsers.USER_EMAIL, trimmedEmail));
+            instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, trimmedName), Updates.combine(updates));
+        }
+        return trimmedName;
+    }
+
+    /**
+     * Generalizes findDeviceIdsByTeamsRolesAndDeviceIds to arbitrary tag keys: entries in
+     * tagFilters AND together; within one key, any of its values match (OR).
+     */
+    public List<String> findDeviceIdsByTags(Map<String, List<String>> tagFilters, List<String> deviceIds) {
         List<Bson> conditions = new ArrayList<>();
-        if (teams != null && !teams.isEmpty()) {
-            conditions.add(Filters.or(
-                Filters.and(Filters.eq(AgenticUsers.TEAM_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.TEAM_NAME, teams)),
-                Filters.and(Filters.ne(AgenticUsers.TEAM_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.SSO_TEAM_NAME, teams))
-            ));
+        if (tagFilters != null) {
+            for (Map.Entry<String, List<String>> entry : tagFilters.entrySet()) {
+                if (entry.getKey() == null || entry.getValue() == null) continue;
+                List<String> values = entry.getValue().stream()
+                        .filter(v -> v != null && !v.trim().isEmpty())
+                        .map(v -> v.trim().toLowerCase())
+                        .collect(Collectors.toList());
+                if (values.isEmpty()) continue;
+                conditions.add(Filters.elemMatch(AgenticUsers.DEVICE_TAGS, Filters.and(
+                        Filters.eq(DeviceTag.KEY, entry.getKey().trim().toLowerCase()),
+                        Filters.in(DeviceTag.VALUE, values))));
+            }
         }
-        if (roles != null && !roles.isEmpty()) {
-            conditions.add(Filters.or(
-                Filters.and(Filters.eq(AgenticUsers.ROLE_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.USER_ROLE, roles)),
-                Filters.and(Filters.ne(AgenticUsers.ROLE_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.SSO_USER_ROLE, roles))
-            ));
-        }
-        boolean hasTeamOrRole = !conditions.isEmpty();
+        boolean hasTagFilters = !conditions.isEmpty();
         boolean hasDeviceIds = deviceIds != null && !deviceIds.isEmpty();
-        if (!hasTeamOrRole && !hasDeviceIds) {
+        if (!hasTagFilters && !hasDeviceIds) {
             return new ArrayList<>();
         }
 
-        // Explicit device IDs come straight from a dropdown sourced off live device data at pick
-        // time — trust them directly rather than re-deriving through a team/role join.
-        if (!hasTeamOrRole) {
+        // Device IDs come straight from a dropdown built off live module_info data at pick time —
+        // trust them directly rather than re-deriving through a username/tag join.
+        if (!hasTagFilters) {
             return new ArrayList<>(new HashSet<>(deviceIds));
         }
 
+        // module_info is updated on every heartbeat, unlike AgenticUsers.devices which is only
+        // ever backfilled once — resolve devices live instead of trusting the stored field.
+        Map<String, Set<String>> liveDevicesByUsername = ModuleInfoDao.instance.fetchUsernameToDeviceIdsForEndpointShield();
         Bson userFilter = conditions.size() == 1 ? conditions.get(0) : Filters.and(conditions);
-        Set<String> teamRoleDeviceIds = new HashSet<>();
+        Set<String> tagDeviceIds = new HashSet<>();
         for (AgenticUsers user : instance.findAll(userFilter)) {
-            if (user.getDevices() != null) {
-                teamRoleDeviceIds.addAll(user.getDevices());
+            Set<String> liveDevices = liveDevicesByUsername.get(user.getUserName());
+            if (liveDevices != null) {
+                tagDeviceIds.addAll(liveDevices);
             }
         }
 
         if (!hasDeviceIds) {
-            return new ArrayList<>(teamRoleDeviceIds);
+            return new ArrayList<>(tagDeviceIds);
         }
 
-        // Both dimensions given — a device must satisfy the team/role match AND be explicitly picked.
-        teamRoleDeviceIds.retainAll(new HashSet<>(deviceIds));
-        return new ArrayList<>(teamRoleDeviceIds);
+        // Both dimensions given — a device must satisfy the tag match AND be explicitly picked.
+        tagDeviceIds.retainAll(new HashSet<>(deviceIds));
+        return new ArrayList<>(tagDeviceIds);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/monitoring/ModuleInfoDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/monitoring/ModuleInfoDao.java
@@ -8,6 +8,12 @@ import com.akto.dto.monitoring.ModuleInfo.ModuleType;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Projections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.bson.conversions.Bson;
 
 public class ModuleInfoDao extends AccountsContextDao<ModuleInfo> {
@@ -47,5 +53,23 @@ public class ModuleInfoDao extends AccountsContextDao<ModuleInfo> {
     @Override
     public Class<ModuleInfo> getClassT() {
         return ModuleInfo.class;
+    }
+
+    // Ported from the dashboard's AgentUsersDao.findDeviceIdsByTags live-device join — module_info
+    // is updated on every heartbeat, unlike AgenticUsers.devices which is only ever backfilled
+    // once, so guardrail tag-targeting resolves against this instead of the stored field.
+    public Map<String, Set<String>> fetchUsernameToDeviceIdsForEndpointShield() {
+        List<ModuleInfo> modules = findAll(Filters.eq(ModuleInfo.MODULE_TYPE, ModuleType.MCP_ENDPOINT_SHIELD),
+            Projections.include(ModuleInfo.NAME, ModuleInfo.ADDITIONAL_DATA));
+        Map<String, Set<String>> result = new HashMap<>();
+        for (ModuleInfo m : modules) {
+            Map<String, Object> ad = m.getAdditionalData();
+            if (ad == null || ad.get("username") == null) continue;
+            String username = String.valueOf(ad.get("username")).trim();
+            String deviceId = m.getName() == null ? "" : m.getName().trim();
+            if (username.isEmpty() || deviceId.isEmpty()) continue;
+            result.computeIfAbsent(username, k -> new HashSet<>()).add(deviceId);
+        }
+        return result;
     }
 }

--- a/libs/dao/src/main/java/com/akto/dto/AgenticUsers.java
+++ b/libs/dao/src/main/java/com/akto/dto/AgenticUsers.java
@@ -15,30 +15,17 @@ public class AgenticUsers {
 
     public static final String USER_NAME = "userName";
     public static final String USER_EMAIL = "userEmail";
-    public static final String USER_ROLE = "userRole";
-    public static final String TEAM_NAME = "teamName";
     public static final String LAST_UPDATED_AT = "lastUpdatedAt";
     public static final String LAST_UPDATED_BY = "lastUpdatedBy";
-    public static final String TEAM_SOURCE = "teamSource";
-    public static final String ROLE_SOURCE = "roleSource";
-    public static final String SSO_TEAM_NAME = "ssoTeamName";
-    public static final String SSO_USER_ROLE = "ssoUserRole";
-    public static final String SOURCE_SSO = "sso";
-    public static final String SOURCE_MANUAL = "manual";
-    public static final String DEVICES = "devices";
+
+    public static final String DEVICE_TAGS = "deviceTags";
 
     private String userName;
     private String userEmail;
-    private String userRole;
-    private String teamName;
     private int lastUpdatedAt;
     private String lastUpdatedBy;
     private List<String> devices;
-    // "sso" or "manual" — SSO writes are skipped when source is "manual".
-    private String teamSource;
-    private String roleSource;
-    // Last values provided by SSO — always kept up-to-date regardless of manual pin.
-    // Used to restore the effective value immediately when an admin clears a manual override.
-    private String ssoTeamName;
-    private String ssoUserRole;
+
+    // Generic key-value tags (team, role, department, arbitrary Okta groups, ...).
+    private List<DeviceTag> deviceTags;
 }

--- a/libs/dao/src/main/java/com/akto/dto/DeviceTag.java
+++ b/libs/dao/src/main/java/com/akto/dto/DeviceTag.java
@@ -1,0 +1,31 @@
+package com.akto.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// Ported from the dashboard's DeviceTag model, for tag-based guardrail targeting resolution
+// in the data-abstractor. Kept in sync with com.akto.dto.DeviceTag in the main dashboard repo.
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeviceTag {
+
+    public static final String SOURCE_MANUAL = "manual";
+
+    public static final String KEY = "key";
+    public static final String VALUE = "value";
+    public static final String SOURCE = "source";
+    public static final String LAST_UPDATED_AT = "lastUpdatedAt";
+    public static final String LAST_UPDATED_BY = "lastUpdatedBy";
+
+    private String key;
+    private String value;
+    // Free-form, not an enum — e.g. "manual", "okta", and any future identity provider,
+    // added with no schema change.
+    private String source;
+    private int lastUpdatedAt;
+    private String lastUpdatedBy;
+}

--- a/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
+++ b/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
@@ -101,12 +101,15 @@ public class GuardrailPolicies {
     private boolean applyToAllServers;
 
     // applyToDeviceIds is resolved at fetch time (not stored) by the dashboard before serving to the enforcement layer.
-    // null  => no team/role targeting configured => apply to all devices.
+    // null  => no team/role/device targeting configured => apply to all devices.
     // list (even empty) => targeting configured; apply ONLY to these device ids.
-    //          An empty list here means 0 devices currently match the selected teams/roles
+    //          An empty list here means 0 devices currently match the selected teams/roles/deviceIds
     //          (or resolution failed) => apply to none, NOT apply to all.
     private List<String> targetTeams;
     private List<String> targetRoles;
+    // Explicitly-picked device IDs (dashboard UI shows them labeled by username, but the stored
+    // value here is the device ID itself — usernames aren't a reliable unique identity).
+    private List<String> targetDeviceIds;
     @BsonIgnore
     private List<String> applyToDeviceIds;
     

--- a/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
+++ b/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
@@ -101,18 +101,22 @@ public class GuardrailPolicies {
     private boolean applyToAllServers;
 
     // applyToDeviceIds is resolved at fetch time (not stored) by the dashboard before serving to the enforcement layer.
-    // null  => no team/role/device targeting configured => apply to all devices.
+    // null  => no device/tag targeting configured => apply to all devices.
     // list (even empty) => targeting configured; apply ONLY to these device ids.
-    //          An empty list here means 0 devices currently match the selected teams/roles/deviceIds
+    //          An empty list here means 0 devices currently match the selected deviceIds/tags
     //          (or resolution failed) => apply to none, NOT apply to all.
-    private List<String> targetTeams;
-    private List<String> targetRoles;
     // Explicitly-picked device IDs (dashboard UI shows them labeled by username, but the stored
     // value here is the device ID itself — usernames aren't a reliable unique identity).
     private List<String> targetDeviceIds;
+
+    // Generic key-value targeting (team, role, department, arbitrary tags, ...), ported from the
+    // dashboard's DeviceTag redesign. Resolved the same way as targetDeviceIds above, via
+    // AgentUsersDao.findDeviceIdsByTags, and unioned with that result at fetch time.
+    private Map<String, List<String>> targetTags;
+
     @BsonIgnore
     private List<String> applyToDeviceIds;
-    
+
 
     // Blocked host/path list — block-only glob patterns matched against the request host+path.
     // Object-shaped so it can be extended later without a data migration.

--- a/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
@@ -3131,11 +3131,11 @@ public class DbLayer {
         }
     }
 
-    public static List<String> findDeviceIdsByTeamsAndRoles(List<String> teams, List<String> roles) {
+    public static List<String> findDeviceIdsByTeamsRolesAndDeviceIds(List<String> teams, List<String> roles, List<String> deviceIds) {
         try {
-            return AgentUsersDao.instance.findDeviceIdsByTeamsAndRoles(teams, roles);
+            return AgentUsersDao.instance.findDeviceIdsByTeamsRolesAndDeviceIds(teams, roles, deviceIds);
         } catch (Exception e) {
-            loggerMaker.errorAndAddToDb(e, "Error in findDeviceIdsByTeamsAndRoles: " + e.getMessage());
+            loggerMaker.errorAndAddToDb(e, "Error in findDeviceIdsByTeamsRolesAndDeviceIds: " + e.getMessage());
             return new ArrayList<>();
         }
     }

--- a/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
@@ -302,15 +302,28 @@ public class DbLayer {
         }
         try {
             String userName = String.valueOf(additionalData.get("username"));
-            Object teamObj = additionalData.get("team");
-            Object roleObj = additionalData.get("userRole");
-            String teamName = teamObj == null ? null : StringUtils.trimToNull(teamObj.toString());
-            String userRole = roleObj == null ? null : StringUtils.trimToNull(roleObj.toString());
-            String device = moduleInfo.getName();
-            AgentUsersDao.instance.upsertAgentUser(userName, teamName, userRole, device, Context.now());
+
+            // additionalData's wire keys ("team"/"userRole") are the device's own self-reported
+            // field names, unrelated to (and unchanged by) AgenticUsers' deviceTags redesign —
+            // each one just becomes a single-value deviceTags entry under its tag key ("team"/"role").
+            Map<String, List<String>> deviceTagUpdates = new HashMap<>();
+            putIfPresent(deviceTagUpdates, "team", additionalData.get("team"));
+            putIfPresent(deviceTagUpdates, "role", additionalData.get("userRole"));
+            if (deviceTagUpdates.isEmpty()) return;
+
+            // mergeDeviceTags only updates an existing doc (no upsert) — ensureDashboardIdentity
+            // creates one on the first check-in from a brand-new device-reported user, matching the
+            // dashboard's own AgentUsersDao.ensureDashboardIdentity + mergeDeviceTags call order.
+            AgentUsersDao.instance.ensureDashboardIdentity(userName, null, "device");
+            AgentUsersDao.instance.mergeDeviceTags(userName, "device", deviceTagUpdates, "device");
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb(e, "Error syncing agent user from module info: " + e.getMessage(), LogDb.DB_ABS);
         }
+    }
+
+    private static void putIfPresent(Map<String, List<String>> deviceTagUpdates, String tagKey, Object rawValue) {
+        String value = rawValue == null ? null : StringUtils.trimToNull(rawValue.toString());
+        if (value != null) deviceTagUpdates.put(tagKey, Collections.singletonList(value));
     }
 
     public static void bulkUpdateModuleInfo(List<ModuleInfo> moduleInfoList) {
@@ -3131,11 +3144,11 @@ public class DbLayer {
         }
     }
 
-    public static List<String> findDeviceIdsByTeamsRolesAndDeviceIds(List<String> teams, List<String> roles, List<String> deviceIds) {
+    public static List<String> findDeviceIdsByTags(Map<String, List<String>> tagFilters, List<String> deviceIds) {
         try {
-            return AgentUsersDao.instance.findDeviceIdsByTeamsRolesAndDeviceIds(teams, roles, deviceIds);
+            return AgentUsersDao.instance.findDeviceIdsByTags(tagFilters, deviceIds);
         } catch (Exception e) {
-            loggerMaker.errorAndAddToDb(e, "Error in findDeviceIdsByTeamsRolesAndDeviceIds: " + e.getMessage());
+            loggerMaker.errorAndAddToDb(e, "Error in findDeviceIdsByTags: " + e.getMessage());
             return new ArrayList<>();
         }
     }


### PR DESCRIPTION
- Updated GuardrailPoliciesAction to include targetDeviceIds in device ID resolution.
- Refactored AgentUsersDao to support finding device IDs based on teams, roles, and device IDs.
- Modified DbLayer to call the new method in AgentUsersDao for device ID retrieval.
- Adjusted comments in GuardrailPolicies to reflect the new targeting logic for devices.