### PR TITLE
feat: add email index to AgenticUsers for improved SSO user lookup

### DIFF
--- a/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
@@ -18,6 +18,9 @@ public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
 
         MCollection.createIndexIfAbsent(getDBName(), getCollName(),
             new String[]{AgenticUsers.USER_NAME}, false);
+
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+            new String[]{AgenticUsers.USER_EMAIL}, false);
     }
 
     /**

--- a/libs/utils/src/main/resources/db/changelog/account/011-agent-users-email-index.xml
+++ b/libs/utils/src/main/resources/db/changelog/account/011-agent-users-email-index.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:mongodb="http://www.liquibase.org/xml/ns/mongodb"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+        http://www.liquibase.org/xml/ns/mongodb
+        http://www.liquibase.org/xml/ns/mongodb/liquibase-mongodb-latest.xsd">
+
+    <!--
+        Mirrors AgentUsersDao.createIndicesIfAbsent. upsertTagFromSso now matches existing
+        AgenticUsers documents by userEmail (in addition to userName) so that an SSO login can
+        find a user record created under a different username but the same email. Without an
+        index, that lookup falls back to a full collection scan.
+
+        Index name matches MCollection.generateIndexName so this is a no-op if DaoInit already
+        built it.
+    -->
+
+    <changeSet id="011-account-agent-users-email-index" author="akto">
+        <preConditions onFail="MARK_RAN">
+            <mongodb:collectionExists collectionName="agent_users"/>
+        </preConditions>
+        <mongodb:createIndex collectionName="agent_users">
+            <mongodb:keys>{ "userEmail": -1 }</mongodb:keys>
+            <mongodb:options>{ "name": "userEmail_-1" }</mongodb:options>
+        </mongodb:createIndex>
+        <rollback>
+            <mongodb:dropIndex collectionName="agent_users">
+                <mongodb:keys>{ "userEmail": -1 }</mongodb:keys>
+            </mongodb:dropIndex>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This update introduces a new index on the userEmail field in the agent_users collection to enhance the SSO login process. The change ensures that user records can be matched by email, even if created under different usernames, thereby optimizing lookup efficiency and preventing full collection scans.