### PR TITLE
added mini-runtime support to edit envs

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/AdminSettingsAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AdminSettingsAction.java
@@ -614,10 +614,17 @@ public class AdminSettingsAction extends UserAction {
     }
 
     public String updateRuntimeEnvOverrides() {
+        if (this.runtimeEnvOverrides == null || this.runtimeEnvOverrides.isEmpty()) {
+            return SUCCESS.toUpperCase();
+        }
         try {
+            List<Bson> updates = new ArrayList<>();
+            for (Map.Entry<String, String> entry : this.runtimeEnvOverrides.entrySet()) {
+                updates.add(Updates.set(AccountSettings.RUNTIME_ENV_OVERRIDES + "." + entry.getKey(), entry.getValue()));
+            }
             AccountSettingsDao.instance.updateOne(
                 AccountSettingsDao.generateFilter(),
-                Updates.set(AccountSettings.RUNTIME_ENV_OVERRIDES, this.runtimeEnvOverrides)
+                Updates.combine(updates)
             );
             return SUCCESS.toUpperCase();
         } catch (Exception e) {

--- a/apps/dashboard/src/main/java/com/akto/action/AdminSettingsAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AdminSettingsAction.java
@@ -132,6 +132,9 @@ public class AdminSettingsAction extends UserAction {
     @Setter
     @Getter
     private List<String> filterLogPolicy;
+    @Setter
+    @Getter
+    private Map<String, String> runtimeEnvOverrides;
 
     public String updateSetupType() {
         if (this.setupType == null) {
@@ -606,6 +609,19 @@ public class AdminSettingsAction extends UserAction {
             return SUCCESS.toUpperCase();
         } catch (Exception e) {
             logger.error("Error updating filter log policy", e);
+            return ERROR.toUpperCase();
+        }
+    }
+
+    public String updateRuntimeEnvOverrides() {
+        try {
+            AccountSettingsDao.instance.updateOne(
+                AccountSettingsDao.generateFilter(),
+                Updates.set(AccountSettings.RUNTIME_ENV_OVERRIDES, this.runtimeEnvOverrides)
+            );
+            return SUCCESS.toUpperCase();
+        } catch (Exception e) {
+            logger.error("Error updating runtime env overrides", e);
             return ERROR.toUpperCase();
         }
     }

--- a/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
@@ -223,7 +223,8 @@ public class ModuleInfoAction extends UserAction {
                     Filters.regex(ModuleInfo.NAME, _DEFAULT_PREFIX_REGEX_STRING),
                     Filters.eq(ModuleInfo.MODULE_TYPE, ModuleType.TRAFFIC_COLLECTOR.toString()),
                     Filters.eq(ModuleInfo.MODULE_TYPE, ModuleType.AKTO_AGENT_GATEWAY.toString()),
-                    Filters.eq(ModuleInfo.MODULE_TYPE, ModuleType.THREAT_DETECTION.toString())
+                    Filters.eq(ModuleInfo.MODULE_TYPE, ModuleType.THREAT_DETECTION.toString()),
+                    Filters.eq(ModuleInfo.MODULE_TYPE, ModuleType.MINI_RUNTIME.toString())
                 )
             );
 

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -13552,6 +13552,29 @@
             </result>
         </action>
 
+        <action name="api/updateRuntimeEnvOverrides" class="com.akto.action.AdminSettingsAction" method="updateRuntimeEnvOverrides">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <interceptor-ref name="roleAccessInterceptor">
+                <param name="featureLabel">ADMIN_ACTIONS</param>
+                <param name="accessType">READ_WRITE</param>
+                <param name="actionDescription">User updated mini-runtime env overrides</param>
+            </interceptor-ref>
+            <result name="FORBIDDEN" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="SUCCESS" type="json">
+                <param name="root">runtimeEnvOverrides</param>
+            </result>
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/saveDashboardLayout" class="com.akto.action.UserDashboardAction" method="saveDashboardLayout">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
@@ -1082,6 +1082,13 @@ const settingRequests = {
             data: {filterLogPolicy}
         })
     },
+    updateRuntimeEnvOverrides(runtimeEnvOverrides) {
+        return request({
+            url: '/api/updateRuntimeEnvOverrides',
+            method: 'post',
+            data: {runtimeEnvOverrides}
+        })
+    },
     rebootModules(moduleIds, deleteTopicAndReboot = false) {
         return request({
             url: '/api/rebootModules',

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/health_logs/ModuleEnvConfig.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/health_logs/ModuleEnvConfig.jsx
@@ -39,7 +39,13 @@ const ModuleEnvConfigComponent = ({ title, description, module, allowedEnvFields
 
     const handleSave = async () => {
         try {
-            await onSaveEnv(module.id, module.name, envData);
+            const changedEnvData = {};
+            for (const key of Object.keys(envData)) {
+                if (envData[key] !== initialEnvData[key]) {
+                    changedEnvData[key] = envData[key];
+                }
+            }
+            await onSaveEnv(module.id, module.name, changedEnvData);
             setInitialEnvData({ ...envData });
         } catch (error) {
             func.setToast(true, true, "Error saving environment config");

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
@@ -1,4 +1,4 @@
-import { Button, LegacyCard, DataTable, Checkbox, Modal, Text, Tooltip, Icon, HorizontalStack } from "@shopify/polaris"
+import { Button, LegacyCard, DataTable, Checkbox, Modal, Text, Tooltip, Icon, HorizontalStack, Banner } from "@shopify/polaris"
 import { AlertMinor } from "@shopify/polaris-icons"
 import { useEffect, useState } from "react";
 import settingRequests from "../api";
@@ -12,13 +12,16 @@ const ModuleInfo = () => {
     const [ selectedModules, setSelectedModules ] = useState([])
     const [ modalActive, setModalActive ] = useState(false)
     const [ selectedModule, setSelectedModule ] = useState(null)
+    const [ runtimeEnvOverrides, setRuntimeEnvOverrides ] = useState({})
 
-    const CONFIGURABLE_MODULE_TYPES = ['TRAFFIC_COLLECTOR', 'AKTO_AGENT_GATEWAY', 'THREAT_DETECTION'];
+    const CONFIGURABLE_MODULE_TYPES = ['TRAFFIC_COLLECTOR', 'AKTO_AGENT_GATEWAY', 'THREAT_DETECTION', 'MINI_RUNTIME'];
 
     const fetchModuleInfo = async () => {
         const response = await settingRequests.fetchModuleInfo();
         setModuleInfos(response.moduleInfos || []);
         setAllowedEnvFields(response.allowedEnvFields || []);
+        const adminSettings = await settingRequests.fetchAdminSettings();
+        setRuntimeEnvOverrides(adminSettings?.accountSettings?.runtimeEnvOverrides || {});
     }
 
     useEffect(() => {
@@ -70,8 +73,19 @@ const ModuleInfo = () => {
 
     const handleSaveEnv = async (moduleId, moduleName, envData) => {
         try {
-            await settingRequests.updateModuleEnvAndReboot(moduleId, moduleName, envData);
-            func.setToast(true, false, "Environment config saved successfully. Module will reboot.");
+            if (selectedModule?.moduleType === 'MINI_RUNTIME') {
+                await settingRequests.updateRuntimeEnvOverrides(envData);
+                const activeMiniRuntimeIds = moduleInfos
+                    .filter(m => m.moduleType === 'MINI_RUNTIME' && canRebootModule(m))
+                    .map(m => m.id);
+                if (activeMiniRuntimeIds.length > 0) {
+                    await settingRequests.rebootModules(activeMiniRuntimeIds, false);
+                }
+                func.setToast(true, false, `Env overrides saved. Restarting ${activeMiniRuntimeIds.length} active mini-runtime instance(s).`);
+            } else {
+                await settingRequests.updateModuleEnvAndReboot(moduleId, moduleName, envData);
+                func.setToast(true, false, "Environment config saved successfully. Module will reboot.");
+            }
             handleModalClose();
             await fetchModuleInfo();
         } catch (error) {
@@ -176,10 +190,17 @@ const ModuleInfo = () => {
                 large
             >
                 <Modal.Section>
+                    {selectedModule?.moduleType === 'MINI_RUNTIME' && (
+                        <Banner tone="warning" title="Applies to all instances">
+                            These values are account-wide - saving here changes them for every mini-runtime instance on this account, not just {selectedModule?.name || 'this one'}.
+                        </Banner>
+                    )}
                     <ModuleEnvConfigComponent
                         title="Environment Variables"
                         description={`Configure environment variables for ${selectedModule?.name || 'module'}`}
-                        module={selectedModule}
+                        module={selectedModule?.moduleType === 'MINI_RUNTIME'
+                            ? { ...selectedModule, additionalData: { env: runtimeEnvOverrides } }
+                            : selectedModule}
                         allowedEnvFields={allowedEnvFields}
                         onSaveEnv={handleSaveEnv}
                     />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
@@ -184,7 +184,6 @@ const ModuleInfo = () => {
                 <Modal.Section>
                     {selectedModule?.moduleType === 'MINI_RUNTIME' && (
                         <Banner tone="warning" title="Applies to all instances">
-                            Applies to all instances.
                         </Banner>
                     )}
                     <ModuleEnvConfigComponent

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
@@ -12,7 +12,6 @@ const ModuleInfo = () => {
     const [ selectedModules, setSelectedModules ] = useState([])
     const [ modalActive, setModalActive ] = useState(false)
     const [ selectedModule, setSelectedModule ] = useState(null)
-    const [ runtimeEnvOverrides, setRuntimeEnvOverrides ] = useState({})
 
     const CONFIGURABLE_MODULE_TYPES = ['TRAFFIC_COLLECTOR', 'AKTO_AGENT_GATEWAY', 'THREAT_DETECTION', 'MINI_RUNTIME'];
 
@@ -20,8 +19,6 @@ const ModuleInfo = () => {
         const response = await settingRequests.fetchModuleInfo();
         setModuleInfos(response.moduleInfos || []);
         setAllowedEnvFields(response.allowedEnvFields || []);
-        const adminSettings = await settingRequests.fetchAdminSettings();
-        setRuntimeEnvOverrides(adminSettings?.accountSettings?.runtimeEnvOverrides || {});
     }
 
     useEffect(() => {
@@ -187,15 +184,13 @@ const ModuleInfo = () => {
                 <Modal.Section>
                     {selectedModule?.moduleType === 'MINI_RUNTIME' && (
                         <Banner tone="warning" title="Applies to all instances">
-                            These values are account-wide - saving here changes them for every mini-runtime instance on this account, not just {selectedModule?.name || 'this one'}.
+                            Applies to all instances.
                         </Banner>
                     )}
                     <ModuleEnvConfigComponent
                         title="Environment Variables"
                         description={`Configure environment variables for ${selectedModule?.name || 'module'}`}
-                        module={selectedModule?.moduleType === 'MINI_RUNTIME'
-                            ? { ...selectedModule, additionalData: { env: runtimeEnvOverrides } }
-                            : selectedModule}
+                        module={selectedModule}
                         allowedEnvFields={allowedEnvFields}
                         onSaveEnv={handleSaveEnv}
                     />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/module_info/ModuleInfo.jsx
@@ -75,17 +75,12 @@ const ModuleInfo = () => {
         try {
             if (selectedModule?.moduleType === 'MINI_RUNTIME') {
                 await settingRequests.updateRuntimeEnvOverrides(envData);
-                const activeMiniRuntimeIds = moduleInfos
-                    .filter(m => m.moduleType === 'MINI_RUNTIME' && canRebootModule(m))
-                    .map(m => m.id);
-                if (activeMiniRuntimeIds.length > 0) {
-                    await settingRequests.rebootModules(activeMiniRuntimeIds, false);
-                }
-                func.setToast(true, false, `Env overrides saved. Restarting ${activeMiniRuntimeIds.length} active mini-runtime instance(s).`);
+                const miniRuntimeIds = moduleInfos.filter(m => m.moduleType === 'MINI_RUNTIME' && canRebootModule(m)).map(m => m.id);
+                await settingRequests.rebootModules(miniRuntimeIds, false);
             } else {
                 await settingRequests.updateModuleEnvAndReboot(moduleId, moduleName, envData);
-                func.setToast(true, false, "Environment config saved successfully. Module will reboot.");
             }
+            func.setToast(true, false, "Environment config saved successfully. Module will reboot.");
             handleModalClose();
             await fetchModuleInfo();
         } catch (error) {

--- a/libs/dao/src/main/java/com/akto/dao/AccountSettingsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/AccountSettingsDao.java
@@ -71,6 +71,13 @@ public class AccountSettingsDao extends AccountsContextDao<AccountSettings> {
         );
     }
 
+    public void updateRuntimeEnvOverrides(Map<String, String> envOverrides) {
+        instance.updateOne(
+            AccountSettingsDao.generateFilter(),
+            Updates.set(AccountSettings.RUNTIME_ENV_OVERRIDES, envOverrides)
+        );
+    }
+
     public String getInitStackType() {
         return instance.findOne(AccountSettingsDao.generateFilter()).getInitStackType();
     }

--- a/libs/dao/src/main/java/com/akto/dto/AccountSettings.java
+++ b/libs/dao/src/main/java/com/akto/dto/AccountSettings.java
@@ -67,6 +67,11 @@ public class AccountSettings {
     private Map<String, String> filterHeaderValueMap;
     public static final String FILTER_HEADER_VALUE_MAP = "filterHeaderValueMap";
 
+    public static final String RUNTIME_ENV_OVERRIDES = "runtimeEnvOverrides";
+    @Getter
+    @Setter
+    private Map<String, String> runtimeEnvOverrides;
+
     private Map<String, CollectionReplaceDetails> apiCollectionNameMapper;
     public static final String API_COLLECTION_NAME_MAPPER = "apiCollectionNameMapper";
     public static final String GLOBAL_RATE_LIMIT = "globalRateLimit";

--- a/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
+++ b/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
@@ -61,6 +61,12 @@ public class ModuleInfoConstants {
             put("AKTO_LOG_LEVEL", "Log Level");
         }});
 
+        put(ModuleInfo.ModuleType.MINI_RUNTIME, new HashMap<String, String>() {{
+            put("AKTO_LOG_LEVEL", "Log Level");
+            put("DEBUG_URLS", "Debug URLs (url1,url2,url3)");
+            put("DEBUG_HOSTS", "Debug Hosts (host1,host2,host3)");
+        }});
+
         put(ModuleInfo.ModuleType.MCP_ENDPOINT_SHIELD, new java.util.LinkedHashMap<String, String>() {{
             put("AKTO_API_TOKEN", "Akto API Token");
             put("DATABASE_ABSTRACTOR_SERVICE_URL", "Database Abstractor Service URL");

--- a/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
+++ b/libs/dao/src/main/java/com/akto/dto/monitoring/ModuleInfoConstants.java
@@ -65,6 +65,11 @@ public class ModuleInfoConstants {
             put("AKTO_LOG_LEVEL", "Log Level");
             put("DEBUG_URLS", "Debug URLs (url1,url2,url3)");
             put("DEBUG_HOSTS", "Debug Hosts (host1,host2,host3)");
+            put("MINI_RUNTIME_NAME", "Mini Runtime Name");
+            put("AKTO_CONFIG_NAME", "Config Name");
+            put("AKTO_KAFKA_BROKER_URL", "Kafka Broker URL");
+            put("AKTO_KAFKA_GROUP_ID_CONFIG", "Kafka Group ID Config");
+            put("AKTO_KAFKA_MAX_POLL_RECORDS_CONFIG", "Kafka Max Poll Records Config");
         }});
 
         put(ModuleInfo.ModuleType.MCP_ENDPOINT_SHIELD, new java.util.LinkedHashMap<String, String>() {{


### PR DESCRIPTION
## Problem

An account can run many mini-runtime instances. Today, changing a mini-runtime env var (log level, Kafka config, debug filters) means editing every instance's deployment config and restarting each one by hand — there's no way to change a value once and have it apply fleet-wide.

## Why

Fill a value once in the dashboard, every mini-runtime instance for that account picks it up — no per-instance deployment edits.

## Flow

```
User edits env vars in Module Info UI (mini-runtime row)
        │
        ▼
POST /api/updateRuntimeEnvOverrides  ──▶  AccountSettings.runtimeEnvOverrides (Mongo, one doc per account)
        │
        ▼
POST /api/rebootModules (active MINI_RUNTIME instances only)
        │
        ▼
ModuleInfo.reboot = true  ──▶  existing heartbeat mechanism picks it up (~30s) ──▶ instance restarts
```

Two read paths for the UI itself:
```
Module Info table  ◀── ModuleInfo.additionalData.env  (real, per-instance values, reported every heartbeat)
Env editor modal   ──▶ writes to AccountSettings.runtimeEnvOverrides (account-wide, not per-instance)
```

## What's in this PR

- New `AccountSettings.runtimeEnvOverrides` field + `api/updateRuntimeEnvOverrides` endpoint (per-key merge, not whole-map replace).
- `MINI_RUNTIME` added to the Module Info page's configurable module types, reusing the existing per-module env editor UI/component as-is.
- `MINI_RUNTIME` added to `rebootModules`'s allowed-module filter — without this, instances named via `MINI_RUNTIME_NAME` (not the `Default_`/`akto-mr` fallback) never actually got rebooted.
- Env editor now only submits changed keys, so an untouched field can't accidentally overwrite a real value with blank.

Companion PRs (same feature): mini-runtime side https://github.com/akto-api-security/akto/pull/6025, cyborg side https://github.com/akto-api-security/akto/pull/6018

## Verified

5 concurrent mini-runtime instances: saved `DEBUG_URLS`/`DEBUG_HOSTS` from this UI, confirmed live pickup within ~30s with no restart; saved `AKTO_LOG_LEVEL`, confirmed all active instances rebooted and the fresh boot reflected the new value.