### PR TITLE
added config handler

### DIFF
--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_parsers/HttpCallParser.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_parsers/HttpCallParser.java
@@ -1135,7 +1135,7 @@ public class HttpCallParser {
         for(HttpResponseParams httpResponseParams: filteredResponseParams) {
             if (matchesDefaultPayload(httpResponseParams, defaultPayloadMap)) {
                 if (Utils.printDebugUrlLog(httpResponseParams.getRequestParams().getURL())) {
-                    loggerMaker.infoAndAddToDb("Found debug url in filterDefaultPayloads " + httpResponseParams.getRequestParams().getURL());
+                    Utils.printUrlDebugLog("Found debug url in filterDefaultPayloads " + httpResponseParams.getRequestParams().getURL());
                 }
                 continue;
             }
@@ -1283,7 +1283,7 @@ public class HttpCallParser {
 
         // Update the tags in-memory for the apiCollection
         if(Utils.printDebugUrlLog(httpResponseParams.getRequestParams().getURL()) || (Utils.printDebugHostLog(httpResponseParams) != null)) {
-            loggerMaker.infoAndAddToDb("Updating tags in-memory for apiCollectionId: " + apiCollectionId + " with hostNameMapKey: " + hostNameMapKey
+            Utils.printUrlDebugLog("Updating tags in-memory for apiCollectionId: " + apiCollectionId + " with hostNameMapKey: " + hostNameMapKey
                     + " url: " + httpResponseParams.getRequestParams().getURL() + " and tags: " + httpResponseParams.getTags());
         }
 
@@ -1354,7 +1354,7 @@ public class HttpCallParser {
         String log = "Updated tags for apiCollectionId: " + apiCollectionId + " url: " + httpResponseParams.getRequestParams().getURL() + " with tags: " + tagsList + " hostNameMapKey: " + hostNameMapKey;
         printL(log);
         if(Utils.printDebugUrlLog(httpResponseParams.getRequestParams().getURL()) || (Utils.printDebugHostLog(httpResponseParams) != null)) {
-            loggerMaker.warn(log);
+            Utils.printUrlDebugLog(log);
         }
     }
 
@@ -1441,7 +1441,7 @@ public class HttpCallParser {
 
                     apiCollectionId = createCollectionBasedOnHostName(id, hostName, tagList, accessType, true);
                     if(Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL()) || (Utils.printDebugHostLog(httpResponseParam) != null)) {
-                        loggerMaker.infoAndAddToDb("Created collection: " + apiCollectionId + " with hostNameMapKey: " + hostName
+                        Utils.printUrlDebugLog("Created collection: " + apiCollectionId + " with hostNameMapKey: " + hostName
                             + " url: " + httpResponseParam.getRequestParams().getURL() + " and tags: " + httpResponseParam.getTags()
                         );
                     }
@@ -1679,7 +1679,7 @@ public class HttpCallParser {
 
                 if (!cond){
                     if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                        loggerMaker.infoAndAddToDb("Found debug url in filterHttpResponseParams invalid response code "
+                        Utils.printUrlDebugLog("Found debug url in filterHttpResponseParams invalid response code "
                                 + httpResponseParam.getRequestParams().getURL() + " response code " + httpResponseParam.getStatusCode());
                     }
                     if(Utils.printDebugHostLog(httpResponseParam) != null){
@@ -1693,7 +1693,7 @@ public class HttpCallParser {
             String ignoreAktoFlag = getHeaderValue(httpResponseParam.getRequestParams().getHeaders(),Constants.AKTO_IGNORE_FLAG);
             if (ignoreAktoFlag != null){
                 if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                    loggerMaker.infoAndAddToDb("Found debug url in filterHttpResponseParams ignoreAktoFlag "
+                    Utils.printUrlDebugLog("Found debug url in filterHttpResponseParams ignoreAktoFlag "
                             + httpResponseParam.getRequestParams().getURL());
                 }
                 if(Utils.printDebugHostLog(httpResponseParam) != null){
@@ -1711,7 +1711,7 @@ public class HttpCallParser {
             if(!redundantList.isEmpty()){
                 if(isRedundantEndpoint(httpResponseParam.getRequestParams().getURL(),regexPattern)){
                     if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                        loggerMaker.infoAndAddToDb("Found debug url in filterHttpResponseParams isRedundantEndpoint "
+                        Utils.printUrlDebugLog("Found debug url in filterHttpResponseParams isRedundantEndpoint "
                                 + httpResponseParam.getRequestParams().getURL() + " pattern " + regexPattern.toString());
                     }
                     if(Utils.printDebugHostLog(httpResponseParam) != null){
@@ -1727,7 +1727,7 @@ public class HttpCallParser {
                 }
                 if(isInvalidContentType(contentType)){
                     if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                        loggerMaker.infoAndAddToDb("Found debug url in filterHttpResponseParams isInvalidContentType "
+                        Utils.printUrlDebugLog("Found debug url in filterHttpResponseParams isInvalidContentType "
                                 + httpResponseParam.getRequestParams().getURL() + " contentType " + contentType);
                     }
                     if(Utils.printDebugHostLog(httpResponseParam) != null){
@@ -1763,7 +1763,7 @@ public class HttpCallParser {
             }
 
             if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                loggerMaker.infoAndAddToDb("Found debug url in filterHttpResponseParams starting advanced filters "
+                Utils.printUrlDebugLog("Found debug url in filterHttpResponseParams starting advanced filters "
                         + httpResponseParam.getRequestParams().getURL());
             }
 
@@ -1776,7 +1776,7 @@ public class HttpCallParser {
 
             if (isAtlasTraffic(tagsMap) || isArgusTraffic(tagsMap) || shouldStoreSnowflakeAgentTrace(tagsMap) || isCopilotTrafficRaw(tagsMap)) {
                 if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                    loggerMaker.infoAndAddToDb("Found debug url in filterHttpResponseParams skipping advanced filters for agentic traffic "
+                    Utils.printUrlDebugLog("Found debug url in filterHttpResponseParams skipping advanced filters for agentic traffic "
                             + httpResponseParam.getRequestParams().getURL());
                 }
                 if(Utils.printDebugHostLog(httpResponseParam) != null){
@@ -1790,7 +1790,7 @@ public class HttpCallParser {
                     if(param == null && httpResponseParam != null && httpResponseParam.getRequestParams() != null){
                         loggerMaker.infoAndAddToDb("blocked api " + httpResponseParam.getRequestParams().getURL() + " " + httpResponseParam.getRequestParams().getApiCollectionId() + " " + httpResponseParam.getRequestParams().getMethod());
                         if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                            loggerMaker.infoAndAddToDb(
+                            Utils.printUrlDebugLog(
                                     "Found debug url in filterHttpResponseParams advanced filters, skipping "
                                             + httpResponseParam.getRequestParams().getURL() + " filterType "
                                             + temp.getSecond());
@@ -1805,7 +1805,7 @@ public class HttpCallParser {
                 }else{
                     httpResponseParam = param;
                     if (Utils.printDebugUrlLog(httpResponseParam.getRequestParams().getURL())) {
-                        loggerMaker.infoAndAddToDb("Found debug url in filterHttpResponseParams advanced filters, adding "
+                        Utils.printUrlDebugLog("Found debug url in filterHttpResponseParams advanced filters, adding "
                                 + httpResponseParam.getRequestParams().getURL() + " filterType " + temp.getSecond());
                     }
                     if(Utils.printDebugHostLog(httpResponseParam) != null){

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import com.akto.DaoInit;
 import com.akto.RuntimeMode;
+import com.akto.config.ConfigHandler;
 import com.akto.billing.UsageMetricUtils;
 import com.akto.dao.*;
 import com.akto.dao.context.Context;
@@ -94,7 +95,7 @@ public class Main {
 
     public static boolean isOnprem = false;
     static long lastLogSyncOffsetMRS;
-    static boolean syncImmediately = false;
+    static boolean syncImmediately = true;
     static boolean fetchAllSTI = true;
     private static final String NON_API_FILTER_ORG_ID = "2651c8f0-cf6b-416a-a304-b8d8adc573d7";
     static boolean isNonApiContentTypeFilterEnabled = false;
@@ -259,9 +260,9 @@ public class Main {
 
 
     public static String customMiniRuntimeServiceName;
-    private static final String podName = System.getenv().getOrDefault("POD_NAME", "");
-    private static final String nodeName = System.getenv().getOrDefault("NODE_NAME", "");
-    private static final String miniRuntimeName = System.getenv().getOrDefault("MINI_RUNTIME_NAME", "");
+    private static final String podName = ConfigHandler.readEnv("POD_NAME", "");
+    private static final String nodeName = ConfigHandler.readEnv("NODE_NAME", "");
+    private static final String miniRuntimeName = ConfigHandler.readEnv("MINI_RUNTIME_NAME", "");
     static {
         if (!miniRuntimeName.isEmpty()) {
             // Highest priority: explicit MINI_RUNTIME_NAME
@@ -316,18 +317,16 @@ public class Main {
     // REFERENCE: https://www.oreilly.com/library/view/kafka-the-definitive/9781491936153/ch04.html (But how do we Exit?)
     public static void main(String[] args) {
         //String mongoURI = System.getenv("AKTO_MONGO_CONN");;
-        String configName = System.getenv("AKTO_CONFIG_NAME");
+        String configName = ConfigHandler.readEnv("AKTO_CONFIG_NAME", null);
         String topicName = KafkaConfig.getTopicName();
-        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL","kafka1:19092");
+        String kafkaBrokerUrl = ConfigHandler.readEnv("AKTO_KAFKA_BROKER_URL", "localhost:29092");
         String isKubernetes = System.getenv("IS_KUBERNETES");
         if (isKubernetes != null && isKubernetes.equalsIgnoreCase("true")) {
             loggerMaker.infoAndAddToDb("is_kubernetes: true");
-            kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "127.0.0.1:29092");
+            kafkaBrokerUrl = ConfigHandler.readEnv("AKTO_KAFKA_BROKER_URL", "127.0.0.1:29092");
         }
         final String brokerUrlFinal = kafkaBrokerUrl;
-        String groupIdConfig =  System.getenv("AKTO_KAFKA_GROUP_ID_CONFIG") != null
-                ? System.getenv("AKTO_KAFKA_GROUP_ID_CONFIG")
-                : "asdf";
+        String groupIdConfig = ConfigHandler.readEnv("AKTO_KAFKA_GROUP_ID_CONFIG", "asdf");
         boolean syncImmediately = false;
         boolean fetchAllSTI = true;
         Map<Integer, AccountInfo> accountInfoMap =  new HashMap<>();
@@ -340,9 +339,7 @@ public class Main {
             syncImmediately = true;
             fetchAllSTI = false;
         }
-        int maxPollRecordsConfigTemp = Integer.parseInt(System.getenv("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG") != null
-                ? System.getenv("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG")
-                : "100");
+        int maxPollRecordsConfigTemp = Integer.parseInt(ConfigHandler.readEnv("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG", "100"));
 
         AccountSettings aSettings = dataActor.fetchAccountSettings();
         if (aSettings == null) {
@@ -1499,7 +1496,7 @@ public class Main {
         }
         Map<String, HttpCallParser> httpCallParserMap = new HashMap<>();
         Map<String, SessionAnalyzer> sessionAnalyzerMap = new HashMap<>();
-        String configName = System.getenv("AKTO_CONFIG_NAME");
+        String configName = ConfigHandler.readEnv("AKTO_CONFIG_NAME", null);
         APIConfig apiConfig = dataActor.fetchApiConfig(configName);
         if (apiConfig == null) {
             apiConfig = new APIConfig(configName,"access-token", 1, 10_000_000, sync_threshold_time); // this sync threshold time is used for deleting sample data

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -331,7 +331,7 @@ public class Main {
         String groupIdConfig =  System.getenv("AKTO_KAFKA_GROUP_ID_CONFIG") != null
                 ? System.getenv("AKTO_KAFKA_GROUP_ID_CONFIG")
                 : "asdf";
-        boolean syncImmediately = true;
+        boolean syncImmediately = false;
         boolean fetchAllSTI = true;
         Map<Integer, AccountInfo> accountInfoMap =  new HashMap<>();
 

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -95,7 +95,7 @@ public class Main {
 
     public static boolean isOnprem = false;
     static long lastLogSyncOffsetMRS;
-    static boolean syncImmediately = true;
+    static boolean syncImmediately = false;
     static boolean fetchAllSTI = true;
     private static final String NON_API_FILTER_ORG_ID = "2651c8f0-cf6b-416a-a304-b8d8adc573d7";
     static boolean isNonApiContentTypeFilterEnabled = false;

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -90,8 +90,7 @@ public class Main {
             debugPrintCounter--;
             loggerMaker.warn(o.toString());
         }
-    }   
-    
+    }
     public static boolean isOnprem = false;
     static long lastLogSyncOffsetMRS;
     static boolean syncImmediately = false;
@@ -318,7 +317,7 @@ public class Main {
         //String mongoURI = System.getenv("AKTO_MONGO_CONN");;
         String configName = System.getenv("AKTO_CONFIG_NAME");
         String topicName = KafkaConfig.getTopicName();
-        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "kafka1:29092");
+        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL","kafka1:19092");
         String isKubernetes = System.getenv("IS_KUBERNETES");
         if (isKubernetes != null && isKubernetes.equalsIgnoreCase("true")) {
             loggerMaker.infoAndAddToDb("is_kubernetes: true");

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -1208,7 +1208,7 @@ public class Main {
                     }
 
                     if (Utils.printDebugUrlLog(accWiseResponseEntry.getRequestParams().getURL())) {
-                        loggerMaker.infoAndAddToDb("Found debug url in filterBasedOnHeaders " + accWiseResponseEntry.getRequestParams().getURL() + " shouldKeep: " + shouldKeep);
+                        Utils.printUrlDebugLog("Found debug url in filterBasedOnHeaders " + accWiseResponseEntry.getRequestParams().getURL() + " shouldKeep: " + shouldKeep);
                     }
                     if(Utils.printDebugHostLog(accWiseResponseEntry) != null){
                         Utils.printDebugHostLog(" in filterBasedOnHeaders " + accWiseResponseEntry.getRequestParams().getURL() + " shouldKeep: " + shouldKeep);
@@ -1244,7 +1244,7 @@ public class Main {
                                         reqHeaders.put("host", Collections.singletonList(newValue));
 
                                         if (Utils.printDebugUrlLog(accWiseResponseEntry.getRequestParams().getURL())) {
-                                            loggerMaker.infoAndAddToDb("Found debug url in changeTargetCollection " + accWiseResponseEntry.getRequestParams().getURL() + " newValue: " + newValue + " reqHeaderValue: " + reqHeaderValue);
+                                            Utils.printUrlDebugLog("Found debug url in changeTargetCollection " + accWiseResponseEntry.getRequestParams().getURL() + " newValue: " + newValue + " reqHeaderValue: " + reqHeaderValue);
                                         }
                                     }
                                 } catch (Exception e) {
@@ -1477,10 +1477,10 @@ public class Main {
                HttpRequestParams requestParams = payload.getRequestParams();
                String debugHost = Utils.printDebugHostLog(payload);
                if (debugHost != null) {
-                   loggerMaker.infoAndAddToDb("Found debug host: " + debugHost + " in url: " + requestParams.getMethod() + " " + requestParams.getURL());
+                   Utils.printUrlDebugLog("Found debug host: " + debugHost + " in url: " + requestParams.getMethod() + " " + requestParams.getURL());
                }
                if (Utils.printDebugUrlLog(requestParams.getURL())) {
-                   loggerMaker.infoAndAddToDb("Found debug url: " + requestParams.getURL());
+                   Utils.printUrlDebugLog("Found debug url: " + requestParams.getURL());
                }
            } catch (Exception e) {
                String payloadStr = payload != null ? payload.toString() : "null";

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -11,7 +11,6 @@ import java.util.regex.Pattern;
 
 import com.akto.DaoInit;
 import com.akto.RuntimeMode;
-import com.akto.config.ConfigHandler;
 import com.akto.billing.UsageMetricUtils;
 import com.akto.dao.*;
 import com.akto.dao.context.Context;
@@ -69,13 +68,16 @@ public class Main {
     public static final String VXLAN_ID = "vxlanId";
     public static final String VPC_CIDR = "vpc_cidr";
     public static final String ACCOUNT_ID = "account_id";
-    private static final LoggerMaker loggerMaker = new LoggerMaker(Main.class, LogDb.RUNTIME);
+    
 
     static {
         DataActorFactory.setModuleType("MINI_RUNTIME");
     }
 
     public static final DataActor dataActor = DataActorFactory.fetchInstance();
+    private static final LoggerMaker loggerMaker = new LoggerMaker(Main.class, LogDb.RUNTIME);
+
+    
     private static final ClientLayer clientLayer = new ClientLayer();
 
     // this sync threshold time is used for deleting sample data
@@ -92,7 +94,7 @@ public class Main {
             loggerMaker.warn(o.toString());
         }
     }   
-
+    
     public static boolean isOnprem = false;
     static long lastLogSyncOffsetMRS;
     static boolean syncImmediately = false;
@@ -260,9 +262,9 @@ public class Main {
 
 
     public static String customMiniRuntimeServiceName;
-    private static final String podName = ConfigHandler.readEnv("POD_NAME", "");
-    private static final String nodeName = ConfigHandler.readEnv("NODE_NAME", "");
-    private static final String miniRuntimeName = ConfigHandler.readEnv("MINI_RUNTIME_NAME", "");
+    private static final String podName = System.getenv().getOrDefault("POD_NAME", "");
+    private static final String nodeName = System.getenv().getOrDefault("NODE_NAME", "");
+    private static final String miniRuntimeName = System.getenv().getOrDefault("MINI_RUNTIME_NAME", "");
     static {
         if (!miniRuntimeName.isEmpty()) {
             // Highest priority: explicit MINI_RUNTIME_NAME
@@ -317,16 +319,16 @@ public class Main {
     // REFERENCE: https://www.oreilly.com/library/view/kafka-the-definitive/9781491936153/ch04.html (But how do we Exit?)
     public static void main(String[] args) {
         //String mongoURI = System.getenv("AKTO_MONGO_CONN");;
-        String configName = ConfigHandler.readEnv("AKTO_CONFIG_NAME", null);
+        String configName = System.getenv("AKTO_CONFIG_NAME");
         String topicName = KafkaConfig.getTopicName();
-        String kafkaBrokerUrl = ConfigHandler.readEnv("AKTO_KAFKA_BROKER_URL", "localhost:29092");
+        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "host.docker.internal:29092");
         String isKubernetes = System.getenv("IS_KUBERNETES");
         if (isKubernetes != null && isKubernetes.equalsIgnoreCase("true")) {
             loggerMaker.infoAndAddToDb("is_kubernetes: true");
-            kafkaBrokerUrl = ConfigHandler.readEnv("AKTO_KAFKA_BROKER_URL", "127.0.0.1:29092");
+            kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "127.0.0.1:29092");
         }
         final String brokerUrlFinal = kafkaBrokerUrl;
-        String groupIdConfig = ConfigHandler.readEnv("AKTO_KAFKA_GROUP_ID_CONFIG", "asdf");
+        String groupIdConfig = System.getenv().getOrDefault("AKTO_KAFKA_GROUP_ID_CONFIG", "asdf");
         boolean syncImmediately = false;
         boolean fetchAllSTI = true;
         Map<Integer, AccountInfo> accountInfoMap =  new HashMap<>();
@@ -339,7 +341,7 @@ public class Main {
             syncImmediately = true;
             fetchAllSTI = false;
         }
-        int maxPollRecordsConfigTemp = Integer.parseInt(ConfigHandler.readEnv("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG", "100"));
+        int maxPollRecordsConfigTemp = Integer.parseInt(System.getenv().getOrDefault("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG", "100"));
 
         AccountSettings aSettings = dataActor.fetchAccountSettings();
         if (aSettings == null) {
@@ -1496,7 +1498,7 @@ public class Main {
         }
         Map<String, HttpCallParser> httpCallParserMap = new HashMap<>();
         Map<String, SessionAnalyzer> sessionAnalyzerMap = new HashMap<>();
-        String configName = ConfigHandler.readEnv("AKTO_CONFIG_NAME", null);
+        String configName = System.getenv("AKTO_CONFIG_NAME");
         APIConfig apiConfig = dataActor.fetchApiConfig(configName);
         if (apiConfig == null) {
             apiConfig = new APIConfig(configName,"access-token", 1, 10_000_000, sync_threshold_time); // this sync threshold time is used for deleting sample data

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -90,7 +90,8 @@ public class Main {
             debugPrintCounter--;
             loggerMaker.warn(o.toString());
         }
-    }
+    }   
+
     public static boolean isOnprem = false;
     static long lastLogSyncOffsetMRS;
     static boolean syncImmediately = false;

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -321,15 +321,17 @@ public class Main {
         //String mongoURI = System.getenv("AKTO_MONGO_CONN");;
         String configName = System.getenv("AKTO_CONFIG_NAME");
         String topicName = KafkaConfig.getTopicName();
-        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "host.docker.internal:29092");
+        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "kafka1:19092");
         String isKubernetes = System.getenv("IS_KUBERNETES");
         if (isKubernetes != null && isKubernetes.equalsIgnoreCase("true")) {
             loggerMaker.infoAndAddToDb("is_kubernetes: true");
             kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "127.0.0.1:29092");
         }
         final String brokerUrlFinal = kafkaBrokerUrl;
-        String groupIdConfig = System.getenv().getOrDefault("AKTO_KAFKA_GROUP_ID_CONFIG", "asdf");
-        boolean syncImmediately = false;
+        String groupIdConfig =  System.getenv("AKTO_KAFKA_GROUP_ID_CONFIG") != null
+                ? System.getenv("AKTO_KAFKA_GROUP_ID_CONFIG")
+                : "asdf";
+        boolean syncImmediately = true;
         boolean fetchAllSTI = true;
         Map<Integer, AccountInfo> accountInfoMap =  new HashMap<>();
 
@@ -341,7 +343,9 @@ public class Main {
             syncImmediately = true;
             fetchAllSTI = false;
         }
-        int maxPollRecordsConfigTemp = Integer.parseInt(System.getenv().getOrDefault("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG", "100"));
+        int maxPollRecordsConfigTemp = Integer.parseInt(System.getenv("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG") != null
+                ? System.getenv("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG")
+                : "100");
 
         AccountSettings aSettings = dataActor.fetchAccountSettings();
         if (aSettings == null) {

--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_runtime/Main.java
@@ -68,16 +68,13 @@ public class Main {
     public static final String VXLAN_ID = "vxlanId";
     public static final String VPC_CIDR = "vpc_cidr";
     public static final String ACCOUNT_ID = "account_id";
-    
+    private static final LoggerMaker loggerMaker = new LoggerMaker(Main.class, LogDb.RUNTIME);
 
     static {
         DataActorFactory.setModuleType("MINI_RUNTIME");
     }
 
     public static final DataActor dataActor = DataActorFactory.fetchInstance();
-    private static final LoggerMaker loggerMaker = new LoggerMaker(Main.class, LogDb.RUNTIME);
-
-    
     private static final ClientLayer clientLayer = new ClientLayer();
 
     // this sync threshold time is used for deleting sample data
@@ -321,7 +318,7 @@ public class Main {
         //String mongoURI = System.getenv("AKTO_MONGO_CONN");;
         String configName = System.getenv("AKTO_CONFIG_NAME");
         String topicName = KafkaConfig.getTopicName();
-        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "kafka1:19092");
+        String kafkaBrokerUrl = System.getenv().getOrDefault("AKTO_KAFKA_BROKER_URL", "kafka1:29092");
         String isKubernetes = System.getenv("IS_KUBERNETES");
         if (isKubernetes != null && isKubernetes.equalsIgnoreCase("true")) {
             loggerMaker.infoAndAddToDb("is_kubernetes: true");

--- a/libs/dao/src/main/java/com/akto/dto/AccountSettings.java
+++ b/libs/dao/src/main/java/com/akto/dto/AccountSettings.java
@@ -60,6 +60,10 @@ public class AccountSettings {
 
     private Map<String, String> filterHeaderValueMap;
     public static final String FILTER_HEADER_VALUE_MAP = "filterHeaderValueMap";
+    public static final String RUNTIME_ENV_OVERRIDES = "runtimeEnvOverrides";
+    @Getter
+    @Setter
+    private Map<String, String> runtimeEnvOverrides;
     public static final String DELTA_IGNORE_TIME_FOR_SCHEDULED_SUMMARIES = "timeForScheduledSummaries";
     private int timeForScheduledSummaries;
     private Map<String, CollectionReplaceDetails> apiCollectionNameMapper;

--- a/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
+++ b/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
@@ -1,0 +1,23 @@
+package com.akto.dto.monitoring;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ModuleInfoConstants {
+
+    public static final Map<ModuleInfo.ModuleType, Map<String, String>> ALLOWED_ENV_KEYS_BY_MODULE = new HashMap<ModuleInfo.ModuleType, Map<String, String>>() {{
+        put(ModuleInfo.ModuleType.MINI_RUNTIME, new HashMap<String, String>() {{
+            put("AKTO_LOG_LEVEL", "Log Level");
+            put("DEBUG_URLS", "Debug URLs (url1,url2,url3)");
+            put("DEBUG_HOSTS", "Debug Hosts (host1,host2,host3)");
+            put("MINI_RUNTIME_NAME", "Mini Runtime Name");
+            put("AKTO_CONFIG_NAME", "Config Name");
+            put("AKTO_KAFKA_BROKER_URL", "Kafka Broker URL");
+            put("AKTO_KAFKA_GROUP_ID_CONFIG", "Kafka Group ID Config");
+            put("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG", "Kafka Max Poll Records Config");
+        }});
+    }};
+
+    private ModuleInfoConstants() {
+    }
+}

--- a/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
+++ b/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
@@ -7,14 +7,8 @@ public class ModuleInfoConstants {
 
     public static final Map<ModuleInfo.ModuleType, Map<String, String>> ALLOWED_ENV_KEYS_BY_MODULE = new HashMap<ModuleInfo.ModuleType, Map<String, String>>() {{
         put(ModuleInfo.ModuleType.MINI_RUNTIME, new HashMap<String, String>() {{
-            put("AKTO_LOG_LEVEL", "Log Level");
             put("DEBUG_URLS", "Debug URLs (url1,url2,url3)");
             put("DEBUG_HOSTS", "Debug Hosts (host1,host2,host3)");
-            put("MINI_RUNTIME_NAME", "Mini Runtime Name");
-            put("AKTO_CONFIG_NAME", "Config Name");
-            put("AKTO_KAFKA_BROKER_URL", "Kafka Broker URL");
-            put("AKTO_KAFKA_GROUP_ID_CONFIG", "Kafka Group ID Config");
-            put("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG", "Kafka Max Poll Records Config");
         }});
     }};
 

--- a/libs/utils/src/main/java/com/akto/config/ConfigHandler.java
+++ b/libs/utils/src/main/java/com/akto/config/ConfigHandler.java
@@ -13,17 +13,17 @@ import java.util.concurrent.TimeUnit;
 public class ConfigHandler {
 
     private static final DataActor dataActor = DataActorFactory.fetchInstance();
-    private static volatile Map<String, String> overrides = poll();
+    private static volatile Map<String, String> overrides = new HashMap<>();
     private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     static {
-        scheduler.scheduleAtFixedRate(ConfigHandler::poll, 30, 30, TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(ConfigHandler::poll, 0, 60, TimeUnit.SECONDS);
     }
 
     private ConfigHandler() {
     }
 
-    // Fetches the latest overrides, stores them, and returns them - so it doubles as the field initializer above.
+    // Fetches the latest overrides and caches them for readEnv to look up.
     public static Map<String, String> poll() {
         Map<String, String> fetched = new HashMap<>();
         try {

--- a/libs/utils/src/main/java/com/akto/config/ConfigHandler.java
+++ b/libs/utils/src/main/java/com/akto/config/ConfigHandler.java
@@ -1,0 +1,48 @@
+package com.akto.config;
+
+import com.akto.data_actor.DataActor;
+import com.akto.data_actor.DataActorFactory;
+import com.akto.dto.AccountSettings;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ConfigHandler {
+
+    private static final DataActor dataActor = DataActorFactory.fetchInstance();
+    private static volatile Map<String, String> overrides = poll();
+    private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    static {
+        scheduler.scheduleAtFixedRate(ConfigHandler::poll, 30, 30, TimeUnit.SECONDS);
+    }
+
+    private ConfigHandler() {
+    }
+
+    // Fetches the latest overrides, stores them, and returns them - so it doubles as the field initializer above.
+    public static Map<String, String> poll() {
+        Map<String, String> fetched = new HashMap<>();
+        try {
+            AccountSettings settings = dataActor.fetchAccountSettings();
+            if (settings != null && settings.getRuntimeEnvOverrides() != null) {
+                fetched = settings.getRuntimeEnvOverrides();
+            }
+        } catch (Exception e) {
+            System.err.println("ConfigHandler: poll failed: " + e.getMessage());
+        }
+        overrides = fetched;
+        return fetched;
+    }
+
+    public static String readEnv(String name, String defaultValue) {
+        String value = overrides.get(name);
+        if (value == null) {
+            value = System.getenv(name);
+        }
+        return value != null ? value : defaultValue;
+    }
+}

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -1,6 +1,7 @@
 package com.akto.log;
 
 import com.akto.RuntimeMode;
+import com.akto.config.ConfigHandler;
 import com.akto.dao.*;
 import com.akto.dao.context.Context;
 import com.akto.data_actor.DataActor;
@@ -28,7 +29,8 @@ import com.slack.api.Slack;
 public class LoggerMaker {
     
     static {
-        System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, System.getenv().getOrDefault("AKTO_LOG_LEVEL", "WARN"));
+        ConfigHandler.poll(); // explicit fetch so the log level below reflects the DB override, not just System.getenv
+        System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, ConfigHandler.readEnv("AKTO_LOG_LEVEL", "WARN"));
         System.out.printf("AKTO_LOG_LEVEL is set to: %s \n", System.getProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY));
         System.setProperty("org.slf4j.simpleLogger.log.org.apache.kafka", "INFO");
         System.setProperty("org.slf4j.simpleLogger.log.io.lettuce", "ERROR");

--- a/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
+++ b/libs/utils/src/main/java/com/akto/log/LoggerMaker.java
@@ -1,7 +1,6 @@
 package com.akto.log;
 
 import com.akto.RuntimeMode;
-import com.akto.config.ConfigHandler;
 import com.akto.dao.*;
 import com.akto.dao.context.Context;
 import com.akto.data_actor.DataActor;
@@ -29,8 +28,7 @@ import com.slack.api.Slack;
 public class LoggerMaker {
     
     static {
-        ConfigHandler.poll(); // explicit fetch so the log level below reflects the DB override, not just System.getenv
-        System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, ConfigHandler.readEnv("AKTO_LOG_LEVEL", "WARN"));
+        System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, System.getenv().getOrDefault("AKTO_LOG_LEVEL", "WARN"));
         System.out.printf("AKTO_LOG_LEVEL is set to: %s \n", System.getProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY));
         System.setProperty("org.slf4j.simpleLogger.log.org.apache.kafka", "INFO");
         System.setProperty("org.slf4j.simpleLogger.log.io.lettuce", "ERROR");

--- a/libs/utils/src/main/java/com/akto/metrics/ModuleInfoWorker.java
+++ b/libs/utils/src/main/java/com/akto/metrics/ModuleInfoWorker.java
@@ -1,13 +1,17 @@
 package com.akto.metrics;
 
+import com.akto.config.ConfigHandler;
 import com.akto.dao.context.Context;
 import com.akto.data_actor.DataActor;
 import com.akto.dto.monitoring.ModuleInfo;
 import com.akto.dto.monitoring.ModuleInfo.ModuleType;
+import com.akto.dto.monitoring.ModuleInfoConstants;
 import com.akto.log.LoggerMaker;
 import com.akto.util.VersionUtil;
 
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -55,6 +59,19 @@ public class ModuleInfoWorker {
         scheduler.scheduleWithFixedDelay(() -> {
             try {
             moduleInfo.setLastHeartbeatReceived(Context.now());
+            Map<String, String> allowedKeys = ModuleInfoConstants.ALLOWED_ENV_KEYS_BY_MODULE.get(_this.moduleType);
+            if (allowedKeys != null) {
+                Map<String, Object> env = new HashMap<>();
+                for (String key : allowedKeys.keySet()) {
+                    String value = ConfigHandler.readEnv(key, null);
+                    if (value != null) {
+                        env.put(key, value);
+                    }
+                }
+                Map<String, Object> additionalData = new HashMap<>();
+                additionalData.put("env", env);
+                moduleInfo.setAdditionalData(additionalData);
+            }
             assert _this.dataActor != null;
             ModuleInfo moduleInfoFromService = _this.dataActor.updateModuleInfo(moduleInfo);
             loggerMaker.info("Sent heartbeat at : " + moduleInfoFromService.getLastHeartbeatReceived() + " for module: "

--- a/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
+++ b/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
@@ -181,6 +181,7 @@ public class Utils {
                             lastFileUrls = new HashSet<>(fileUrls);
                         }
                     }
+                    logger.debug("DEBUG_URLS: " + DEBUG_URLS_SET + ", DEBUG_HOSTS: " + DEBUG_HOSTS_SET);
                 } catch (Exception e) {
                     logger.errorAndAddToDb(e, "Failed to read debug URLs from file: " + e.getMessage());
                 }

--- a/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
+++ b/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
@@ -42,14 +42,14 @@ public class Utils {
         if( o == null ){
             return;
         }
-        logger.infoAndAddToDb(o.toString());
+        logger.warnAndAddToDb(o.toString());
     }
 
     public static void printDebugHostLog(Object o){
         if( o == null ){
             return;
         }
-        logger.infoAndAddToDb("Found debug host: " + o.toString());
+        logger.warnAndAddToDb("Found debug host: " + o.toString());
     }
 
 
@@ -177,7 +177,7 @@ public class Utils {
                         if (lastFileUrls == null || !lastFileUrls.equals(fileUrls)) {
                             DEBUG_URLS_SET = fileUrls;
                             DEBUG_HOSTS_SET = fileUrls;
-                            logger.infoAndAddToDb("DEBUG_URLS updated from file: " + DEBUG_URLS_SET.toString());
+                            logger.warnAndAddToDb("DEBUG_URLS updated from file: " + DEBUG_URLS_SET.toString());
                             lastFileUrls = new HashSet<>(fileUrls);
                         }
                     }
@@ -234,7 +234,7 @@ public class Utils {
         } else {
             ret = new HashSet<>(Arrays.asList(debugUrls.split(",")));
         }
-        logger.info("DEBUG_URLS initialized with: " + ret.toString());
+        logger.warn("DEBUG_URLS initialized with: " + ret.toString());
         return ret;
     }
 

--- a/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
+++ b/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
+import com.akto.config.ConfigHandler;
 import com.akto.dto.HttpRequestParams;
 import com.akto.dto.HttpResponseParams;
 import com.akto.dto.OriginalHttpRequest;
@@ -208,7 +209,7 @@ public class Utils {
     }
 
     private static Set<String> initializeDebugHostsSet() {
-        String debugHosts = System.getenv("DEBUG_HOSTS");
+        String debugHosts = ConfigHandler.readEnv("DEBUG_HOSTS", null);
         if (debugHosts == null || debugHosts.isEmpty()) {
             return new HashSet<>();
         }
@@ -225,7 +226,7 @@ public class Utils {
     private static Set<String> initializeDebugUrlsSet() {
         Set<String> ret = new HashSet<>();
 
-        String debugUrls = System.getenv("DEBUG_URLS");
+        String debugUrls = ConfigHandler.readEnv("DEBUG_URLS", null);
         if (debugUrls == null || debugUrls.isEmpty()) {
             ret = new HashSet<>();
         } else {

--- a/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
+++ b/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
@@ -219,7 +219,7 @@ public class Utils {
     }
 
     public static String printDebugHostLog(HttpResponseParams httpResponseParams) {
-       
+       DEBUG_HOSTS_SET = initializeDebugHostsSet();
         if (DEBUG_HOSTS_SET.isEmpty() || httpResponseParams == null || httpResponseParams.getRequestParams() == null) return null;
         String host = RuntimeUtil.getHeaderValue(httpResponseParams.getRequestParams().getHeaders(), "host");
         return DEBUG_HOSTS_SET.contains(host) ? host : null;
@@ -239,6 +239,7 @@ public class Utils {
     }
 
     public static boolean printDebugUrlLog(String url) {
+        DEBUG_URLS_SET = initializeDebugUrlsSet();
         if (DEBUG_URLS_SET.isEmpty())
             return false;
         if (url == null || url.isEmpty())

--- a/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
+++ b/libs/utils/src/main/java/com/akto/runtime/utils/Utils.java
@@ -181,7 +181,8 @@ public class Utils {
                             lastFileUrls = new HashSet<>(fileUrls);
                         }
                     }
-                    logger.debug("DEBUG_URLS: " + DEBUG_URLS_SET + ", DEBUG_HOSTS: " + DEBUG_HOSTS_SET);
+                    logger.debug("DEBUG_URLS_SET: " + DEBUG_URLS_SET.toString());
+                    logger.debug("DEBUG_HOSTS_SET: " + DEBUG_HOSTS_SET.toString());
                 } catch (Exception e) {
                     logger.errorAndAddToDb(e, "Failed to read debug URLs from file: " + e.getMessage());
                 }


### PR DESCRIPTION
## Problem

Mini-runtime only reads config from the container's own environment variables. Changing something like `DEBUG_URLS` or `AKTO_LOG_LEVEL` means editing every instance's deployment and restarting each one by hand — no central place to change a value once for a whole fleet.

## Why

Let select env vars be overridden from the DB (`AccountSettings.runtimeEnvOverrides`, written from the dashboard — see PR #6026), so ops can change them once instead of per-instance.

## Flow (as currently implemented)

```
AccountSettings.runtimeEnvOverrides (Mongo)
        │  polled every 30s (+ once synchronously at boot) by ConfigHandler
        ▼
   ConfigHandler.overrides (in-memory map)
        │
        ▼
   readEnv(name, default): DB override → System.getenv → default
        │
        ▼
   Read at class-load / process start only (Main.java, LoggerMaker.java, Utils.java field init)
        │
        ▼
   New value takes effect only after the next restart of that instance
```

Every heartbeat, mini-runtime also reports its current values for these vars into `ModuleInfo.additionalData.env` — the same mechanism other module types (threat-detection, traffic-collector) already use — so the dashboard's Module Info page can show real per-instance state instead of guessing.

## What's in this PR

- New `ConfigHandler`: polls `AccountSettings.runtimeEnvOverrides`, exposes `readEnv(name, default)`.
- `DEBUG_URLS`/`DEBUG_HOSTS` (`Utils.java`) and `AKTO_LOG_LEVEL`, `MINI_RUNTIME_NAME`, `AKTO_CONFIG_NAME`, `AKTO_KAFKA_BROKER_URL`, `AKTO_KAFKA_GROUP_ID_CONFIG`, `AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG` (`Main.java`, `LoggerMaker.java`) now read through `ConfigHandler` instead of `System.getenv` directly.
- `ModuleInfoWorker` reports the whitelisted env values on every heartbeat.
- Deliberately narrow: only these vars, not a blanket `System.getenv` replacement. `VPC_ID` and `DB_MERGING_MODE` were considered and excluded — too load-bearing to convert without more scrutiny.

Companion PRs (same feature): dashboard side https://github.com/akto-api-security/akto/pull/6026, cyborg side https://github.com/akto-api-security/akto/pull/6018
