### PR TITLE
fix: restore browserName/browserVersion mapping in Endpoint Shield agent table

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
@@ -160,6 +160,8 @@ const mapModuleToAgent = (module) => ({
     lastDeployed: module.startedTs || 0,
     os: module.additionalData?.os || DEFAULT_VALUE,
     osDisplayName: module.additionalData?.osDisplayName || DEFAULT_VALUE,
+    browserName: module.additionalData?.browserName || DEFAULT_VALUE,
+    browserVersion: module.additionalData?.browserVersion || DEFAULT_VALUE,
     osVersion: module.additionalData?.osVersion || DEFAULT_VALUE,
     arch: module.additionalData?.arch || DEFAULT_VALUE,
     kernelVersion: module.additionalData?.kernelVersion || DEFAULT_VALUE,


### PR DESCRIPTION
## Summary
- PR #6017 added browser icon/name display for extension agents (OS/Browser column on the Endpoint Shield page), but the `additionalData.browserName`/`browserVersion` -> agent-object mapping got dropped during a later merge that rebuilt this page onto a different paginated backend with its own separate mapping function (`mapModuleToAgent`), which never had these two fields.
- The display logic (`getOsOrBrowserComp`, icon maps, "OS/Browser" heading) survived the merge fine since it doesn't depend on which mapping function feeds it — it just never received the data, so every extension agent fell back to the generic "Browser" label instead of e.g. "Chrome 151".
- Restores the exact two-line mapping PR #6017 originally added, in the one place it's needed now that this page only has a single consolidated mapping function.

## Test plan
- [x] Inserted a synthetic `MCP_ENDPOINT_SHIELD` `module_info` doc locally with `additionalData.browserName = "Chrome"`, `browserVersion = "151"`, and a hyphenated `deviceId` (extension-shaped)
- [x] Confirmed before the fix: OS/Browser column showed generic "Browser" fallback
- [x] Confirmed after the fix: column shows the Chrome icon + "Chrome 151"
- [x] No other consumers of `mapModuleToAgent` needed changes (single call site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)