### PR TITLE
refactor: migrate legacy team/role fields to device tags in AgenticUs…

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
@@ -12,6 +12,7 @@ import com.akto.dao.testing_run_findings.TestingRunIssuesDao;
 import com.akto.dto.ApiCollection;
 import com.akto.dto.ApiInfo;
 import com.akto.dto.ComponentRiskAnalysis;
+import com.akto.dto.DeviceTag;
 import com.akto.dto.McpAuditInfo;
 import com.akto.dto.traffic.CollectionTags;
 import com.akto.dto.test_editor.Info;
@@ -98,17 +99,20 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
     @Setter private String queryValue; // free-text search — asset/group name (summary), or username/deviceId (fetchAgenticAssetDevicesPage)
     @Setter private Map<String, Integer> trafficMap;
     @Setter private Map<String, Double> riskScoreMap;
-    @Setter private Map<String, List<String>> filters; // AG Grid column filters, keyed by field name (e.g. "team", "userRole")
+    @Setter private Map<String, List<String>> filters; // AG Grid column filters, keyed by field name (e.g. "tags", "groupName")
 
     // ---- Server-side pagination for fetchUsersAndDevicesSummary ----
     @Setter private String groupBy; // "user" | "device"
     @Setter private Map<String, List<String>> sensitiveMap; // collection id (string) -> sensitive types
     @Setter private Map<String, String> usernameMap; // Endpoint Shield username resolution map
-    @Setter private Map<String, Map<String, String>> userMetadataMap; // username -> {team, userRole, teamSource, roleSource}
+    @Setter private Map<String, Map<String, String>> userMetadataMap; // username -> {userEmail}
+    // username -> that user's generic device tags (AgenticUsers.deviceTags, each {key, value, source}).
+    // Device rows inherit their resolved owner's tags (see classifyHostGroupedRows).
+    @Setter private Map<String, List<Map<String, String>>> tagsByUsername;
 
     // ---- Server-side pagination for fetchDeviceEndpointsSummary ----
     @Setter private String parentDeviceId; // blank => paginated top-level device rows; set => that device's (device,service) children
-    @Setter private Map<String, Map<String, String>> deviceMetadataMap; // deviceId -> {username, team, role, os}
+    @Setter private Map<String, Map<String, String>> deviceMetadataMap; // deviceId -> {username, os}
     @Setter private Map<String, Map<String, Integer>> violationsByCollectionId; // collection id (string) -> {critical, high, medium, low}
     @Setter private Map<String, Integer> userAnalysisFlatMap; // "serviceId|deviceId" -> total AI-interaction tokens (see constants.js's buildUserAnalysisFlatMap)
 
@@ -656,32 +660,6 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
         if (usernameMap == null || usernameMap.isEmpty() || deviceId == null) return "-";
         String v = usernameMap.get("__deviceId__" + deviceId.toLowerCase(Locale.ROOT));
         return StringUtils.isNotBlank(v) ? v : "-";
-    }
-
-    // Java port of constants.js's buildTeamGroupsFromDevices — team name -> member count, from an
-    // already-built per-device list (DeviceAcc.toResponse() rows). Used to precompute the grid's
-    // "Teams" column server-side instead of shipping the raw per-device list (up to hundreds of
-    // entries per row) just so the browser can do this same tally.
-    private static List<BasicDBObject> buildTeamGroupsForRow(List<BasicDBObject> devices, Map<String, String> usernameMap, Map<String, Map<String, String>> userMetadataMap) {
-        if (usernameMap == null || usernameMap.isEmpty() || userMetadataMap == null || userMetadataMap.isEmpty()) return Collections.emptyList();
-        Map<String, Integer> teamCounts = new LinkedHashMap<>();
-        for (BasicDBObject d : devices) {
-            String deviceId = String.valueOf(d.get("deviceId"));
-            String username = usernameMap.get("__deviceId__" + deviceId.toLowerCase(Locale.ROOT));
-            if (StringUtils.isBlank(username) || "-".equals(username)) continue;
-            Map<String, String> meta = userMetadataMap.get(username);
-            String team = meta != null ? meta.get("team") : null;
-            if (StringUtils.isBlank(team)) continue;
-            teamCounts.merge(team, 1, Integer::sum);
-        }
-        List<BasicDBObject> out = new ArrayList<>();
-        for (Map.Entry<String, Integer> e : teamCounts.entrySet()) {
-            BasicDBObject g = new BasicDBObject();
-            g.put("name", e.getKey());
-            g.put("count", e.getValue());
-            out.add(g);
-        }
-        return out;
     }
 
     private static Comparator<BasicDBObject> buildDeviceComparator(String key) {
@@ -1739,8 +1717,6 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                 // fixed (see fetchAgenticAssetDetail, the lazy per-asset endpoint the Overview tab's
                 // full device list — topology graph, etc. — now comes from instead).
                 List<BasicDBObject> devices = buildDevicesForGroup(g, byId, traffic, risk, userAnalysis);
-                List<BasicDBObject> teamGroups = buildTeamGroupsForRow(devices, usernameMap, userMetadataMap);
-                if (!teamGroups.isEmpty()) row.put("groups", teamGroups);
                 int aiInteractionsTotal = 0;
                 for (BasicDBObject d : devices) {
                     Object v = d.get("aiInteractions");
@@ -2148,10 +2124,8 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
         boolean hasPersonalAccount = false;
         boolean hasLocalMcpServer = false;
         boolean hasMisconfiguredConfig = false;
-        String team = "";
-        String userRole = "";
-        String teamSource = "sso";
-        String roleSource = "sso";
+        // Generic device tags (AgenticUsers.deviceTags), resolved via this group's owner username.
+        List<Map<String, String>> tags = Collections.emptyList();
         int nonSkillCollectionsCount = 0;
         final Set<String> uniqueSkillNames = new HashSet<>();
         // Device-row extras (DeviceEndpoints only — null/zero when not populated, e.g. Users-and-Devices).
@@ -2211,10 +2185,17 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             row.put("sensitiveInRespTypes", new ArrayList<>(sensitiveTypes));
             row.put("riskScore", maxRiskScore);
             row.put("lastSeenEpoch", maxTrafficTimestamp);
-            row.put("team", team);
-            row.put("userRole", userRole);
-            row.put("teamSource", teamSource);
-            row.put("roleSource", roleSource);
+            row.put("tags", tags);
+            // Bare tag keys only — matches constants.js's buildTagFilterValues ("filtering is by
+            // tag key only... regardless of value") so the Tags column's Set Filter/dropdown options
+            // and this row's own filter-membership value stay derived the same way client- and
+            // server-side.
+            Set<String> tagKeys = new LinkedHashSet<>();
+            for (Map<String, String> t : tags) {
+                String k = t != null ? t.get(DeviceTag.KEY) : null;
+                if (StringUtils.isNotBlank(k)) tagKeys.add(k);
+            }
+            row.put("tagFilterValues", new ArrayList<>(tagKeys));
             row.put("hasPersonalAccount", hasPersonalAccount);
             row.put("hasLocalMcpServer", hasLocalMcpServer);
             row.put("hasMisconfiguredConfig", hasMisconfiguredConfig);
@@ -2260,7 +2241,17 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             Map<String, String> usernames, Map<String, Map<String, String>> userMeta,
             Map<String, Map<String, String>> deviceMeta, Map<String, Map<String, Integer>> violationsByCollectionId,
             boolean excludeConnectorIngested) {
+        return classifyHostGroupedRows(collections, groupBy, traffic, risk, sensitive, usernames, userMeta,
+                deviceMeta, violationsByCollectionId, excludeConnectorIngested, Collections.emptyMap());
+    }
+
+    private Map<String, HostGroupSummary> classifyHostGroupedRows(List<ApiCollection> collections, String groupBy,
+            Map<String, Integer> traffic, Map<String, Double> risk, Map<String, List<String>> sensitive,
+            Map<String, String> usernames, Map<String, Map<String, String>> userMeta,
+            Map<String, Map<String, String>> deviceMeta, Map<String, Map<String, Integer>> violationsByCollectionId,
+            boolean excludeConnectorIngested, Map<String, List<Map<String, String>>> tagsByUser) {
         boolean isUserGroup = "user".equals(groupBy);
+        Map<String, List<Map<String, String>>> tags = tagsByUser != null ? tagsByUser : Collections.emptyMap();
         Map<String, HostGroupSummary> groups = new LinkedHashMap<>();
 
         for (ApiCollection c : collections) {
@@ -2290,22 +2281,14 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             final String fKey = key;
             HostGroupSummary g = groups.computeIfAbsent(key, k -> {
                 HostGroupSummary gs = new HostGroupSummary(fKey);
-                if (isUserGroup && userMeta != null) {
-                    Map<String, String> meta = userMeta.get(fKey);
-                    if (meta != null) {
-                        gs.team = meta.getOrDefault("team", "");
-                        gs.userRole = meta.getOrDefault("userRole", "");
-                        gs.teamSource = meta.getOrDefault("teamSource", "sso");
-                        gs.roleSource = meta.getOrDefault("roleSource", "sso");
-                    }
+                if (isUserGroup) {
+                    gs.tags = tags.getOrDefault(fKey, Collections.emptyList());
                 }
                 if (!isUserGroup && deviceMeta != null) {
                     Map<String, String> meta = deviceMeta.get(fKey);
                     if (meta != null) {
                         gs.os = meta.get("os");
                         gs.username = StringUtils.isNotBlank(meta.get("username")) ? meta.get("username") : "-";
-                        gs.team = meta.getOrDefault("team", "");
-                        gs.userRole = meta.getOrDefault("role", "");
                     }
                 }
                 return gs;
@@ -2315,6 +2298,11 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             if (!isUserGroup && "-".equals(g.username)) {
                 String resolved = resolveUsername(hostName, usernames, envType);
                 if (StringUtils.isNotBlank(resolved) && !"-".equals(resolved)) g.username = resolved;
+            }
+            // Device tags are the resolved owner's device tags (AgenticUsers.deviceTags is keyed by
+            // username, not deviceId) — re-derive whenever the username above may have just changed.
+            if (!isUserGroup && !"-".equals(g.username)) {
+                g.tags = tags.getOrDefault(g.username, Collections.emptyList());
             }
             g.accumulate(c, hostName, envType, collRisk, collTraffic, sensitiveTypes, collViolations);
         }
@@ -2346,13 +2334,14 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             Map<String, List<String>> sensitive = sensitiveMap != null ? sensitiveMap : Collections.emptyMap();
             Map<String, String> usernames = usernameMap != null ? usernameMap : Collections.emptyMap();
             Map<String, Map<String, String>> userMeta = userMetadataMap != null ? userMetadataMap : Collections.emptyMap();
+            Map<String, List<Map<String, String>>> tagsByUser = tagsByUsername != null ? tagsByUsername : Collections.emptyMap();
 
             List<ApiCollection> collections = ApiCollectionsDao.instance.findAll(
                     Filters.empty(),
                     Projections.include(ApiCollection.ID, ApiCollection.HOST_NAME, ApiCollection.TAGS_STRING, ApiCollection.SKILLS)
             );
 
-            Map<String, HostGroupSummary> groups = classifyHostGroupedRows(collections, groupBy, traffic, risk, sensitive, usernames, userMeta, null, null, false);
+            Map<String, HostGroupSummary> groups = classifyHostGroupedRows(collections, groupBy, traffic, risk, sensitive, usernames, userMeta, null, null, false, tagsByUser);
             List<HostGroupSummary> all = new ArrayList<>(groups.values());
 
             if (StringUtils.isNotBlank(queryValue)) {
@@ -2360,19 +2349,9 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                 all.removeIf(g -> g.groupName == null || !g.groupName.toLowerCase(Locale.ROOT).contains(q));
             }
 
-            // AG Grid column filters (agSetColumnFilter on "team"/"userRole", agTextColumnFilter on
-            // "groupName") — extractFilterModel (AgGridTable.jsx) keys these by colDef field name.
+            // AG Grid column filters (agSetColumnFilter on "tags", agTextColumnFilter on "groupName")
+            // — extractFilterModel (AgGridTable.jsx) keys these by colDef field name.
             if (filters != null) {
-                List<String> teamFilter = filters.get("team");
-                if (teamFilter != null && !teamFilter.isEmpty()) {
-                    Set<String> allowed = new HashSet<>(teamFilter);
-                    all.removeIf(g -> !allowed.contains(g.team));
-                }
-                List<String> roleFilter = filters.get("userRole");
-                if (roleFilter != null && !roleFilter.isEmpty()) {
-                    Set<String> allowed = new HashSet<>(roleFilter);
-                    all.removeIf(g -> !allowed.contains(g.userRole));
-                }
                 List<String> nameFilter = filters.get("groupName");
                 if (nameFilter != null && !nameFilter.isEmpty() && StringUtils.isNotBlank(nameFilter.get(0))) {
                     String q = nameFilter.get(0).toLowerCase(Locale.ROOT);
@@ -2384,6 +2363,13 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                 if (usernameFilter != null && !usernameFilter.isEmpty()) {
                     Set<String> allowed = new HashSet<>(usernameFilter);
                     all.removeIf(g -> !allowed.contains(g.username));
+                }
+                // Generic device-tag filter — matches by tag KEY only (buildTagFilterValues'
+                // semantics: "group" matches any row with a "group" tag, regardless of value).
+                List<String> tagsFilter = filters.get("tags");
+                if (tagsFilter != null && !tagsFilter.isEmpty()) {
+                    Set<String> allowedKeys = new HashSet<>(tagsFilter);
+                    all.removeIf(g -> g.tags.stream().noneMatch(t -> t != null && allowedKeys.contains(t.get(DeviceTag.KEY))));
                 }
             }
 
@@ -2413,11 +2399,11 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
     }
 
     /**
-     * Tab-header counts ("Users (1234)" / "Devices (567)"), distinct team/role names for the edit
-     * modal's autocomplete, and each tab's "Agentic assets" total (sum of endpointsCount across every
-     * row — needs the full per-group classification, not just distinct-key counting, so this calls
-     * classifyHostGroupedRows for both groupBy modes; same order of cost as fetchUsersAndDevicesSummary
-     * itself, just without the pagination slice).
+     * Tab-header counts ("Users (1234)" / "Devices (567)"), distinct device-tag keys for the Tags
+     * filter/"Edit device tags" modal, and each tab's "Agentic assets" total (sum of endpointsCount
+     * across every row — needs the full per-group classification, not just distinct-key counting, so
+     * this calls classifyHostGroupedRows for both groupBy modes; same order of cost as
+     * fetchUsersAndDevicesSummary itself, just without the pagination slice).
      */
     public String fetchUsersAndDevicesStats() {
         response = new BasicDBObject();
@@ -2426,15 +2412,16 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             Map<String, Double> risk = riskScoreMap != null ? riskScoreMap : Collections.emptyMap();
             Map<String, String> usernames = usernameMap != null ? usernameMap : Collections.emptyMap();
             Map<String, Map<String, String>> userMeta = userMetadataMap != null ? userMetadataMap : Collections.emptyMap();
+            Map<String, List<Map<String, String>>> tagsByUser = tagsByUsername != null ? tagsByUsername : Collections.emptyMap();
             List<ApiCollection> collections = ApiCollectionsDao.instance.findAll(
                     Filters.empty(),
                     Projections.include(ApiCollection.ID, ApiCollection.HOST_NAME, ApiCollection.TAGS_STRING, ApiCollection.SKILLS)
             );
 
             Map<String, HostGroupSummary> userGroups = classifyHostGroupedRows(collections, "user", traffic, risk,
-                    Collections.emptyMap(), usernames, userMeta, null, null, false);
+                    Collections.emptyMap(), usernames, userMeta, null, null, false, tagsByUser);
             Map<String, HostGroupSummary> deviceGroups = classifyHostGroupedRows(collections, "device", traffic, risk,
-                    Collections.emptyMap(), usernames, Collections.emptyMap(), null, null, false);
+                    Collections.emptyMap(), usernames, Collections.emptyMap(), null, null, false, tagsByUser);
 
             long usersAgenticAssetsTotal = 0;
             for (HostGroupSummary g : userGroups.values()) {
@@ -2444,24 +2431,6 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             for (HostGroupSummary g : deviceGroups.values()) {
                 devicesAgenticAssetsTotal += g.hostNames.size();
             }
-
-            // Distinct team/role names across all known users — feeds the "Edit team & role" modal's
-            // autocomplete suggestions, which previously read straight off the full in-memory user
-            // array; cheap to compute here since userMetadataMap is already keyed by username.
-            Set<String> teams = new HashSet<>();
-            Set<String> roles = new HashSet<>();
-            for (String username : userGroups.keySet()) {
-                Map<String, String> meta = userMeta.get(username);
-                if (meta == null) continue;
-                String team = meta.get("team");
-                String role = meta.get("userRole");
-                if (StringUtils.isNotBlank(team)) teams.add(team);
-                if (StringUtils.isNotBlank(role)) roles.add(role);
-            }
-            List<String> teamList = new ArrayList<>(teams);
-            List<String> roleList = new ArrayList<>(roles);
-            Collections.sort(teamList);
-            Collections.sort(roleList);
 
             // Distinct device-owner usernames — feeds the Devices tab's "User" filter (GithubServerTable
             // choices, UsersAndDevices.jsx). deviceGroups already resolved each device's username
@@ -2473,13 +2442,26 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             List<String> deviceUsernameList = new ArrayList<>(deviceUsernames);
             Collections.sort(deviceUsernameList);
 
+            // Distinct device-tag keys across every known user/device — feeds the Tags column's Set
+            // Filter dropdown (both tabs) and the "Edit device tags" modal's key autocomplete.
+            Set<String> tagKeys = new TreeSet<>();
+            for (HostGroupSummary g : userGroups.values()) {
+                for (Map<String, String> t : g.tags) {
+                    if (t != null && StringUtils.isNotBlank(t.get(DeviceTag.KEY))) tagKeys.add(t.get(DeviceTag.KEY));
+                }
+            }
+            for (HostGroupSummary g : deviceGroups.values()) {
+                for (Map<String, String> t : g.tags) {
+                    if (t != null && StringUtils.isNotBlank(t.get(DeviceTag.KEY))) tagKeys.add(t.get(DeviceTag.KEY));
+                }
+            }
+
             response.put("usersCount", userGroups.size());
             response.put("devicesCount", deviceGroups.size());
             response.put("usersAgenticAssetsTotal", usersAgenticAssetsTotal);
             response.put("devicesAgenticAssetsTotal", devicesAgenticAssetsTotal);
-            response.put("teams", teamList);
-            response.put("roles", roleList);
             response.put("usernames", deviceUsernameList);
+            response.put("tagKeys", new ArrayList<>(tagKeys));
             return SUCCESS.toUpperCase();
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb("Error fetching users and devices stats: " + e.getMessage());
@@ -2607,6 +2589,7 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             Map<String, Map<String, String>> deviceMeta = deviceMetadataMap != null ? deviceMetadataMap : Collections.emptyMap();
             Map<String, String> usernames = usernameMap != null ? usernameMap : Collections.emptyMap();
             Map<String, Map<String, Integer>> violations = violationsByCollectionId != null ? violationsByCollectionId : Collections.emptyMap();
+            Map<String, List<Map<String, String>>> tagsByUser = tagsByUsername != null ? tagsByUsername : Collections.emptyMap();
 
             List<ApiCollection> collections = ApiCollectionsDao.instance.findAll(
                     Filters.empty(),
@@ -2642,7 +2625,7 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             }
 
             Map<String, HostGroupSummary> groups = classifyHostGroupedRows(collections, "device", traffic, risk,
-                    Collections.emptyMap(), usernames, Collections.emptyMap(), deviceMeta, violations, true);
+                    Collections.emptyMap(), usernames, Collections.emptyMap(), deviceMeta, violations, true, tagsByUser);
             List<HostGroupSummary> all = new ArrayList<>(groups.values());
 
             if (StringUtils.isNotBlank(queryValue)) {
@@ -2653,7 +2636,7 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                 });
             }
 
-            // AG Grid column filters (agSetColumnFilter on "os"/"group"/"role") — extractFilterModel
+            // AG Grid column filters (agSetColumnFilter on "os"/"tags") — extractFilterModel
             // (AgGridTable.jsx) keys these by colDef field name, matching DEVICE_COL_DEFS in
             // DeviceEndpoints.jsx. A key present with an empty list means the user unchecked every
             // value, which must match zero rows (real Set Filter semantics) — containsKey (not
@@ -2667,13 +2650,9 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                     Set<String> allowed = new HashSet<>(filters.get("os"));
                     all.removeIf(g -> !allowed.contains(g.os));
                 }
-                if (filters.containsKey("group")) {
-                    Set<String> allowed = new HashSet<>(filters.get("group"));
-                    all.removeIf(g -> !allowed.contains(g.team));
-                }
-                if (filters.containsKey("role")) {
-                    Set<String> allowed = new HashSet<>(filters.get("role"));
-                    all.removeIf(g -> !allowed.contains(g.userRole));
+                if (filters.containsKey("tags")) {
+                    Set<String> allowedKeys = new HashSet<>(filters.get("tags"));
+                    all.removeIf(g -> g.tags.stream().noneMatch(t -> t != null && allowedKeys.contains(t.get(DeviceTag.KEY))));
                 }
             }
 

--- a/apps/dashboard/src/main/java/com/akto/action/GuardrailPoliciesAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/GuardrailPoliciesAction.java
@@ -103,17 +103,18 @@ public class GuardrailPoliciesAction extends UserAction {
             this.guardrailPolicies = GuardrailPoliciesDao.instance.findAllSortedByCreatedTimestamp(skip, limit);
             this.total = GuardrailPoliciesDao.instance.getTotalCount();
 
-            // Resolve targetTeams/targetRoles → device IDs fresh on every fetch.
+            // Resolve targetTags/targetDeviceIds → device IDs fresh on every fetch.
             // applyToDeviceIds left null (never set below) = no targeting configured → apply to all devices.
             // applyToDeviceIds set to a List (possibly empty, when targeting matches zero devices)
             // = targeting configured → apply only to the listed device labels; empty means apply to none.
             // null vs. an empty List must stay distinguishable on the wire — do not collapse them.
             for (GuardrailPolicies p : this.guardrailPolicies) {
-                boolean hasTargeting = (p.getTargetTeams() != null && !p.getTargetTeams().isEmpty())
-                        || (p.getTargetRoles() != null && !p.getTargetRoles().isEmpty());
+                boolean hasTagTargeting = p.getTargetTags() != null && !p.getTargetTags().isEmpty();
+                boolean hasTargeting = hasTagTargeting
+                        || (p.getTargetDeviceIds() != null && !p.getTargetDeviceIds().isEmpty());
                 if (hasTargeting) {
-                    p.setApplyToDeviceIds(AgentUsersDao.instance.findDeviceIdsByTeamsAndRoles(
-                            p.getTargetTeams(), p.getTargetRoles()));
+                    p.setApplyToDeviceIds(AgentUsersDao.instance.findDeviceIdsByTags(
+                            p.getTargetTags(), p.getTargetDeviceIds()));
                 }
                 EnterpriseLicenseComplianceCatalog.applyToPolicy(p);
             }
@@ -348,11 +349,11 @@ public class GuardrailPoliciesAction extends UserAction {
         if (p.getIgnorePhrases() != null) {
             updates.add(Updates.set("ignorePhrases", p.getIgnorePhrases()));
         }
-        if (p.getTargetTeams() != null) {
-            updates.add(Updates.set("targetTeams", p.getTargetTeams()));
+        if (p.getTargetDeviceIds() != null) {
+            updates.add(Updates.set("targetDeviceIds", p.getTargetDeviceIds()));
         }
-        if (p.getTargetRoles() != null) {
-            updates.add(Updates.set("targetRoles", p.getTargetRoles()));
+        if (p.getTargetTags() != null) {
+            updates.add(Updates.set("targetTags", p.getTargetTags()));
         }
         updates.add(Updates.set("blockPersonalAccounts", p.isBlockPersonalAccounts()));
         if (StringUtils.isNotBlank(p.getBehaviour())) {

--- a/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
@@ -8,7 +8,6 @@ import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Updates;
 
 import com.akto.dao.AccountsDao;
-import com.akto.dao.AgentUsersDao;
 import com.akto.dao.ConfigsDao;
 import com.akto.dao.CustomRoleDao;
 import com.akto.dao.PendingInviteCodesDao;
@@ -597,11 +596,9 @@ public class SignupAction implements Action, ServletResponseAware, ServletReques
             List<String> oktaGroups = resolveOktaGroups(oktaConfig, oktaUserId, accessToken);
             Map<String, String> oktaGroupToAktoUserRoleMap = oktaConfig.getOktaGroupToAktoUserRoleMap();
             String resolvedRole = fetchOktaRole(oktaGroups, oktaGroupToAktoUserRoleMap);
-            String actualOktaRole = extractOktaRoleGroupName(oktaGroups, oktaGroupToAktoUserRoleMap);
-            String team = extractOktaTeamName(oktaGroups, oktaGroupToAktoUserRoleMap);
             logger.infoAndAddToDb("[Okta SSO] email=" + email + ", username=" + username + ", oktaGroups=" + oktaGroups
-                    + ", team=" + team + ", actualOktaRole=" + actualOktaRole + ", dashboardRole=" + resolvedRole);
-            enrichAgenticUserFromSso(username, email, team, actualOktaRole, "okta");
+                    + ", dashboardRole=" + resolvedRole);
+
             createUserAndRedirect(email, username, new SignupInfo.OktaSignupInfo(accessToken, username), accountId, Config.ConfigType.OKTA.toString(), resolvedRole, this.scopeRoleMapping);
             code = "";
         } catch (Exception e) {
@@ -751,39 +748,6 @@ public class SignupAction implements Action, ServletResponseAware, ServletReques
             return RBAC.Role.MEMBER.name();
         }
         return resolveAktoRoleFromOktaGroupNames(groups, oktaGroupToAktoUserRoleMap);
-    }
-
-    /**
-     * Extracts the organisational team name from Okta groups.
-     * Groups mapped to an Akto role in {@code oktaGroupToAktoUserRoleMap} are skipped —
-     * the first remaining group is the team.
-     */
-    private String extractOktaTeamName(List<String> groups, Map<String, String> oktaGroupToAktoUserRoleMap) {
-        return groups.stream()
-                .filter(g -> oktaGroupToAktoUserRoleMap == null || !oktaGroupToAktoUserRoleMap.containsKey(g))
-                .findFirst()
-                .orElse("");
-    }
-
-    /**
-     * Raw Okta group that this user's role is coming from — the first group present in
-     * {@code oktaGroupToAktoUserRoleMap} — passed to AgenticUsers as-is, with no RBAC mapping.
-     */
-    private String extractOktaRoleGroupName(List<String> groups, Map<String, String> oktaGroupToAktoUserRoleMap) {
-        if (oktaGroupToAktoUserRoleMap == null || oktaGroupToAktoUserRoleMap.isEmpty()) return "";
-        return groups.stream()
-                .filter(oktaGroupToAktoUserRoleMap::containsKey)
-                .findFirst()
-                .orElse("");
-    }
-
-    /**
-     * Persists SSO-derived team/role into AgenticUsers.
-     * Respects manual dashboard overrides — fields pinned as "manual" are never overwritten.
-     * Call this from every {@code registerViaXxx} method that has team/role data.
-     */
-    private void enrichAgenticUserFromSso(String userName, String userEmail, String teamName, String userRole, String provider) {
-        AgentUsersDao.instance.upsertTagFromSso(userName, userEmail, teamName, userRole, provider);
     }
 
     private static List<String> extractOktaGroupNamesFromApiResponse(List<Map<String, Object>> groupsList) {

--- a/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
@@ -5,6 +5,7 @@ import com.akto.dao.AgentUsersDao;
 import com.akto.dao.context.Context;
 import com.akto.dao.monitoring.ModuleInfoDao;
 import com.akto.dto.AgenticUsers;
+import com.akto.dto.DeviceTag;
 import com.akto.dto.monitoring.ModuleInfo;
 import com.akto.dto.monitoring.ModuleInfo.ModuleType;
 import com.akto.dto.monitoring.ModuleInfoConstants;
@@ -19,9 +20,11 @@ import lombok.Setter;
 import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class ModuleInfoAction extends UserAction {
@@ -49,10 +52,7 @@ public class ModuleInfoAction extends UserAction {
     private List<String> usernames;
     @Getter
     @Setter
-    private String team;
-    @Getter
-    @Setter
-    private String userRole;
+    private Map<String, List<String>> tags;
     @Getter
     @Setter
     private String userEmail;
@@ -428,7 +428,9 @@ public class ModuleInfoAction extends UserAction {
             return ERROR.toUpperCase();
         }
 
-        AgentUsersDao.instance.upsertTagFromDashboard(username, userEmail, team, userRole, getSUser().getLogin());
+        String identityUserName = AgentUsersDao.instance.ensureDashboardIdentity(username, userEmail, getSUser().getLogin());
+        AgentUsersDao.instance.mergeDeviceTags(identityUserName, DeviceTag.SOURCE_MANUAL,
+                tags != null ? tags : Collections.emptyMap(), getSUser().getLogin());
         return SUCCESS.toUpperCase();
     }
 
@@ -439,23 +441,32 @@ public class ModuleInfoAction extends UserAction {
         }
 
         String updatedBy = getSUser().getLogin();
+        Map<String, List<String>> tagsToApply = tags != null ? tags : Collections.emptyMap();
         for (String u : usernames) {
-            AgentUsersDao.instance.upsertTagFromDashboard(u, null, team, userRole, updatedBy);
+            String identityUserName = AgentUsersDao.instance.ensureDashboardIdentity(u, null, updatedBy);
+            AgentUsersDao.instance.mergeDeviceTags(identityUserName, DeviceTag.SOURCE_MANUAL, tagsToApply, updatedBy);
         }
         return SUCCESS.toUpperCase();
     }
 
     public String fetchAgenticUsers() {
         agenticUsers = AgentUsersDao.instance.findAll(Filters.empty());
-        // Overwrite teamName/userRole with SSO values for users not manually pinned,
-        // so callers always see a single consistent effective field.
+
+        // AgenticUsers.devices is only ever backfilled once by a startup migration and never
+        // kept in sync afterwards — overwrite with live devices from module_info (updated every
+        // heartbeat) instead of trusting the stored field.
+        Map<String, Set<String>> liveDevicesByUsername = ModuleInfoDao.instance.fetchUsernameToDeviceIdsForEndpointShield();
         for (AgenticUsers u : agenticUsers) {
-            if (!AgenticUsers.SOURCE_MANUAL.equals(u.getTeamSource()) && u.getSsoTeamName() != null) {
-                u.setTeamName(u.getSsoTeamName());
-            }
-            if (!AgenticUsers.SOURCE_MANUAL.equals(u.getRoleSource()) && u.getSsoUserRole() != null) {
-                u.setUserRole(u.getSsoUserRole());
-            }
+            Set<String> liveDevices = liveDevicesByUsername.remove(u.getUserName());
+            u.setDevices(liveDevices != null ? new ArrayList<>(liveDevices) : new ArrayList<>());
+        }
+        // Any username reporting devices but with no team/role ever assigned has no AgenticUsers
+        // doc yet — synthesize a lightweight entry so it still shows up as filterable/previewable.
+        for (Map.Entry<String, Set<String>> entry : liveDevicesByUsername.entrySet()) {
+            AgenticUsers synthetic = new AgenticUsers();
+            synthetic.setUserName(entry.getKey());
+            synthetic.setDevices(new ArrayList<>(entry.getValue()));
+            agenticUsers.add(synthetic);
         }
         return SUCCESS.toUpperCase();
     }

--- a/apps/dashboard/src/main/java/com/akto/action/user/OktaSsoAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/user/OktaSsoAction.java
@@ -36,6 +36,7 @@ public class OktaSsoAction extends UserAction {
     private String redirectUri;
     private String managementApiToken;
     private Map<String, String> oktaGroupToAktoUserRoleMap;
+    private boolean syncGroupsToUserTags;
     private List<String> oktaGroupNames;
 
     private static boolean hasStoredOktaApiToken(OktaConfig c) {
@@ -130,10 +131,30 @@ public class OktaSsoAction extends UserAction {
             addActionError(validationError);
             return ERROR.toUpperCase();
         }
+
+        // This flag only gates the periodic org-wide sync cron (device-tag writes happen there
+        // exclusively, not at login) — the cron has no login session to read a JWT groups claim
+        // from, so it can only run via the Management API. Reject enabling it without a token.
+        boolean tokenPresentAfterSave;
+        if (incomingToken == null) {
+            tokenPresentAfterSave = hasStoredOktaApiToken(oktaConfig);
+        } else if (incomingToken.trim().isEmpty()) {
+            tokenPresentAfterSave = false;
+        } else if (isMaskedTokenSubmission(incomingToken)) {
+            tokenPresentAfterSave = hasStoredOktaApiToken(oktaConfig);
+        } else {
+            tokenPresentAfterSave = true;
+        }
+        if (syncGroupsToUserTags && !tokenPresentAfterSave) {
+            addActionError("Set a Management API token before enabling group sync.");
+            return ERROR.toUpperCase();
+        }
+
         List<Bson> bsonUpdates = new ArrayList<>();
         bsonUpdates.add(Updates.set("oktaGroupToAktoUserRoleMap", activeMapping));
         bsonUpdates.add(Updates.unset("groupRoleMapping"));
         bsonUpdates.add(Updates.unset("oktaRoleMapping"));
+        bsonUpdates.add(Updates.set(OktaConfig.SYNC_GROUPS_TO_USER_TAGS, syncGroupsToUserTags));
         if (incomingToken != null) {
             if (incomingToken.trim().isEmpty()) {
                 bsonUpdates.add(Updates.unset(OktaConfig.MANAGEMENT_API_TOKEN));
@@ -190,9 +211,11 @@ public class OktaSsoAction extends UserAction {
             this.authorisationServerId = oktaConfig.getAuthorisationServerId();
             this.redirectUri = oktaConfig.getRedirectUri();
             this.oktaGroupToAktoUserRoleMap = oktaConfig.getOktaGroupToAktoUserRoleMap();
+            this.syncGroupsToUserTags = oktaConfig.isSyncGroupsToUserTags();
             this.managementApiToken = hasStoredOktaApiToken(oktaConfig) ? Constants.ASTERISK : null;
         } else {
             this.managementApiToken = null;
+            this.syncGroupsToUserTags = false;
         }
 
         return SUCCESS.toUpperCase();
@@ -236,6 +259,13 @@ public class OktaSsoAction extends UserAction {
     }
     public void setOktaGroupToAktoUserRoleMap(Map<String, String> oktaGroupToAktoUserRoleMap) {
         this.oktaGroupToAktoUserRoleMap = oktaGroupToAktoUserRoleMap;
+    }
+
+    public boolean isSyncGroupsToUserTags() {
+        return syncGroupsToUserTags;
+    }
+    public void setSyncGroupsToUserTags(boolean syncGroupsToUserTags) {
+        this.syncGroupsToUserTags = syncGroupsToUserTags;
     }
 
     public void setManagementApiToken(String managementApiToken) {

--- a/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
+++ b/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
@@ -3692,6 +3692,26 @@ public class InitializerListener implements ServletContextListener {
         }
     }
 
+    private static void migrateTeamRoleToDeviceTags(BackwardCompatibility backwardCompatibility){
+        if(backwardCompatibility.getMigrateTeamRoleToDeviceTags() == 0){
+            BackwardCompatibilityUtils.migrateTeamRoleToDeviceTags();
+            BackwardCompatibilityDao.instance.updateOne(
+                Filters.eq("_id", backwardCompatibility.getId()),
+                Updates.set(BackwardCompatibility.MIGRATE_TEAM_ROLE_TO_DEVICE_TAGS, Context.now())
+            );
+        }
+    }
+
+    private static void migrateGuardrailTargetTeamsRolesToTags(BackwardCompatibility backwardCompatibility){
+        if(backwardCompatibility.getMigrateGuardrailTargetTeamsRolesToTags() == 0){
+            BackwardCompatibilityUtils.migrateGuardrailTargetTeamsRolesToTags();
+            BackwardCompatibilityDao.instance.updateOne(
+                Filters.eq("_id", backwardCompatibility.getId()),
+                Updates.set(BackwardCompatibility.MIGRATE_GUARDRAIL_TARGET_TEAMS_ROLES_TO_TAGS, Context.now())
+            );
+        }
+    }
+
 
     public static void setBackwardCompatibilities(BackwardCompatibility backwardCompatibility){
         if (DashboardMode.isMetered()) {
@@ -3703,6 +3723,8 @@ public class InitializerListener implements ServletContextListener {
         markSummariesAsVulnerable(backwardCompatibility);
         moveUserDataFromModuleInfoToAgenticUsers(backwardCompatibility);
         cleanupApiInfoTags(backwardCompatibility);
+        migrateTeamRoleToDeviceTags(backwardCompatibility);
+        migrateGuardrailTargetTeamsRolesToTags(backwardCompatibility);
         dropLastCronRunInfoField(backwardCompatibility);
         cleanupRbacEntriesForDeveloperRole(backwardCompatibility);
         fetchIntegratedConnections(backwardCompatibility);

--- a/apps/dashboard/src/main/java/com/akto/utils/scripts/BackwardCompatibilityUtils.java
+++ b/apps/dashboard/src/main/java/com/akto/utils/scripts/BackwardCompatibilityUtils.java
@@ -3,6 +3,7 @@ package com.akto.utils.scripts;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,18 +11,23 @@ import java.util.Set;
 import com.akto.dao.AgentUsersDao;
 import com.akto.dao.ApiCollectionsDao;
 import com.akto.dao.ApiInfoDao;
+import com.akto.dao.GuardrailPoliciesDao;
+import com.akto.dao.MCollection;
 import com.akto.dao.context.Context;
 import com.akto.dao.monitoring.ModuleInfoDao;
 import com.akto.dto.AgenticUsers;
 import com.akto.dto.ApiCollection;
 import com.akto.dto.ApiInfo;
+import com.akto.dto.DeviceTag;
 import com.akto.dto.monitoring.ModuleInfo;
 import com.akto.dto.traffic.CollectionTags;
 import com.akto.util.Constants;
 import com.akto.util.Pair;
+import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Updates;
+import org.bson.Document;
 import org.bson.conversions.Bson;
 
 import java.util.List;
@@ -65,6 +71,7 @@ public class BackwardCompatibilityUtils {
 
         List<AgenticUsers> agenticUsers = new ArrayList<>();
 
+        int now = Context.now();
         for (Map.Entry<String,Set<String>> entry : userNameToDevicesMap.entrySet()) {
             Set<String> devices = entry.getValue();
             Pair<String,String> roleAndTeam = userNameToRoleAndTeamMap.getOrDefault(entry.getKey(), new Pair<>("", ""));
@@ -74,13 +81,165 @@ public class BackwardCompatibilityUtils {
             AgenticUsers agenticUser = new AgenticUsers();
             agenticUser.setUserName(entry.getKey());
             agenticUser.setDevices(new ArrayList<>(devices));
-            agenticUser.setUserRole(userRole);
-            agenticUser.setTeamName(team);
-            agenticUser.setLastUpdatedAt(Context.now());
+            agenticUser.setLastUpdatedAt(now);
+
+            List<DeviceTag> tags = new ArrayList<>();
+            if (team != null && !team.trim().isEmpty()) {
+                tags.add(new DeviceTag("team", team.trim().toLowerCase(), "device", now, "migration"));
+            }
+            if (userRole != null && !userRole.trim().isEmpty()) {
+                tags.add(new DeviceTag("role", userRole.trim().toLowerCase(), "device", now, "migration"));
+            }
+            agenticUser.setDeviceTags(tags);
             agenticUsers.add(agenticUser);
         }
         if(agenticUsers.isEmpty()) return;
         AgentUsersDao.instance.insertMany(agenticUsers);
+    }
+
+    /**
+     * One-time, idempotent conversion of agent_users' old fixed teamName/userRole fields (pre
+     * DeviceTag redesign) into deviceTags. Those fields no longer exist on AgenticUsers, so a
+     * plain typed find() would silently drop them — this reads the collection as raw Documents
+     * instead, exactly like scripts/migrate_team_role_to_device_tags.js (kept around as a manual
+     * reference / one-off fallback), so old field values are still visible.
+     *
+     * Filters on legacy-field presence, not on deviceTags being empty: a user can already have
+     * deviceTags from an unrelated source (e.g. Okta group sync racing this migration at startup)
+     * while still carrying unconverted legacy team/role fields, and an empty-deviceTags filter
+     * would silently skip them forever since this only ever runs once. For the same reason the
+     * write merges into any existing deviceTags — keyed by (key, source) — instead of overwriting:
+     * a legacy value is only appended where that (key, source) pair isn't already present, so a
+     * fresher write for the same source (a live sync, or an edit through the new UI) is never
+     * clobbered with a stale legacy one. Different sources for the same key (e.g. a manual "team"
+     * and an Okta "team") simply coexist — there's no single "effective" value to resolve to.
+     */
+    public static void migrateTeamRoleToDeviceTags() {
+        MongoCollection<Document> rawColl = MCollection.getMCollection(
+                AgentUsersDao.instance.getDBName(), AgentUsersDao.instance.getCollName(), Document.class);
+
+        Bson hasLegacyFields = Filters.or(
+                Filters.exists("ssoTeamName", true),
+                Filters.exists("ssoUserRole", true),
+                Filters.exists("teamSource", true),
+                Filters.exists("roleSource", true));
+
+        int now = Context.now();
+        for (Document doc : rawColl.find(hasLegacyFields)) {
+            List<DeviceTag> legacyTags = new ArrayList<>();
+            addLegacyDeviceTag(legacyTags, "team", doc.getString("ssoTeamName"), "okta", now);
+            addLegacyDeviceTag(legacyTags, "role", doc.getString("ssoUserRole"), "okta", now);
+            if ("manual".equals(doc.getString("teamSource"))) {
+                addLegacyDeviceTag(legacyTags, "team", doc.getString("teamName"), DeviceTag.SOURCE_MANUAL, now);
+            }
+            if ("manual".equals(doc.getString("roleSource"))) {
+                addLegacyDeviceTag(legacyTags, "role", doc.getString("userRole"), DeviceTag.SOURCE_MANUAL, now);
+            }
+            if (legacyTags.isEmpty()) continue;
+
+            List<DeviceTag> existingTags = parseExistingDeviceTags(doc.getList(AgenticUsers.DEVICE_TAGS, Document.class));
+            List<DeviceTag> mergedTags = mergeLegacyDeviceTags(existingTags, legacyTags);
+
+            AgentUsersDao.instance.updateOne(
+                    Filters.eq(Constants.ID, doc.get(Constants.ID)),
+                    Updates.set(AgenticUsers.DEVICE_TAGS, mergedTags));
+        }
+    }
+
+    private static void addLegacyDeviceTag(List<DeviceTag> tags, String key, String value, String source, int now) {
+        if (value != null && !value.trim().isEmpty()) {
+            tags.add(new DeviceTag(key, value.trim().toLowerCase(), source, now, "migration"));
+        }
+    }
+
+    private static List<DeviceTag> parseExistingDeviceTags(List<Document> raw) {
+        List<DeviceTag> tags = new ArrayList<>();
+        if (raw == null) return tags;
+        for (Document d : raw) {
+            tags.add(new DeviceTag(
+                    d.getString(DeviceTag.KEY),
+                    d.getString(DeviceTag.VALUE),
+                    d.getString(DeviceTag.SOURCE),
+                    d.getInteger(DeviceTag.LAST_UPDATED_AT, 0),
+                    d.getString(DeviceTag.LAST_UPDATED_BY)));
+        }
+        return tags;
+    }
+
+    /** Existing (key, source) pairs win — a legacy value is only appended where that pair is absent. */
+    private static List<DeviceTag> mergeLegacyDeviceTags(List<DeviceTag> existing, List<DeviceTag> legacy) {
+        Set<Pair<String, String>> seenKeySource = new HashSet<>();
+        for (DeviceTag t : existing) {
+            seenKeySource.add(new Pair<>(t.getKey(), t.getSource()));
+        }
+        List<DeviceTag> merged = new ArrayList<>(existing);
+        for (DeviceTag t : legacy) {
+            if (seenKeySource.add(new Pair<>(t.getKey(), t.getSource()))) {
+                merged.add(t);
+            }
+        }
+        return merged;
+    }
+
+    /**
+     * One-time, idempotent conversion of guardrail_policies' old fixed targetTeams/targetRoles
+     * fields into the generic targetTags model. Same raw-Document approach as
+     * migrateTeamRoleToDeviceTags, for the same reason (those fields no longer exist on
+     * GuardrailPolicies). Run after migrateTeamRoleToDeviceTags so the "team"/"role" keys line up.
+     *
+     * Filters on legacy-field presence, not on targetTags being empty, and merges rather than
+     * overwrites — same reasoning as migrateTeamRoleToDeviceTags: a policy already edited through
+     * the new UI before this migration runs could have targetTags set for "team"/"role" that must
+     * not be clobbered or duplicated by the stale legacy value.
+     */
+    public static void migrateGuardrailTargetTeamsRolesToTags() {
+        MongoCollection<Document> rawColl = MCollection.getMCollection(
+                GuardrailPoliciesDao.instance.getDBName(), GuardrailPoliciesDao.instance.getCollName(), Document.class);
+
+        Bson hasLegacyFields = Filters.or(
+                Filters.exists("targetTeams", true),
+                Filters.exists("targetRoles", true));
+
+        for (Document doc : rawColl.find(hasLegacyFields)) {
+            Map<String, List<String>> legacyTags = new HashMap<>();
+            addLegacyTargetTagKey(legacyTags, "team", doc.getList("targetTeams", String.class));
+            addLegacyTargetTagKey(legacyTags, "role", doc.getList("targetRoles", String.class));
+            if (legacyTags.isEmpty()) continue;
+
+            Map<String, List<String>> existingTags = parseExistingTargetTags(doc.get("targetTags", Document.class));
+            boolean changed = false;
+            for (Map.Entry<String, List<String>> entry : legacyTags.entrySet()) {
+                if (!existingTags.containsKey(entry.getKey())) {
+                    existingTags.put(entry.getKey(), entry.getValue());
+                    changed = true;
+                }
+            }
+            if (!changed) continue;
+
+            GuardrailPoliciesDao.instance.updateOne(
+                    Filters.eq(Constants.ID, doc.get(Constants.ID)),
+                    Updates.set("targetTags", existingTags));
+        }
+    }
+
+    private static Map<String, List<String>> parseExistingTargetTags(Document raw) {
+        Map<String, List<String>> tags = new LinkedHashMap<>();
+        if (raw == null) return tags;
+        for (Map.Entry<String, Object> entry : raw.entrySet()) {
+            if (entry.getValue() instanceof List) {
+                tags.put(entry.getKey(), (List<String>) entry.getValue());
+            }
+        }
+        return tags;
+    }
+
+    private static void addLegacyTargetTagKey(Map<String, List<String>> targetTags, String key, List<String> values) {
+        if (values == null || values.isEmpty()) return;
+        List<String> normalized = values.stream()
+                .filter(v -> v != null && !v.trim().isEmpty())
+                .map(v -> v.trim().toLowerCase())
+                .collect(Collectors.toList());
+        if (!normalized.isEmpty()) targetTags.put(key, normalized);
     }
 
     public static void cleanupApiInfoTags() {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailPolicies.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailPolicies.jsx
@@ -437,14 +437,16 @@ function GuardrailPolicies() {
 
         // User targeting (Atlas only)
         if (isEndpointSecurityCategory()) {
-            const targetTeams = policy.targetTeams || [];
-            const targetRoles = policy.targetRoles || [];
-            if (targetTeams.length === 0 && targetRoles.length === 0) {
+            const targetTags = policy.targetTags || {};
+            const targetDeviceIds = policy.targetDeviceIds || [];
+            const tagKeyCount = Object.keys(targetTags).filter(k => (targetTags[k] || []).length > 0).length;
+            if (tagKeyCount === 0 && targetDeviceIds.length === 0) {
                 details.push({ label: "Target Users", value: "All users" });
             } else {
-                const userParts = [];
-                if (targetTeams.length > 0) userParts.push(`${targetTeams.length} Team${targetTeams.length !== 1 ? 's' : ''}`);
-                if (targetRoles.length > 0) userParts.push(`${targetRoles.length} Role${targetRoles.length !== 1 ? 's' : ''}`);
+                const userParts = Object.entries(targetTags)
+                    .filter(([, values]) => (values || []).length > 0)
+                    .map(([key, values]) => `${values.length} ${key.charAt(0).toUpperCase()}${key.slice(1)}${values.length !== 1 ? 's' : ''}`);
+                if (targetDeviceIds.length > 0) userParts.push(`${targetDeviceIds.length} User${targetDeviceIds.length !== 1 ? 's' : ''}`);
                 details.push({ label: "Target Users", value: userParts.join(", ") });
             }
         }
@@ -634,8 +636,12 @@ function GuardrailPolicies() {
                 ...(guardrailData.tokenLimitDetection ? { tokenLimitDetection: guardrailData.tokenLimitDetection } : {}),
                 ...(guardrailData.anomalyDetection ? { anomalyDetection: guardrailData.anomalyDetection } : {}),
                 applyToAllServers: guardrailData.applyToAllServers ?? true,
-                targetTeams: guardrailData.targetTeams || [],
-                targetRoles: guardrailData.targetRoles || [],
+                // Prefer targetTags; fall back to converting a legacy export's targetTeams/targetRoles.
+                targetTags: guardrailData.targetTags || {
+                    ...(guardrailData.targetTeams?.length ? { team: guardrailData.targetTeams } : {}),
+                    ...(guardrailData.targetRoles?.length ? { role: guardrailData.targetRoles } : {}),
+                },
+                targetDeviceIds: guardrailData.targetDeviceIds || [],
                 applyOnResponse: guardrailData.applyOnResponse || false,
                 applyOnRequest: guardrailData.applyOnRequest || false,
                 behaviour: guardrailData.behaviour != null

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/CreateGuardrailPage.jsx
@@ -67,6 +67,15 @@ import "./createGuardrailPage.css";
 const expandGroupsToV2 = (selectedKeys) =>
     (selectedKeys || []).filter(key => key).map(key => ({ id: key, name: key }));
 
+// deviceId is the agent's device label, "{hostname}-{first8ofMachineID}" — the unique,
+// stable part is the segment after the LAST hyphen (the hostname itself may contain hyphens).
+// Falls back to a plain prefix slice for any value that doesn't follow that format.
+const deviceIdSuffix = (deviceId) => {
+    if (!deviceId) return '';
+    const idx = deviceId.lastIndexOf('-');
+    return idx >= 0 ? deviceId.slice(idx + 1) : deviceId.slice(0, 8);
+};
+
 // Agents: expand each selected canonical group key (e.g. 'claude2') into every raw wire-level
 // tag value it aliases. The guardrails-service matches on the raw client-type segment the client
 // sends — it never sees this dashboard's canonical grouping key — so we must store the raw values.
@@ -239,8 +248,10 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
 
     // Step 12: User targeting
     const [applyToAllUsers, setApplyToAllUsers] = useState(true);
-    const [targetTeams, setTargetTeams] = useState([]);
-    const [targetRoles, setTargetRoles] = useState([]);
+    // Generic device-tag targeting: { [tagKey]: [selectedValues] }. Any tag key present on
+    // AgenticUsers (group, role, team, department, ...) is targetable, not just a fixed set.
+    const [targetTags, setTargetTags] = useState({});
+    const [targetDeviceIds, setTargetDeviceIds] = useState([]);
     const [enterpriseLicenseComplianceCategories, setEnterpriseLicenseComplianceCategories] = useState([]);
 
     const [agenticUsers, setAgenticUsers] = useState([]);
@@ -256,17 +267,59 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
     // Get collections from PersistStore
     const allCollections = PersistStore(state => state.allCollections);
 
-    const availableTeams = useMemo(() => {
-        const teams = new Set();
-        (agenticUsers || []).forEach(u => { if (u.teamName) teams.add(u.teamName); });
-        return Array.from(teams).sort();
+    // Every device-tag key/value pair seen across AgenticUsers — powers the dynamic
+    // tag-key picker below (any key is targetable, e.g. group, role, team, department).
+    const availableTagKeyValues = useMemo(() => {
+        const map = new Map();
+        (agenticUsers || []).forEach(u => {
+            (u.deviceTags || []).forEach(t => {
+                if (!t?.key || !t.value) return;
+                if (!map.has(t.key)) map.set(t.key, new Set());
+                map.get(t.key).add(t.value);
+            });
+        });
+        return Array.from(map.entries())
+            .map(([key, values]) => ({ key, values: Array.from(values).sort() }))
+            .sort((a, b) => a.key.localeCompare(b.key));
     }, [agenticUsers]);
 
-    const availableRoles = useMemo(() => {
-        const roles = new Set();
-        (agenticUsers || []).forEach(u => { if (u.userRole) roles.add(u.userRole); });
-        return Array.from(roles).sort();
+    // One dropdown option per device (not per username) — usernames can repeat across devices
+    // (or even across different people), so the device ID is the actual selectable/stored value.
+    // Devices with no ID (agenticUsers[].devices already excludes them, see ModuleInfoDao) are
+    // never in this list, so there's nothing un-targetable to show.
+    const availableDevices = useMemo(() => {
+        const options = [];
+        (agenticUsers || []).forEach(u => {
+            (u.devices || []).forEach(deviceId => {
+                if (!deviceId) return;
+                options.push({ label: `${u.userName || u.userEmail} · ${deviceIdSuffix(deviceId)}`, value: deviceId });
+            });
+        });
+        return options.sort((a, b) => a.label.localeCompare(b.label));
     }, [agenticUsers]);
+
+    // Flatten agenticUsers[].devices into per-device rows, then filter by the same
+    // AND-across-type / OR-within-type semantics used server-side to resolve applyToDeviceIds —
+    // this is what powers the live "applies to N devices" preview in the wizard.
+    const matchingDeviceRows = useMemo(() => {
+        const rows = [];
+        (agenticUsers || []).forEach(u => {
+            (u.devices || []).forEach(deviceId => {
+                rows.push({ deviceId, username: u.userName, tags: u.deviceTags || [] });
+            });
+        });
+        if (applyToAllUsers) return rows;
+        const tagKeys = Object.keys(targetTags || {}).filter(k => (targetTags[k] || []).length > 0);
+        const deviceSet = new Set(targetDeviceIds);
+        if (tagKeys.length === 0 && deviceSet.size === 0) return [];
+        return rows.filter(r => {
+            const matchesAllTagKeys = tagKeys.every(k => {
+                const valueSet = new Set(targetTags[k]);
+                return r.tags.some(t => t.key === k && valueSet.has(t.value));
+            });
+            return matchesAllTagKeys && (deviceSet.size === 0 || deviceSet.has(r.deviceId));
+        });
+    }, [agenticUsers, applyToAllUsers, targetTags, targetDeviceIds]);
 
     // Create validation state object
     const getStoredStateData = () => ({
@@ -339,16 +392,16 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
         applyOnResponse,
         policyBehaviour,
         applyToAllUsers,
-        targetTeams,
-        targetRoles,
+        targetTags,
+        targetDeviceIds,
         enterpriseLicenseComplianceCategories,
         serverScopeLeftDirty: leftSteps.has(ServerSettingsConfig.number) && !applyToAllServers &&
             (selectedMcpServers || []).length === 0 &&
             (selectedAgentServers || []).length === 0 &&
             (selectedBrowserLlms || []).length === 0,
         userScopeLeftDirty: leftSteps.has(ServerSettingsConfig.number) && !applyToAllUsers &&
-            (targetTeams || []).length === 0 &&
-            (targetRoles || []).length === 0,
+            Object.values(targetTags || {}).every(values => !(values || []).length) &&
+            (targetDeviceIds || []).length === 0,
     });
 
     const getStepsWithSummary = () => {
@@ -650,8 +703,7 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
         setApplyOnRequest(false);
         setPolicyBehaviour(GUARDRAIL_BEHAVIOUR.BLOCK);
         setApplyToAllUsers(true);
-        setTargetTeams([]);
-        setTargetRoles([]);
+        setTargetTags({});
         setEnterpriseLicenseComplianceCategories([]);
     };
 
@@ -820,9 +872,11 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
             caseSensitive: !!entry.caseSensitive
         })));
 
-        setApplyToAllUsers(!policy.targetTeams?.length && !policy.targetRoles?.length);
-        setTargetTeams(policy.targetTeams || []);
-        setTargetRoles(policy.targetRoles || []);
+        const loadedTargetTags = policy.targetTags || {};
+        const hasAnyTag = Object.values(loadedTargetTags).some(values => (values || []).length > 0);
+        setApplyToAllUsers(!hasAnyTag && !policy.targetDeviceIds?.length);
+        setTargetTags(loadedTargetTags);
+        setTargetDeviceIds(policy.targetDeviceIds || []);
         setEnterpriseLicenseComplianceCategories(policy.enterpriseLicenseComplianceCategories || []);
     };
 
@@ -957,8 +1011,10 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                 ignorePhrases: cleanedIgnorePhrases,
                 applyOnResponse,
                 applyOnRequest,
-                targetTeams: applyToAllUsers ? [] : targetTeams,
-                targetRoles: applyToAllUsers ? [] : targetRoles,
+                targetTags: applyToAllUsers ? {} : Object.fromEntries(
+                    Object.entries(targetTags).filter(([, values]) => (values || []).length > 0)
+                ),
+                targetDeviceIds: applyToAllUsers ? [] : targetDeviceIds,
                 enterpriseLicenseComplianceCategories,
                 ...(isEditMode && editingPolicy ? { hexId: editingPolicy.hexId } : {})
             };
@@ -1167,12 +1223,13 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                         collectionsLoading={collectionsLoading}
                         policyBehaviour={policyBehaviour}
                         setPolicyBehaviour={setPolicyBehaviour}
-                        targetTeams={targetTeams}
-                        setTargetTeams={setTargetTeams}
-                        targetRoles={targetRoles}
-                        setTargetRoles={setTargetRoles}
-                        availableTeams={availableTeams}
-                        availableRoles={availableRoles}
+                        targetTags={targetTags}
+                        setTargetTags={setTargetTags}
+                        targetDeviceIds={targetDeviceIds}
+                        setTargetDeviceIds={setTargetDeviceIds}
+                        availableTagKeyValues={availableTagKeyValues}
+                        availableDevices={availableDevices}
+                        matchingDeviceRows={matchingDeviceRows}
                         usersLoading={usersLoading}
                         applyToAllUsers={applyToAllUsers}
                         setApplyToAllUsers={setApplyToAllUsers}
@@ -1194,12 +1251,6 @@ const CreateGuardrailPage = ({ onClose, onSave, editingPolicy = null, isEditMode
                         onTryPrompt={handleSamplePayloadClick}
                         enterpriseLicenseComplianceCategories={enterpriseLicenseComplianceCategories}
                         setEnterpriseLicenseComplianceCategories={setEnterpriseLicenseComplianceCategories}
-                        targetTeams={targetTeams}
-                        setTargetTeams={setTargetTeams}
-                        targetRoles={targetRoles}
-                        setTargetRoles={setTargetRoles}
-                        availableTeams={availableTeams}
-                        availableRoles={availableRoles}
                         usersLoading={usersLoading}
                         applyToAllUsers={applyToAllUsers}
                         setApplyToAllUsers={setApplyToAllUsers}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/ServerSettingsStep.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/components/steps/ServerSettingsStep.jsx
@@ -23,7 +23,7 @@ export const ServerSettingsConfig = {
         return { isValid: true, errorMessage: null };
     },
 
-    getSummary: ({ applyToAllServers, applyToAllUsers, selectedMcpServers, selectedAgentServers, selectedBrowserLlms, mcpServers, agentServers, browserLlmServers, applyOnRequest, applyOnResponse, policyBehaviour, targetTeams, targetRoles }) => {
+    getSummary: ({ applyToAllServers, applyToAllUsers, selectedMcpServers, selectedAgentServers, selectedBrowserLlms, mcpServers, agentServers, browserLlmServers, applyOnRequest, applyOnResponse, policyBehaviour, targetTags, targetDeviceIds }) => {
         const appSettings = (applyOnRequest || applyOnResponse) ?
             ` - ${applyOnRequest ? 'Req' : ''}${applyOnRequest && applyOnResponse ? '/' : ''}${applyOnResponse ? 'Res' : ''}` : '';
         const behaviourSuffix = policyBehaviour ? `Rule behaviour: ${policyBehaviour}` : '';
@@ -41,8 +41,13 @@ export const ServerSettingsConfig = {
             summary += ' | All users';
         } else {
             const userParts = [];
-            if (targetTeams?.length > 0) userParts.push(`${targetTeams.length} Team${targetTeams.length !== 1 ? 's' : ''}`);
-            if (targetRoles?.length > 0) userParts.push(`${targetRoles.length} Role${targetRoles.length !== 1 ? 's' : ''}`);
+            Object.entries(targetTags || {}).forEach(([key, values]) => {
+                if (values?.length > 0) {
+                    const label = key.charAt(0).toUpperCase() + key.slice(1);
+                    userParts.push(`${values.length} ${label}${values.length !== 1 ? 's' : ''}`);
+                }
+            });
+            if (targetDeviceIds?.length > 0) userParts.push(`${targetDeviceIds.length} User${targetDeviceIds.length !== 1 ? 's' : ''}`);
             if (userParts.length > 0) summary += ` | ${userParts.join(', ')}`;
         }
         summary += `${appSettings} ${behaviourSuffix}`;
@@ -51,6 +56,15 @@ export const ServerSettingsConfig = {
 };
 
 const conditionsReducer = produce((draft, action) => func.conditionsReducer(draft, action));
+
+// deviceId is the agent's device label, "{hostname}-{first8ofMachineID}" — the unique,
+// stable part is the segment after the LAST hyphen (the hostname itself may contain hyphens).
+// Falls back to a plain prefix slice for any value that doesn't follow that format.
+const deviceIdSuffix = (deviceId) => {
+    if (!deviceId) return '';
+    const idx = deviceId.lastIndexOf('-');
+    return idx >= 0 ? deviceId.slice(idx + 1) : deviceId.slice(0, 8);
+};
 
 const CountPopover = ({ count, label, items }) => {
     const [active, setActive] = useState(false);
@@ -120,12 +134,13 @@ const ServerSettingsStep = ({
     collectionsLoading,
     policyBehaviour,
     setPolicyBehaviour,
-    targetTeams,
-    setTargetTeams,
-    targetRoles,
-    setTargetRoles,
-    availableTeams,
-    availableRoles,
+    targetTags,
+    setTargetTags,
+    targetDeviceIds,
+    setTargetDeviceIds,
+    availableTagKeyValues = [],
+    availableDevices,
+    matchingDeviceRows = [],
     usersLoading,
     applyToAllUsers,
     setApplyToAllUsers,
@@ -145,9 +160,10 @@ const ServerSettingsStep = ({
     });
 
     const [userConditions, userDispatch] = useReducer(conditionsReducer, null, () => {
-        const conds = [];
-        if ((targetRoles || []).length > 0) conds.push({ type: 'ROLE', values: targetRoles });
-        if ((targetTeams || []).length > 0) conds.push({ type: 'TEAM', values: targetTeams });
+        const conds = Object.entries(targetTags || {})
+            .filter(([, values]) => (values || []).length > 0)
+            .map(([key, values]) => ({ type: key, values }));
+        if ((targetDeviceIds || []).length > 0) conds.push({ type: 'DEVICE', values: targetDeviceIds });
         return conds;
     });
 
@@ -159,8 +175,13 @@ const ServerSettingsStep = ({
 
     useEffect(() => {
         if (isAtlas) {
-            setTargetRoles(userConditions.filter(c => c.type === 'ROLE').flatMap(c => c.values).filter(Boolean));
-            setTargetTeams(userConditions.filter(c => c.type === 'TEAM').flatMap(c => c.values).filter(Boolean));
+            const tagMap = {};
+            userConditions.filter(c => c.type !== 'DEVICE').forEach(c => {
+                const values = (c.values || []).filter(Boolean);
+                if (values.length) tagMap[c.type] = values;
+            });
+            setTargetTags(tagMap);
+            setTargetDeviceIds(userConditions.filter(c => c.type === 'DEVICE').flatMap(c => c.values).filter(Boolean));
         }
     }, [userConditions]);
 
@@ -182,9 +203,11 @@ const ServerSettingsStep = ({
             case 'AGENT': return enrichOptions(agentOptions, 'AI Agent');
             case 'MCP_SERVER': return enrichOptions(mcpOptions, 'MCP Server');
             case 'LLM': return enrichOptions(llmOptions, 'LLM');
-            case 'ROLE': return (availableRoles || []).map(r => ({ label: r, value: r })).sort((a, b) => a.label.localeCompare(b.label));
-            case 'TEAM': return (availableTeams || []).map(t => ({ label: t, value: t })).sort((a, b) => a.label.localeCompare(b.label));
-            default: return [];
+            case 'DEVICE': return (availableDevices || []).slice().sort((a, b) => a.label.localeCompare(b.label));
+            default: {
+                const entry = (availableTagKeyValues || []).find(k => k.key === type);
+                return (entry?.values || []).map(v => ({ label: v, value: v })).sort((a, b) => a.label.localeCompare(b.label));
+            }
         }
     };
 
@@ -257,11 +280,15 @@ const ServerSettingsStep = ({
         { label: `LLM${llmOptions.length > 1 ? 's' : ''} [${llmOptions.length}]`, value: 'LLM', disabled: llmOptions.length === 0 },
     ];
 
-    const teamCount = (availableTeams || []).length;
-    const roleCount = (availableRoles || []).length;
+    const deviceCount = (availableDevices || []).length;
+    const tagTypeOptions = (availableTagKeyValues || []).map(({ key, values }) => {
+        const label = key.charAt(0).toUpperCase() + key.slice(1);
+        const count = (values || []).length;
+        return { label: `${count > 1 ? `${label}s` : label} [${count}]`, value: key, disabled: count === 0 };
+    });
     const userTypeOptions = [
-        { label: `${teamCount > 1 ? 'Teams' : 'Team'} [${teamCount}]`, value: 'TEAM', disabled: teamCount === 0 },
-        { label: `${roleCount > 1 ? 'Roles' : 'Role'} [${roleCount}]`, value: 'ROLE', disabled: roleCount === 0 },
+        ...tagTypeOptions,
+        { label: `${deviceCount > 1 ? 'Users' : 'User'} [${deviceCount}]`, value: 'DEVICE', disabled: deviceCount === 0 },
     ];
 
     const renderConditionRows = (conditions, typeOptions, dispatch, operator = 'OR', showError = false) => {
@@ -425,7 +452,7 @@ const ServerSettingsStep = ({
                     <Box borderColor="border" borderWidth="1" borderRadius="2" background="bg-surface">
                         <Box padding="4">
                             <VerticalStack gap="4">
-                                <Text variant="headingSm">Teams & Roles</Text>
+                                <Text variant="headingSm">Device Tags & Users</Text>
                                 <VerticalStack gap="2">
                                     <RadioButton
                                         label={
@@ -450,16 +477,38 @@ const ServerSettingsStep = ({
                                         }
                                     />
                                     <RadioButton
-                                        label="Select Teams & Roles"
+                                        label="Select Device Tags & Users"
                                         checked={!applyToAllUsers}
                                         id="select_users_teams"
                                         name="userTargeting"
                                         onChange={() => setApplyToAllUsers(false)}
-                                        disabled={(availableTeams || []).length === 0 && (availableRoles || []).length === 0}
-                                        helpText={(availableTeams || []).length === 0 && (availableRoles || []).length === 0
-                                            ? "No Teams or Roles configured. Set them up in your organization settings before selecting."
-                                            : "Choose specific Teams & Roles."
-                                        }
+                                        disabled={(availableTagKeyValues || []).length === 0 && (availableDevices || []).length === 0}
+                                        helpText={(() => {
+                                            const noOptions = (availableTagKeyValues || []).length === 0 && (availableDevices || []).length === 0;
+                                            if (noOptions) {
+                                                return "No device tags or users found. Devices must report in before you can target them here.";
+                                            }
+                                            if (userConditions.length === 0) {
+                                                return "Choose specific device tags or Users.";
+                                            }
+                                            if (matchingDeviceRows.length === 0) {
+                                                return "Applies to 0 users with the current selection.";
+                                            }
+                                            return (
+                                                <HorizontalStack gap="1" blockAlign="center" wrap>
+                                                    <Text variant="bodyMd" tone="subdued">Applies to</Text>
+                                                    <CountPopover
+                                                        count={matchingDeviceRows.length}
+                                                        label={`user${matchingDeviceRows.length !== 1 ? 's' : ''}`}
+                                                        items={matchingDeviceRows.map(r => ({
+                                                            value: r.deviceId,
+                                                            label: `${r.username} · ${deviceIdSuffix(r.deviceId)}`,
+                                                        }))}
+                                                    />
+                                                    <Text variant="bodyMd" tone="subdued">with the current selection.</Text>
+                                                </HorizontalStack>
+                                            );
+                                        })()}
                                     />
                                     {!applyToAllUsers && (
                                         <Box paddingInlineStart="6">

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
@@ -19,7 +19,6 @@ import {
   RiskScoreCellRenderer,
   ViolationsCellRenderer,
   InteractionsCellRenderer,
-  GroupCellRenderer,
 } from "./AgenticCellRenderers";
 import SpinnerCentered from "@/apps/dashboard/components/progress/SpinnerCentered";
 import "../../../components/layouts/style.css";
@@ -118,16 +117,6 @@ const COL_DEFS = [
     sortable: false,
     filter: false,
     cellRenderer: ViolationsCellRenderer,
-    cellStyle: { display: "flex", alignItems: "center" },
-  },
-  {
-    field: "groups",
-    headerName: "Group",
-    flex: 1,
-    minWidth: 160,
-    sortable: false,
-    filter: false,
-    cellRenderer: GroupCellRenderer,
     cellStyle: { display: "flex", alignItems: "center" },
   },
   {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticCellRenderers.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticCellRenderers.jsx
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { createPortal } from "react-dom";
+import React from "react";
 import { Badge, Box, HorizontalStack, Text, Tooltip } from "@shopify/polaris";
 import McpRedIcon from "@/assets/McpRedIcon.svg";
 import PersonLockIcon from "@/assets/PersonLockIcon.svg";
@@ -139,54 +138,3 @@ export function InteractionsCellRenderer({ value, data }) {
     );
 }
 
-export function GroupCellRenderer({ data }) {
-    const [tipPos, setTipPos] = useState(null);
-    if (!data?.groups?.length) return <Text variant="bodySm" color="subdued">-</Text>;
-
-    const primary = data.groups[0];
-    const rest = data.groups.slice(1);
-
-    return (
-        <HorizontalStack gap="2" blockAlign="center" wrap={false}>
-            <Text variant="bodySm">{primary.name} [{primary.count}]</Text>
-            {rest.length > 0 && (
-                <>
-                    {/* count chip — neutral palette pill, hover reveals a portal tooltip */}
-                    <Box
-                        as="span"
-                        background="bg-strong"
-                        borderRadius="4"
-                        paddingInlineStart="2"
-                        paddingInlineEnd="2"
-                        onMouseEnter={(e) => {
-                            const r = e.currentTarget.getBoundingClientRect();
-                            setTipPos({ top: r.bottom + 6, left: r.left });
-                        }}
-                        onMouseLeave={() => setTipPos(null)}
-                    >
-                        <Text variant="bodySm" color="subdued" fontWeight="semibold">+{rest.length}</Text>
-                    </Box>
-                    {/* createPortal renders into document.body — escapes AG Grid's overflow:hidden */}
-                    {tipPos && createPortal(
-                        <Box
-                            position="fixed"
-                            background="bg"
-                            borderColor="border"
-                            borderWidth="1"
-                            borderRadius="2"
-                            padding="2"
-                            shadow="lg"
-                            zIndex="9999"
-                            style={{ top: tipPos.top, left: tipPos.left, whiteSpace: "nowrap", pointerEvents: "none" }}
-                        >
-                            {rest.map((g) => (
-                                <Text key={g.name} variant="bodySm">{g.name} [{g.count}]</Text>
-                            ))}
-                        </Box>,
-                        document.body,
-                    )}
-                </>
-            )}
-        </HorizontalStack>
-    );
-}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceEndpoints.jsx
@@ -157,6 +157,27 @@ function RiskScoreCellRenderer({ value }) {
     return <RiskPill score={value} />;
 }
 
+// Compact "key=value" badge — just the first tag inline, rest collapsed behind a "+N"
+// badge with a tooltip, same idiom as the classic Users & Devices page's Tags column.
+const MAX_VISIBLE_TAGS = 1;
+function TagsCellRenderer({ value }) {
+    if (!value || value.length === 0) return null;
+    const shown = value.slice(0, MAX_VISIBLE_TAGS);
+    const rest = value.slice(MAX_VISIBLE_TAGS);
+    return (
+        <HorizontalStack gap="1" wrap={false} blockAlign="center">
+            {shown.map((t, i) => (
+                <Badge key={`${t.key}-${i}`} size="small" status="info">{`${t.key}=${t.value}`}</Badge>
+            ))}
+            {rest.length > 0 && (
+                <Tooltip content={rest.map((t) => `${t.key}=${t.value}`).join(", ")} dismissOnMouseOut>
+                    <Badge size="small" status="info">{`+${rest.length}`}</Badge>
+                </Tooltip>
+            )}
+        </HorizontalStack>
+    );
+}
+
 function ViolationsCellRenderer({ value }) {
     if (!value) return null;
     const parts = ["critical", "high", "medium", "low"].filter(k => value[k] > 0);
@@ -240,12 +261,14 @@ function buildDeviceColDefs(filterOptions) {
             filter: "agSetColumnFilter", filterParams: { values: filterOptions.os },
         },
         {
-            field: "group", headerName: "Group", flex: 1, minWidth: 120, sortable: false, valueFormatter: (p) => p.value || "-",
-            filter: "agSetColumnFilter", filterParams: { values: filterOptions.group },
-        },
-        {
-            field: "role", headerName: "Role", flex: 1.2, minWidth: 150, sortable: false, valueFormatter: (p) => p.value || "-",
-            filter: "agSetColumnFilter", filterParams: { values: filterOptions.role },
+            field: "tags", headerName: "Tags", flex: 1.2, minWidth: 160, sortable: false,
+            // Server-computed (AgenticObserveAction.HostGroupSummary.toRow) — filterable by tag KEY
+            // only, matching constants.js's buildTagFilterValues semantics ("group" matches any row
+            // with a "group" tag, regardless of value).
+            filter: "agSetColumnFilter", filterParams: { values: filterOptions.tags },
+            filterValueGetter: (params) => params.data?.tagFilterValues || [],
+            cellRenderer: TagsCellRenderer,
+            valueGetter: (p) => p.data?.tags || [],
         },
         { field: "violations", headerName: "Violations", width: 200, sortable: false, filter: false, cellRenderer: ViolationsCellRenderer },
         { field: "lastTraffic", headerName: "Last Traffic", width: 130, filter: false, valueFormatter: DASH_FORMATTER },
@@ -260,16 +283,13 @@ const DEFAULT_COL_DEF = {
 };
 
 // Backend row field names don't match the grid's column defs directly — device (parent) rows carry
-// team/userRole/lastSeenEpoch (AgenticObserveAction.HostGroupSummary.toRow), service (child) rows
-// carry lastTrafficEpoch (buildDeviceChildren) and no team/role at all. Reshape both into the
-// group/role/lastTraffic the columns actually read, matching AgenticAssetsPage.jsx's shapeRow.
+// lastSeenEpoch (AgenticObserveAction.HostGroupSummary.toRow), service (child) rows carry
+// lastTrafficEpoch (buildDeviceChildren). Reshape both into the lastTraffic the columns actually read.
 function shapeRow(row) {
     if (!row) return row;
     const epoch = row.lastSeenEpoch ?? row.lastTrafficEpoch;
     return {
         ...row,
-        group: row.team,
-        role: row.userRole,
         lastTraffic: epoch > 0 ? func.prettifyEpoch(epoch) : "",
     };
 }
@@ -488,8 +508,8 @@ export default function DeviceEndpoints() {
         loadStats();
     }, [loadStats, refreshKey]);
 
-    // Distinct deviceId/os/team/role values for the grid's Set Filters. os/team/role come from
-    // deviceMetadataMap — already the full, unpaginated account-wide map (fetched once at mount via
+    // Distinct deviceId/os values for the grid's Set Filters. os comes from deviceMetadataMap —
+    // already the full, unpaginated account-wide map (fetched once at mount via
     // fetchEndpointShieldUserMetadata) — so no extra network call. deviceId comes from
     // fetchDeviceEndpointsStats's own deviceIds list (arrives slightly later, once loadStats
     // resolves) rather than being derived client-side, since it must match the grid's own
@@ -497,26 +517,34 @@ export default function DeviceEndpoints() {
     // than re-derive it in the browser and risk drift.
     const filterOptions = useMemo(() => {
         const meta = Object.values(enrichRef.current.deviceMetadataMap || {});
-        const os = new Set(), group = new Set(), role = new Set();
+        const os = new Set();
         meta.forEach((m) => {
             if (m.os) os.add(m.os);
-            if (m.team) group.add(m.team);
-            if (m.role) role.add(m.role);
+        });
+        // Distinct device-tag keys — same source (userMetadataMap, full/unpaginated) as os above,
+        // just keyed by username instead of deviceId.
+        const tags = new Set();
+        Object.values(enrichRef.current.userMetadataMap || {}).forEach((u) => {
+            (u.tags || []).forEach((t) => { if (t?.key) tags.add(t.key); });
         });
         return {
             deviceId: stats.deviceIds || [],
-            os: Array.from(os).sort(), group: Array.from(group).sort(), role: Array.from(role).sort(),
+            os: Array.from(os).sort(),
+            tags: Array.from(tags).sort(),
         };
     }, [refreshKey, stats.deviceIds]);
 
     const onServerFetch = useCallback(({ sortKey, sortOrder, skip, limit, searchString, groupKeys, filters }) => {
-        const { trafficMap, riskScoreMap, usernameMap, deviceMetadataMap, violationsByCollectionId } = enrichRef.current;
+        const { trafficMap, riskScoreMap, usernameMap, userMetadataMap, deviceMetadataMap, violationsByCollectionId } = enrichRef.current;
         const mappedSortKey = SORT_FIELD_MAP[sortKey] || "riskScore";
         const mongoSortOrder = sortOrder === -1 ? 1 : -1; // AG Grid asc=-1/desc=1 is inverted vs Mongo
         const parentDeviceId = groupKeys && groupKeys.length === 1 ? groupKeys[0] : undefined;
+        const tagsByUsername = Object.fromEntries(
+            Object.entries(userMetadataMap || {}).map(([u, m]) => [u, m.tags || []])
+        );
         return api.fetchDeviceEndpointsSummary({
             parentDeviceId, skip, limit, sortKey: mappedSortKey, sortOrder: mongoSortOrder, queryValue: searchString,
-            trafficMap, riskScoreMap, usernameMap, deviceMetadataMap, violationsByCollectionId, filters,
+            trafficMap, riskScoreMap, usernameMap, deviceMetadataMap, violationsByCollectionId, filters, tagsByUsername,
         }).then((res) => ({ value: (res.rows || []).map(shapeRow), total: res.total || 0 }));
     }, []);
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceFlyout.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceFlyout.jsx
@@ -419,8 +419,6 @@ function OverviewTab({ device, agents, collections, onTabChange, startTimestamp,
     const deviceDetails = useMemo(() => [
         { label: "User",      value: safeVal(device.username) },
         { label: "OS",        value: osLabel },
-        { label: "Group",     value: safeVal(device.group) },
-        { label: "Role",      value: safeVal(device.role) },
         { label: "Last Seen", value: safeVal(device.lastTraffic) },
         device.hasPersonalAccount
             ? { label: "Account", value: "Personal account", isWarning: true }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/OverviewTab.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/OverviewTab.jsx
@@ -107,7 +107,6 @@ export default function OverviewTab({ asset, onTabChange, assetDevices = {}, age
     const assetDetails = useMemo(() => [
         { label: "AI Interactions",   value: asset.aiInteractions != null ? Number(asset.aiInteractions).toLocaleString("en-US") : "-" },
         { label: "Last Traffic Seen", value: asset.lastSeen || "-" },
-        { label: "Group",             value: asset.groups?.length ? asset.groups.map(g => g.name).join(", ") : "-" },
     ], [asset]);
 
     return (

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
@@ -320,17 +320,19 @@ function UsersAndDevices() {
     // Only manual rows are ever edited/removed here — tags from any other source (e.g. Okta) are
     // shown read-only, since this dashboard action only ever writes manual-source tags and a
     // synced value would just be overwritten again on the next sync anyway.
-    const updateEntryValue = useCallback((key, value) => {
+    // Identified by index, not key — a key can now have multiple manual values (e.g. team=akto
+    // and team=razorpay both applying at once), so key alone no longer uniquely names an entry.
+    const updateEntryValue = useCallback((idx, value) => {
         setEditTagModal((prev) => ({
             ...prev,
-            entries: prev.entries.map((e) => (e.key === key && e.source === 'manual' ? { ...e, value } : e)),
+            entries: prev.entries.map((e, i) => (i === idx && e.source === 'manual' ? { ...e, value } : e)),
         }));
     }, []);
 
-    const removeEntry = useCallback((key) => {
+    const removeEntry = useCallback((idx) => {
         setEditTagModal((prev) => ({
             ...prev,
-            entries: prev.entries.filter((e) => !(e.key === key && e.source === 'manual')),
+            entries: prev.entries.filter((e, i) => !(i === idx && e.source === 'manual')),
         }));
     }, []);
 
@@ -341,10 +343,10 @@ function UsersAndDevices() {
             func.setToast(true, true, "Device tag key cannot be empty");
             return;
         }
-        // Only checked against other manual rows — a manual value is allowed alongside an
-        // existing non-manual value for the same key, they simply coexist.
-        if (editTagModal.entries.some((e) => e.key === key && e.source === 'manual')) {
-            func.setToast(true, true, "This device tag key already has a manual value in the list below.");
+        // A key can have multiple manual values at once (e.g. team=akto and team=razorpay both
+        // apply) — only guard against adding the exact same key+value pair twice.
+        if (editTagModal.entries.some((e) => e.key === key && e.value === value && e.source === 'manual')) {
+            func.setToast(true, true, "This tag already exists.");
             return;
         }
         setEditTagModal((prev) => ({
@@ -362,13 +364,16 @@ function UsersAndDevices() {
             const groupNames = selectedRows.map((r) => r.groupName).filter(Boolean);
 
             // Only manual rows are ever sent — this action only writes the "manual" source, never
-            // touching tags synced in from elsewhere. Empty value = explicit clear. Manual keys
-            // removed from the original prefill are also sent as an explicit clear, so "remove"
-            // actually un-pins the manual override instead of just hiding it locally; a same-key
-            // tag from another source (if any) is untouched either way.
+            // touching tags synced in from elsewhere. A key with no non-empty manual values left
+            // (all cleared, or removed down to nothing) is sent as [] — an explicit clear — so
+            // clearing/removing every value un-pins the manual override instead of just hiding it
+            // locally; a same-key tag from another source (if any) is untouched either way.
             const manualEntries = editTagModal.entries.filter((e) => e.source === 'manual');
             const tags = {};
-            manualEntries.forEach((e) => { tags[e.key] = e.value ? [e.value] : []; });
+            manualEntries.forEach((e) => {
+                if (!(e.key in tags)) tags[e.key] = [];
+                if (e.value) tags[e.key].push(e.value);
+            });
             if (editTagModal.isBulk) {
                 // "Clear all" in bulk mode clears every manually-set key any selected row currently
                 // has — computed from the union of their real tags, never guessed from one row's set.
@@ -384,6 +389,19 @@ function UsersAndDevices() {
             }
 
             await settingRequests.bulkUpdateUserDeviceTag(groupNames, tags);
+
+            // fetchData/loadStats build tagsByUsername from enrichRef.current.userMetadataMap, which
+            // was only ever fetched once at mount — without refreshing it here, the table/stats
+            // refetch below would keep sending the pre-edit tags and the save would look like it
+            // silently did nothing. force=true also bypasses fetchEndpointShieldUserMetadata's TTL
+            // cache, which would otherwise likely still be warm from that same mount fetch.
+            const shieldResult = await fetchEndpointShieldUserMetadata(true);
+            enrichRef.current = {
+                ...enrichRef.current,
+                usernameMap: shieldResult?.usernameMap || {},
+                userMetadataMap: shieldResult?.userMetadataMap || {},
+            };
+
             func.setToast(true, false, "Tags updated successfully");
             closeEditTagModal();
             setRefreshKey((k) => k + 1);
@@ -489,14 +507,14 @@ function UsersAndDevices() {
                                                     label={entry.key}
                                                     labelHidden
                                                     value={entry.value}
-                                                    onChange={isManual ? (v) => updateEntryValue(entry.key, v) : () => {}}
+                                                    onChange={isManual ? (v) => updateEntryValue(idx, v) : () => {}}
                                                     disabled={!isManual}
                                                     autoComplete="off"
                                                 />
                                             </Box>
                                             <Box minWidth="72px">
                                                 {isManual ? (
-                                                    <Button plain destructive icon={DeleteMinor} onClick={() => removeEntry(entry.key)} accessibilityLabel={`Remove ${entry.key}`} />
+                                                    <Button plain destructive icon={DeleteMinor} onClick={() => removeEntry(idx)} accessibilityLabel={`Remove ${entry.key}`} />
                                                 ) : (
                                                     <Badge size="small">{entry.source}</Badge>
                                                 )}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/UsersAndDevices.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from "react";
-import { Badge, HorizontalStack, Text, Modal, FormLayout, Banner, VerticalStack, Autocomplete, IndexFiltersMode } from "@shopify/polaris";
+import { Badge, HorizontalStack, Text, Modal, FormLayout, Banner, VerticalStack, IndexFiltersMode, TextField, Button, Box, Divider, Tooltip, Checkbox } from "@shopify/polaris";
+import { DeleteMinor } from "@shopify/polaris-icons";
 import { useNavigate } from "react-router-dom";
 import PageWithMultipleCards from "../../../components/layouts/PageWithMultipleCards";
 import GithubServerTable from "@/apps/dashboard/components/tables/GithubServerTable";
@@ -50,6 +51,27 @@ const getRiskScoreStatus = (riskScore) => {
     return "success";
 };
 
+// Compact "key=value" badge for the single Tags column — just the first tag inline, the
+// rest collapsed behind a "+N" badge with a tooltip listing them.
+const MAX_VISIBLE_TAGS = 1;
+function buildTagsDisplay(tags) {
+    if (!tags || tags.length === 0) return null;
+    const shown = tags.slice(0, MAX_VISIBLE_TAGS);
+    const rest = tags.slice(MAX_VISIBLE_TAGS);
+    return (
+        <HorizontalStack gap="1" wrap={false}>
+            {shown.map((t, i) => (
+                <Badge key={`${t.key}-${i}`} size="small" status="info">{`${t.key}=${t.value}`}</Badge>
+            ))}
+            {rest.length > 0 && (
+                <Tooltip content={rest.map((t) => `${t.key}=${t.value}`).join(", ")} dismissOnMouseOut>
+                    <Badge size="small" status="info">{`+${rest.length}`}</Badge>
+                </Tooltip>
+            )}
+        </HorizontalStack>
+    );
+}
+
 function UsersAndDevices() {
     const navigate = useNavigate();
     const [loading, setLoading] = useState(true);
@@ -72,12 +94,20 @@ function UsersAndDevices() {
     const filtersMap = PersistStore((state) => state.filtersMap);
     const setFiltersMap = PersistStore((state) => state.setFiltersMap);
 
-    const [stats, setStats] = useState({ usersCount: 0, devicesCount: 0, usersAgenticAssetsTotal: 0, devicesAgenticAssetsTotal: 0, teams: [], roles: [], usernames: [] });
+    const [stats, setStats] = useState({ usersCount: 0, devicesCount: 0, usersAgenticAssetsTotal: 0, devicesAgenticAssetsTotal: 0, usernames: [], tagKeys: [] });
     const [refreshKey, setRefreshKey] = useState(0);
-    const [editTagModal, setEditTagModal] = useState({ active: false, rows: [], team: '', userRole: '', teamSource: 'sso', roleSource: 'sso', ssoHintTeam: '', ssoHintRole: '', saving: false });
+
+    // entries: [{key, value, source}] — one row per raw tag for the selected user(s); a key can
+    // have more than one row (different sources, e.g. manual + Okta, all coexisting). Only
+    // source==='manual' rows are ever edited/removed here.
+    // isBulk (>1 user selected): existing per-user tags are never prefilled/shown, since they can
+    // differ across users and silently copying one user's values onto the rest would be a data-loss
+    // footgun. Bulk mode only supports adding a new tag (applied to all) or clearing all manual tags.
+    const emptyEditTagModal = { active: false, usernames: [], isBulk: false, entries: [], originalManualKeys: [], clearAll: false, newKey: '', newValue: '', saving: false };
+    const [editTagModal, setEditTagModal] = useState(emptyEditTagModal);
 
     // Everything the paginated fetch needs but the row itself doesn't carry, plus a stash of the
-    // most-recently-fetched page's full row objects (for the bulk "Edit team & role" action, which
+    // most-recently-fetched page's full row objects (for the bulk "Edit device tags" action, which
     // only gets selected IDs from GithubServerTable — selection is only ever made on currently
     // rendered rows, so this is always in sync).
     const enrichRef = useRef({
@@ -122,16 +152,23 @@ function UsersAndDevices() {
         return () => { isMountedRef.current = false; };
     }, []);
 
+    const tagsByUsernameFor = useCallback((userMetadataMap) => Object.fromEntries(
+        Object.entries(userMetadataMap || {}).map(([u, m]) => [u, m.tags || []])
+    ), []);
+
     const loadStats = useCallback(async () => {
         try {
             const { trafficMap, riskScoreMap, usernameMap, userMetadataMap } = enrichRef.current;
-            const result = await api.fetchUsersAndDevicesStats({ trafficMap, riskScoreMap, usernameMap, userMetadataMap });
+            const result = await api.fetchUsersAndDevicesStats({
+                trafficMap, riskScoreMap, usernameMap, userMetadataMap,
+                tagsByUsername: tagsByUsernameFor(userMetadataMap),
+            });
             setStats(result);
         } catch (e) {
             // eslint-disable-next-line no-console
             console.error("fetchUsersAndDevicesStats failed:", e);
         }
-    }, []);
+    }, [tagsByUsernameFor]);
 
     useEffect(() => {
         if (refreshKey === 0) return;
@@ -161,6 +198,7 @@ function UsersAndDevices() {
             return {
                 ...row,
                 groupNameDisplay: buildGroupNameDisplay(row, extraBadges),
+                tagsDisplay: buildTagsDisplay(row.tags),
                 sensitiveSubTypes: transform.prettifySubtypes(row.sensitiveInRespTypes || [], false),
                 sensitiveSubTypesVal: (row.sensitiveInRespTypes || []).join(" ") || "-",
                 riskScoreComp: row.riskScore != null ? (
@@ -177,19 +215,19 @@ function UsersAndDevices() {
         const mappedSortKey = SORT_FIELD_MAP[sortKey] || "riskScore";
         const mongoSortOrder = sortOrder === -1 ? 1 : -1; // GithubServerTable: asc=-1/desc=1, inverted vs Mongo
         const filters = {};
-        if (filtersObj?.team?.length) filters.team = filtersObj.team;
-        if (filtersObj?.userRole?.length) filters.userRole = filtersObj.userRole;
+        if (filtersObj?.tags?.length) filters.tags = filtersObj.tags;
         if (filtersObj?.username?.length) filters.username = filtersObj.username;
         const res = await api.fetchUsersAndDevicesSummary({
             groupBy: isUsersTab ? "user" : "device",
             skip, limit, sortKey: mappedSortKey, sortOrder: mongoSortOrder, queryValue, filters,
             trafficMap, riskScoreMap, sensitiveMap, usernameMap, userMetadataMap,
+            tagsByUsername: tagsByUsernameFor(userMetadataMap),
         });
         const prettified = prettifyRows(res.rows || []);
         lastRowsRef.current = prettified;
         return { value: prettified, total: res.total || 0 };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isUsersTab, prettifyRows]);
+    }, [isUsersTab, prettifyRows, tagsByUsernameFor]);
 
     const headers = useMemo(() => {
         const h = getHeaders({
@@ -209,14 +247,13 @@ function UsersAndDevices() {
     );
 
     const filtersDef = useMemo(() => (isUsersTab ? [
-        { key: "team", label: "Team", choices: (stats.teams || []).map((t) => ({ label: t, value: t })) },
-        { key: "userRole", label: "User role", choices: (stats.roles || []).map((r) => ({ label: r, value: r })) },
+        { key: "tags", label: "Tags", choices: (stats.tagKeys || []).map((t) => ({ label: t, value: t })) },
     ] : [
-        // Devices tab has no Team/User role columns (includeUserColumns=false above), but each row's
-        // owner username is already resolved server-side (HostGroupSummary.username) — filterable even
+        // Devices tab has no Tags column (includeUserColumns=false above), but each row's owner
+        // username is already resolved server-side (HostGroupSummary.username) — filterable even
         // without a dedicated visible column, same as searching by it already implicitly works via groupName.
         { key: "username", label: "User", choices: (stats.usernames || []).map((u) => ({ label: u, value: u })) },
-    ]), [isUsersTab, stats.teams, stats.roles, stats.usernames]);
+    ]), [isUsersTab, stats.tagKeys, stats.usernames]);
 
     const disambiguateLabel = useCallback((key, value) => func.convertToDisambiguateLabelObj(value, null, 2), []);
 
@@ -242,45 +279,123 @@ function UsersAndDevices() {
     }, [filtersMap, setFiltersMap, navigate, tableSelectedTab, setTableSelectedTab]);
 
     const openEditTagModal = useCallback((usernames) => {
-        const rows = lastRowsRef.current.filter((r) => usernames.includes(r.id));
-        if (!rows.length) return;
-        const first = rows[0];
-        const teamSrc = first?.teamSource || 'sso';
-        const roleSrc = first?.roleSource || 'sso';
+        if (usernames.length > 1) {
+            // Bulk mode: don't prefill from any one user's tags — they can differ across the
+            // selection, and pre-filling from just one would risk silently overwriting the rest.
+            setEditTagModal({
+                active: true,
+                usernames,
+                isBulk: true,
+                entries: [],
+                originalManualKeys: [],
+                clearAll: false,
+                newKey: '',
+                newValue: '',
+                saving: false,
+            });
+            return;
+        }
+        const firstUser = lastRowsRef.current.find((r) => usernames.includes(r.id));
+        // One row per raw tag — a key can have more than one value/source at once (e.g. a
+        // manually-set "team" alongside an Okta-synced "team"), and all of them coexist rather
+        // than one overriding the other, so all are shown.
+        const entries = (firstUser?.tags || []).map((t) => ({ key: t.key, value: t.value, source: t.source }));
         setEditTagModal({
             active: true,
-            rows,
-            team: teamSrc === 'manual' ? (first?.team || '') : '',
-            userRole: roleSrc === 'manual' ? (first?.userRole || '') : '',
-            teamSource: teamSrc,
-            roleSource: roleSrc,
-            ssoHintTeam: teamSrc === 'sso' ? (first?.team || '') : '',
-            ssoHintRole: roleSrc === 'sso' ? (first?.userRole || '') : '',
+            usernames,
+            isBulk: false,
+            entries,
+            originalManualKeys: entries.filter((e) => e.source === 'manual').map((e) => e.key),
+            clearAll: false,
+            newKey: '',
+            newValue: '',
             saving: false,
         });
     }, []);
 
     const closeEditTagModal = useCallback(() => {
-        setEditTagModal({ active: false, rows: [], team: '', userRole: '', teamSource: 'sso', roleSource: 'sso', ssoHintTeam: '', ssoHintRole: '', saving: false });
+        setEditTagModal(emptyEditTagModal);
     }, []);
+
+    // Only manual rows are ever edited/removed here — tags from any other source (e.g. Okta) are
+    // shown read-only, since this dashboard action only ever writes manual-source tags and a
+    // synced value would just be overwritten again on the next sync anyway.
+    const updateEntryValue = useCallback((key, value) => {
+        setEditTagModal((prev) => ({
+            ...prev,
+            entries: prev.entries.map((e) => (e.key === key && e.source === 'manual' ? { ...e, value } : e)),
+        }));
+    }, []);
+
+    const removeEntry = useCallback((key) => {
+        setEditTagModal((prev) => ({
+            ...prev,
+            entries: prev.entries.filter((e) => !(e.key === key && e.source === 'manual')),
+        }));
+    }, []);
+
+    const addEntry = useCallback(() => {
+        const key = editTagModal.newKey.trim().toLowerCase();
+        const value = editTagModal.newValue.trim();
+        if (!key) {
+            func.setToast(true, true, "Device tag key cannot be empty");
+            return;
+        }
+        // Only checked against other manual rows — a manual value is allowed alongside an
+        // existing non-manual value for the same key, they simply coexist.
+        if (editTagModal.entries.some((e) => e.key === key && e.source === 'manual')) {
+            func.setToast(true, true, "This device tag key already has a manual value in the list below.");
+            return;
+        }
+        setEditTagModal((prev) => ({
+            ...prev,
+            entries: [...prev.entries, { key, value, source: 'manual' }],
+            newKey: '',
+            newValue: '',
+        }));
+    }, [editTagModal.newKey, editTagModal.newValue, editTagModal.entries]);
 
     const saveEditTag = useCallback(async () => {
         setEditTagModal((prev) => ({ ...prev, saving: true }));
         try {
-            const groupNames = editTagModal.rows.map((r) => r.groupName).filter(Boolean);
-            await settingRequests.bulkUpdateUserDeviceTag(groupNames, editTagModal.team, editTagModal.userRole);
-            func.setToast(true, false, "Team and role updated successfully");
+            const selectedRows = lastRowsRef.current.filter((r) => editTagModal.usernames.includes(r.id));
+            const groupNames = selectedRows.map((r) => r.groupName).filter(Boolean);
+
+            // Only manual rows are ever sent — this action only writes the "manual" source, never
+            // touching tags synced in from elsewhere. Empty value = explicit clear. Manual keys
+            // removed from the original prefill are also sent as an explicit clear, so "remove"
+            // actually un-pins the manual override instead of just hiding it locally; a same-key
+            // tag from another source (if any) is untouched either way.
+            const manualEntries = editTagModal.entries.filter((e) => e.source === 'manual');
+            const tags = {};
+            manualEntries.forEach((e) => { tags[e.key] = e.value ? [e.value] : []; });
+            if (editTagModal.isBulk) {
+                // "Clear all" in bulk mode clears every manually-set key any selected row currently
+                // has — computed from the union of their real tags, never guessed from one row's set.
+                // Tags from other sources aren't affected.
+                if (editTagModal.clearAll) {
+                    selectedRows.forEach((r) => (r.tags || []).forEach((t) => {
+                        if (t?.key && t.source === 'manual' && !(t.key in tags)) tags[t.key] = [];
+                    }));
+                }
+            } else {
+                const currentManualKeys = new Set(manualEntries.map((e) => e.key));
+                editTagModal.originalManualKeys.forEach((k) => { if (!currentManualKeys.has(k)) tags[k] = []; });
+            }
+
+            await settingRequests.bulkUpdateUserDeviceTag(groupNames, tags);
+            func.setToast(true, false, "Tags updated successfully");
             closeEditTagModal();
             setRefreshKey((k) => k + 1);
         } catch {
-            func.setToast(true, true, "Failed to update team and role");
+            func.setToast(true, true, "Failed to update tags");
             setEditTagModal((prev) => ({ ...prev, saving: false }));
         }
     }, [editTagModal, closeEditTagModal]);
 
     const promotedBulkActions = useCallback((selectedIds) => {
         if (!isUsersTab) return [];
-        return [{ content: 'Edit team & role', onAction: () => openEditTagModal(selectedIds) }];
+        return [{ content: 'Edit device tags', onAction: () => openEditTagModal(selectedIds) }];
     }, [isUsersTab, openEditTagModal]);
 
     const summaryItems = useMemo(() => [
@@ -329,67 +444,99 @@ function UsersAndDevices() {
         );
     }
 
+    const hasNonManualEntry = editTagModal.entries.some((e) => e.source && e.source !== 'manual');
+
     const editTagModalComp = (
         <Modal
             open={editTagModal.active}
             onClose={closeEditTagModal}
-            title={`Edit team & role — ${editTagModal.rows.length > 1 ? `${editTagModal.rows.length} users` : (editTagModal.rows[0]?.groupName || '')}`}
+            title={`Edit device tags — ${editTagModal.usernames?.length > 1 ? `${editTagModal.usernames.length} users` : (lastRowsRef.current.find((r) => editTagModal.usernames?.[0] === r.id)?.groupName || '')}`}
             primaryAction={{ content: 'Save', onAction: saveEditTag, loading: editTagModal.saving }}
             secondaryActions={[{ content: 'Cancel', onAction: closeEditTagModal }]}
         >
             <Modal.Section>
                 <VerticalStack gap="4">
-                    {(editTagModal.teamSource === 'sso' || editTagModal.roleSource === 'sso') && (
+                    {editTagModal.isBulk ? (
                         <Banner tone="info">
                             <Text variant="bodySm">
-                                {editTagModal.teamSource === 'sso' && editTagModal.roleSource === 'sso'
-                                    ? 'Team and role are currently managed by SSO. Saving will override SSO values and pin them to your manual entries.'
-                                    : editTagModal.teamSource === 'sso'
-                                        ? 'Team is currently managed by SSO. Saving will override the SSO value and pin it to your manual entry.'
-                                        : 'Role is currently managed by SSO. Saving will override the SSO value and pin it to your manual entry.'
-                                }
+                                Editing {editTagModal.usernames.length} users at once — their existing tags may differ, so they aren't shown here. A tag you add below is applied to all of them; use "Clear all" to remove every manually-set device tag from all of them instead.
+                            </Text>
+                        </Banner>
+                    ) : hasNonManualEntry && (
+                        <Banner tone="info">
+                            <Text variant="bodySm">
+                                Tags synced from elsewhere (e.g. Okta) are shown for reference and can't be edited here — they're managed at the source and will reappear on the next sync. A manual tag can coexist with one of these on the same key; both apply.
                             </Text>
                         </Banner>
                     )}
                     <FormLayout>
-                        <Autocomplete
-                            options={(() => {
-                                const query = (editTagModal.team || '').toLowerCase();
-                                const all = stats.teams || [];
-                                return (query ? all.filter(t => t.toLowerCase().includes(query)) : all).map(t => ({ label: t, value: t }));
-                            })()}
-                            selected={editTagModal.team ? [editTagModal.team] : []}
-                            onSelect={(sel) => setEditTagModal((prev) => ({ ...prev, team: sel[0] || '' }))}
-                            textField={
-                                <Autocomplete.TextField
-                                    label="Team"
-                                    value={editTagModal.team}
-                                    onChange={(v) => setEditTagModal((prev) => ({ ...prev, team: v }))}
-                                    placeholder={editTagModal.teamSource === 'sso' && editTagModal.ssoHintTeam ? `SSO: ${editTagModal.ssoHintTeam}` : 'e.g. Backend, DevOps'}
-                                    autoComplete="off"
-                                    helpText={editTagModal.teamSource === 'manual' ? 'Clear this field to fall back to SSO value.' : undefined}
-                                />
-                            }
-                        />
-                        <Autocomplete
-                            options={(() => {
-                                const query = (editTagModal.userRole || '').toLowerCase();
-                                const all = stats.roles || [];
-                                return (query ? all.filter(r => r.toLowerCase().includes(query)) : all).map(r => ({ label: r, value: r }));
-                            })()}
-                            selected={editTagModal.userRole ? [editTagModal.userRole] : []}
-                            onSelect={(sel) => setEditTagModal((prev) => ({ ...prev, userRole: sel[0] || '' }))}
-                            textField={
-                                <Autocomplete.TextField
-                                    label="User role"
-                                    value={editTagModal.userRole}
-                                    onChange={(v) => setEditTagModal((prev) => ({ ...prev, userRole: v }))}
-                                    placeholder={editTagModal.roleSource === 'sso' && editTagModal.ssoHintRole ? `SSO: ${editTagModal.ssoHintRole}` : 'e.g. Engineer, Architect'}
-                                    autoComplete="off"
-                                    helpText={editTagModal.roleSource === 'manual' ? 'Clear this field to fall back to SSO value.' : undefined}
-                                />
-                            }
-                        />
+                        <VerticalStack gap="2">
+                            <Text variant="headingSm">Existing tags</Text>
+                            {editTagModal.entries.length === 0 ? (
+                                <Text variant="bodySm" color="subdued">
+                                    {editTagModal.isBulk ? "Not shown for multiple users — see note above." : "No device tags yet."}
+                                </Text>
+                            ) : (
+                                editTagModal.entries.map((entry, idx) => {
+                                    const isManual = entry.source === 'manual';
+                                    return (
+                                        <HorizontalStack key={`${entry.key}|${entry.source}|${idx}`} gap="2" blockAlign="center" wrap={false}>
+                                            <Box width="100px">
+                                                <Text variant="bodyMd" fontWeight="medium" truncate>{entry.key}</Text>
+                                            </Box>
+                                            <Box minWidth="0" width="100%">
+                                                <TextField
+                                                    label={entry.key}
+                                                    labelHidden
+                                                    value={entry.value}
+                                                    onChange={isManual ? (v) => updateEntryValue(entry.key, v) : () => {}}
+                                                    disabled={!isManual}
+                                                    autoComplete="off"
+                                                />
+                                            </Box>
+                                            <Box minWidth="72px">
+                                                {isManual ? (
+                                                    <Button plain destructive icon={DeleteMinor} onClick={() => removeEntry(entry.key)} accessibilityLabel={`Remove ${entry.key}`} />
+                                                ) : (
+                                                    <Badge size="small">{entry.source}</Badge>
+                                                )}
+                                            </Box>
+                                        </HorizontalStack>
+                                    );
+                                })
+                            )}
+                        </VerticalStack>
+                        <Divider />
+                        <VerticalStack gap="2">
+                            <Text variant="headingSm">Add a tag</Text>
+                            <HorizontalStack gap="2" blockAlign="end" wrap={false}>
+                                <Box minWidth="0" width="100%">
+                                    <TextField
+                                        label="Key"
+                                        placeholder="e.g. department"
+                                        value={editTagModal.newKey}
+                                        onChange={(v) => setEditTagModal((prev) => ({ ...prev, newKey: v }))}
+                                        autoComplete="off"
+                                    />
+                                </Box>
+                                <Box minWidth="0" width="100%">
+                                    <TextField
+                                        label="Value"
+                                        value={editTagModal.newValue}
+                                        onChange={(v) => setEditTagModal((prev) => ({ ...prev, newValue: v }))}
+                                        autoComplete="off"
+                                    />
+                                </Box>
+                                <Box paddingBlockStart="6"><Button onClick={addEntry}>Add</Button></Box>
+                            </HorizontalStack>
+                        </VerticalStack>
+                        {editTagModal.isBulk && (
+                            <Checkbox
+                                label={`Clear all manually-set device tags for these ${editTagModal.usernames.length} users`}
+                                checked={editTagModal.clearAll}
+                                onChange={(checked) => setEditTagModal((prev) => ({ ...prev, clearAll: checked }))}
+                            />
+                        )}
                     </FormLayout>
                 </VerticalStack>
             </Modal.Section>

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/agenticPageBuilders.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/agenticPageBuilders.js
@@ -351,13 +351,16 @@ export function buildModuleDeviceMap(moduleInfos = []) {
         const ad = module.additionalData || {};
         map[module.name] = {
             username: ad.username || ad.userName || ad.user || ad.email || "-",
-            team: ad.team || "",
-            role: ad.userRole || "",
             os: ad.os || null,
             browserName: ad.browserName || null,
         };
     });
     return map;
+}
+
+function tagsForUsername(username, userMetadataMap) {
+    if (!username || username === "-") return [];
+    return userMetadataMap[username]?.tags || [];
 }
 
 /**
@@ -499,7 +502,7 @@ export function buildDeviceEndpointsPageData(
     collections,
     trafficMap = {},
     riskScoreMap = {},
-    { moduleInfos = [], usernameMap = {}, violationsByCollectionId = {}, violationRows = [], startTimestamp = 0, endTimestamp = 0 } = {},
+    { moduleInfos = [], usernameMap = {}, userMetadataMap = {}, violationsByCollectionId = {}, violationRows = [], startTimestamp = 0, endTimestamp = 0 } = {},
 ) {
     const agenticCollections = collections.filter((c) => !c.deactivated);
     const deviceModules = buildModuleDeviceMap(moduleInfos);
@@ -530,8 +533,7 @@ export function buildDeviceEndpointsPageData(
                 // Reported directly by the browser extension itself (module_info.additionalData.browserName).
                 browserName: mod.browserName || null,
                 username,
-                team: mod.team || "",
-                role: mod.role || "",
+                tags: tagsForUsername(username, userMetadataMap),
                 maxRisk: 0,
                 maxTraffic: 0,
                 hasPersonalAccount: false,
@@ -589,8 +591,6 @@ export function buildDeviceEndpointsPageData(
             const mod = deviceModules[devId];
             const device = deviceMap[devId];
             if (!device.os) device.os = mod.os || null;
-            if (!device.team) device.team = mod.team || "";
-            if (!device.role) device.role = mod.role || "";
         }
     });
 
@@ -607,8 +607,7 @@ export function buildDeviceEndpointsPageData(
             userCount: 1,
             riskScore: Math.round(device.maxRisk * 10) / 10,
             username: device.username,
-            group: device.team,
-            role: device.role,
+            tags: device.tags,
             violations: { ...device.violations },
             lastTraffic: device.maxTraffic > 0 ? func.prettifyEpoch(device.maxTraffic) : "-",
             lastTrafficEpoch: device.maxTraffic || 0,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -107,28 +107,18 @@ export const getHeaders = (options = {}) => {
             mergeType: (a, b) => Math.max(a || 0, b || 0),
             shouldMerge: true
         },
-        ...(includeUserColumns ? [
-            {
-                title: "Team",
-                text: "Team",
-                value: "team",
-                filterKey: "team",
-                textValue: "team",
-                isText: CellType.TEXT,
-                showFilter: true,
-                boxWidth: "120px",
-            },
-            {
-                title: "User role",
-                text: "User role",
-                value: "userRole",
-                filterKey: "userRole",
-                textValue: "userRole",
-                isText: CellType.TEXT,
-                showFilter: true,
-                boxWidth: "120px",
-            },
-        ] : []),
+        // Single compact column for all device tags (group, role, team, department, ...)
+        // instead of one column per key — value is prebuilt badge JSX (see
+        // UsersAndDevices.jsx buildTagsDisplay), same idiom as riskScoreComp/sensitiveSubTypes.
+        // Filterable on the raw "key=value" strings (tagFilterValues), not the display JSX.
+        ...(includeUserColumns ? [{
+            title: "Tags",
+            text: "Tags",
+            value: "tagsDisplay",
+            filterKey: "tagFilterValues",
+            showFilter: true,
+            boxWidth: "220px",
+        }] : []),
     ];
     if (!includeIconColumn) {
         return headers.filter((h) => h.value !== "iconComp");
@@ -593,6 +583,14 @@ const accumulateHostGroupedCollection = (group, c, trafficMap, sensitiveMap, ris
     }
 };
 
+// Filterable keys for a device-tag list — filtering is by tag key only ("group" matches
+// any device with a group tag, regardless of value).
+export const buildTagFilterValues = (tags) => {
+    const keys = new Set();
+    (tags || []).forEach((t) => { if (t?.key) keys.add(t.key); });
+    return Array.from(keys);
+};
+
 const finalizeHostGroupedRow = (g, idSegment) => {
     const clientTypeStr = g.clientTypes.size > 0 ? [...g.clientTypes].sort().join(", ") : "-";
     return {
@@ -611,13 +609,11 @@ const finalizeHostGroupedRow = (g, idSegment) => {
         detectedTimestamp: g.maxTrafficTimestamp,
         lastTraffic: func.prettifyEpoch(g.maxTrafficTimestamp),
         riskScore: g.maxRiskScore,
-        team: g.team || '',
-        userRole: g.userRole || '',
         hasPersonalAccount: g.hasPersonalAccount || false,
         hasLocalMcpServer: g.hasLocalMcpServer || false,
         hasMisconfiguredConfig: g.hasMisconfiguredConfig || false,
-        teamSource: g.teamSource || 'sso',
-        roleSource: g.roleSource || 'sso',
+        tags: g.tags || [],
+        tagFilterValues: buildTagFilterValues(g.tags),
     };
 };
 
@@ -685,10 +681,7 @@ export const groupCollectionsByUser = (collections, trafficMap = {}, sensitiveMa
                 maxRiskScore: 0,
                 uniqueSkillNames: new Set(),
                 nonSkillCollectionsCount: 0,
-                team: meta.team || '',
-                userRole: meta.userRole || '',
-                teamSource: meta.teamSource || 'sso',
-                roleSource: meta.roleSource || 'sso',
+                tags: meta.tags || [],
             };
         }
         const g = users[username];
@@ -763,28 +756,6 @@ function violationsForCollections(collectionIds, violationsByCollectionId) {
     return total > 0 ? merged : null;
 }
 
-// Collections belong to several overlapping groups at once (a collection with N skill tags is a
-// member of N skill groups, plus its owning service/agent/llm group), so buildAgenticAssetsPageData
-// processes the same collection many more times than there are collections. deviceId/serviceName/
-// resolvedUsername only depend on the collection itself, not on which group is asking — precomputing
-// them once per collection (see precomputeCollectionInfo) and passing the lookup map in here turns
-// that repeated per-membership cost back into a per-collection one.
-function buildTeamGroupsForAsset(group, userMetadataMap, collectionInfoMap) {
-    const teamCounts = {};
-    const seenDevices = new Set();
-    (group.collections || []).forEach((c) => {
-        const info = collectionInfoMap.get(c.id);
-        if (!info?.deviceId || seenDevices.has(info.deviceId)) return;
-        seenDevices.add(info.deviceId);
-        const username = info.resolvedUsername;
-        if (!username || username === DEFAULT_VALUE) return;
-        const team = userMetadataMap[username]?.team;
-        if (!team) return;
-        teamCounts[team] = (teamCounts[team] || 0) + 1;
-    });
-    return Object.entries(teamCounts).map(([name, count]) => ({ name, count }));
-}
-
 function finalizeDevices(byDevice) {
     // round to 1 dp and null out zero scores (no data)
     return [...byDevice.values()].map(d => ({
@@ -796,7 +767,7 @@ function finalizeDevices(byDevice) {
 }
 
 // One pass over every collection (not every group-membership) to compute the per-collection values
-// buildTeamGroupsForAsset/buildDevicesForGroup need — see the comment above buildTeamGroupsForAsset.
+// buildDevicesForGroup needs, turning a repeated per-membership cost into a per-collection one.
 function precomputeCollectionInfo(collections, usernameMap) {
     const map = new Map();
     collections.forEach((c) => {
@@ -1076,7 +1047,7 @@ export async function buildAgenticAssetsPageData(
     const agenticFlatData = [];
     const assetDevices = {};
 
-    // buildGroupAggregates/buildTeamGroupsForAsset touch every (collection, group-membership) pair —
+    // buildGroupAggregates touches every (collection, group-membership) pair —
     // at real scale that's ~1.5-2M pairs, tens of seconds of synchronous work (see the comment on
     // buildGroupAggregates). Running the whole loop in one synchronous stretch blocks the main thread
     // solid for that entire time — the page looks and IS frozen. Yielding via a zero-delay setTimeout
@@ -1096,22 +1067,21 @@ export async function buildAgenticAssetsPageData(
         const group = allGroups[__i];
         const collectionIds = (group.collections || []).map((c) => c.id);
         const cachedPerGroup = reuse ? groupsCache.perGroup.get(group.id) : null;
-        let violations, groups;
+        let violations;
         if (cachedPerGroup) {
-            ({ violations, teamGroups: groups } = cachedPerGroup);
+            ({ violations } = cachedPerGroup);
         } else {
             // Skills are capability manifest entries — violations belong to the agent/service
             // collection that declares them, not to the skill itself. Suppress to avoid
             // double-counting.
             violations = violationsForCollections(collectionIds, violationsByCollectionId);
-            groups = buildTeamGroupsForAsset(group, userMetadataMap, collectionInfoMap);
         }
         const { devices, skillNames, aiInteractions } = buildGroupAggregates(
             group, riskScoreMap, trafficMap, collectionInfoMap, analysisByKey, userAnalysisKeysByDeviceId,
             cachedPerGroup ? { devices: cachedPerGroup.devices, skillNames: cachedPerGroup.skillNames } : null,
         );
         if (groupsCache && !reuse) {
-            groupsCache.perGroup.set(group.id, { violations, teamGroups: groups, devices, skillNames });
+            groupsCache.perGroup.set(group.id, { violations, devices, skillNames });
         }
         const riskScore = group.riskScore ?? group.maxRiskScore ?? null;
         const lastSeen = group.detectedTimestamp || 0;
@@ -1140,7 +1110,6 @@ export async function buildAgenticAssetsPageData(
             };
         }
         if (violations) treeRow.violations = violations;
-        if (groups.length) treeRow.groups = groups;
         if (skillNames.size) treeRow.skillCount = skillNames.size;
 
         const flatRow = {
@@ -1162,7 +1131,6 @@ export async function buildAgenticAssetsPageData(
             hasMisconfiguredConfig: group.hasMisconfiguredConfig || false,
         };
         if (violations) flatRow.violations = violations;
-        if (groups.length) flatRow.groups = groups;
         if (aiInteractions) {
             flatRow.aiInteractions = aiInteractions.total;
             flatRow.aiInteractionsDetail = {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -19,12 +19,13 @@ import {
     getClientTagVariants,
     resolveClientKey,
 } from "./mcpClientHelper";
-export { CLIENT_TAG_ALIASES, getClientTagVariants, resolveClientKey };
 import func from "@/util/func";
 import {
     getResolvedUsernameForCollection,
     DEFAULT_VALUE,
 } from "../api_collections/endpointShieldHelper";
+
+export { CLIENT_TAG_ALIASES, getClientTagVariants, resolveClientKey };
 
 // Table constants
 export const PAGE_LIMIT = 100;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/constants.js
@@ -849,28 +849,12 @@ export function getRowViolations(collectionIds, violationsByCollectionId) {
     return violationsForCollections(collectionIds, violationsByCollectionId);
 }
 
-// Team breakdown for a server-computed row's device list. Deliberately lighter than
-// buildTeamGroupsForAsset (used by the legacy/agent-group client pipeline): the server's `devices`
-// list only carries deviceId (not full collection objects), so username resolution here uses only
-// the Endpoint Shield deviceId-keyed lookup tier, not the displayName/name-based fallback tiers
-// getResolvedUsernameForCollection also tries. Documented tradeoff, not an oversight.
-export function buildTeamGroupsFromDevices(devices, usernameMap, userMetadataMap) {
-    const teamCounts = {};
-    (devices || []).forEach((d) => {
-        const key = `__deviceId__${String(d.deviceId).toLowerCase()}`;
-        const username = usernameMap?.[key];
-        if (!username || username === DEFAULT_VALUE) return;
-        const team = userMetadataMap[username]?.team;
-        if (!team) return;
-        teamCounts[team] = (teamCounts[team] || 0) + 1;
-    });
-    return Object.entries(teamCounts).map(([name, count]) => ({ name, count }));
-}
-
 // Fills in the two display fields the flyout's Devices tab (AgenticAssetFlyout.jsx's DevicesTab,
 // unchanged since master) reads straight off each device row — username and a formatted lastSeen
-// string — which AgenticObserveAction.buildDevicesForGroup/DeviceAcc don't send back, same
-// deviceId-keyed lookup tier tradeoff as buildTeamGroupsFromDevices above.
+// string — which AgenticObserveAction.buildDevicesForGroup/DeviceAcc don't send back. The server's
+// `devices` list only carries deviceId (not full collection objects), so username resolution here
+// uses only the Endpoint Shield deviceId-keyed lookup tier, not the displayName/name-based fallback
+// tiers getResolvedUsernameForCollection also tries. Documented tradeoff, not an oversight.
 export function enrichDevicesWithUsername(devices, usernameMap) {
     return (devices || []).map((d) => {
         const key = `__deviceId__${String(d.deviceId).toLowerCase()}`;
@@ -885,7 +869,7 @@ export function enrichDevicesWithUsername(devices, usernameMap) {
 }
 
 // AI-interaction tally for a server-computed row's device list — same tradeoff as
-// buildTeamGroupsFromDevices: only the Endpoint Shield deviceId mapping (the primary,
+// enrichDevicesWithUsername above: only the Endpoint Shield deviceId mapping (the primary,
 // highest-coverage match tier), not the hostname-parts-based fallback tiers
 // analysisKeysForCollection also tries, which need per-collection hostnames the server doesn't send
 // back for these rows.

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api.js
@@ -359,39 +359,38 @@ export default {
     },
     // Paginated, sorted, searchable user/device rows for Users-and-Devices / Endpoints — same
     // lightweight-summary-first-then-slice shape as fetchAgenticAssetsSummary. groupBy: "user"|"device".
-    async fetchUsersAndDevicesSummary({ groupBy, skip, limit, sortKey, sortOrder, queryValue, filters, trafficMap, riskScoreMap, sensitiveMap, usernameMap, userMetadataMap } = {}) {
+    async fetchUsersAndDevicesSummary({ groupBy, skip, limit, sortKey, sortOrder, queryValue, filters, trafficMap, riskScoreMap, sensitiveMap, usernameMap, userMetadataMap, tagsByUsername } = {}) {
         const resp = await request({
             url: '/api/fetchUsersAndDevicesSummary',
             method: 'post',
-            data: { groupBy, skip, limit, sortKey, sortOrder, queryValue, filters, trafficMap, riskScoreMap, sensitiveMap, usernameMap, userMetadataMap },
+            data: { groupBy, skip, limit, sortKey, sortOrder, queryValue, filters, trafficMap, riskScoreMap, sensitiveMap, usernameMap, userMetadataMap, tagsByUsername },
         })
         return { rows: resp?.rows || [], total: resp?.total || 0 }
     },
     // Tab-header counts ("Users (N)" / "Devices (N)") for Users-and-Devices / Endpoints, each tab's
-    // "Agentic assets" total, plus distinct team/role names for the "Edit team & role" modal's autocomplete.
-    async fetchUsersAndDevicesStats({ trafficMap, riskScoreMap, usernameMap, userMetadataMap } = {}) {
+    // "Agentic assets" total, plus distinct device-tag keys for the Tags filter/"Edit device tags" modal.
+    async fetchUsersAndDevicesStats({ trafficMap, riskScoreMap, usernameMap, userMetadataMap, tagsByUsername } = {}) {
         const resp = await request({
             url: '/api/fetchUsersAndDevicesStats',
             method: 'post',
-            data: { trafficMap, riskScoreMap, usernameMap, userMetadataMap },
+            data: { trafficMap, riskScoreMap, usernameMap, userMetadataMap, tagsByUsername },
         })
         return {
             usersCount: resp?.usersCount || 0,
             devicesCount: resp?.devicesCount || 0,
             usersAgenticAssetsTotal: resp?.usersAgenticAssetsTotal || 0,
             devicesAgenticAssetsTotal: resp?.devicesAgenticAssetsTotal || 0,
-            teams: resp?.teams || [],
-            roles: resp?.roles || [],
             usernames: resp?.usernames || [],
+            tagKeys: resp?.tagKeys || [],
         }
     },
     // Paginated top-level device rows for Endpoints' tree grid, or (when parentDeviceId is set) one
     // device's (device,service) children — see AgenticObserveAction.fetchDeviceEndpointsSummary.
-    async fetchDeviceEndpointsSummary({ parentDeviceId, skip, limit, sortKey, sortOrder, queryValue, trafficMap, riskScoreMap, usernameMap, deviceMetadataMap, violationsByCollectionId, filters } = {}) {
+    async fetchDeviceEndpointsSummary({ parentDeviceId, skip, limit, sortKey, sortOrder, queryValue, trafficMap, riskScoreMap, usernameMap, deviceMetadataMap, violationsByCollectionId, filters, tagsByUsername } = {}) {
         const resp = await request({
             url: '/api/fetchDeviceEndpointsSummary',
             method: 'post',
-            data: { parentDeviceId, skip, limit, sortKey, sortOrder, queryValue, trafficMap, riskScoreMap, usernameMap, deviceMetadataMap, violationsByCollectionId, filters },
+            data: { parentDeviceId, skip, limit, sortKey, sortOrder, queryValue, trafficMap, riskScoreMap, usernameMap, deviceMetadataMap, violationsByCollectionId, filters, tagsByUsername },
         })
         return { rows: resp?.rows || [], total: resp?.total || 0 }
     },

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/endpointShieldHelper.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/endpointShieldHelper.js
@@ -108,9 +108,12 @@ let _shieldMetaCache = { ts: 0, data: null };
 let _shieldMetaInflight = null;
 const SHIELD_META_TTL_MS = 3000;
 
-const fetchEndpointShieldUserMetadata = async () => {
+// force=true bypasses the TTL cache (but still joins an in-flight fetch rather than firing a
+// second one) — used right after writing a device tag, where the caller needs the just-saved
+// value back immediately rather than whatever was cached before the write.
+const fetchEndpointShieldUserMetadata = async (force = false) => {
     const now = Date.now();
-    if (_shieldMetaCache.data && now - _shieldMetaCache.ts <= SHIELD_META_TTL_MS) return _shieldMetaCache.data;
+    if (!force && _shieldMetaCache.data && now - _shieldMetaCache.ts <= SHIELD_META_TTL_MS) return _shieldMetaCache.data;
     if (_shieldMetaInflight) return _shieldMetaInflight;
 
     _shieldMetaInflight = (async () => {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/endpointShieldHelper.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/endpointShieldHelper.js
@@ -124,16 +124,15 @@ const fetchEndpointShieldUserMetadata = async () => {
             const usernameMap = buildUsernameMapFromModuleInfos(moduleInfos);
             const userAnalysisKeysByDeviceId = buildUserAnalysisKeysByDeviceId(moduleInfos);
 
+            // Generic key-value device tags (team/role/department/arbitrary Okta groups, ...)
+            // replace the old dedicated teamName/userRole/teamSource/roleSource fields.
             const userMetadataMap = {};
             const agenticUsers = agenticUsersResp?.agenticUsers || [];
             agenticUsers.forEach((u) => {
                 if (!u?.userName) return;
                 userMetadataMap[u.userName] = {
-                    team: u.teamName || '',
-                    userRole: u.userRole || '',
                     userEmail: u.userEmail || '',
-                    teamSource: u.teamSource || 'sso',
-                    roleSource: u.roleSource || 'sso',
+                    tags: u.deviceTags || [],
                 };
             });
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
@@ -406,7 +406,10 @@ const settingRequests = {
     },
 
     saveOktaGroupRoleMapping(oktaGroupToAktoUserRoleMap, opts = {}) {
-        const data = { oktaGroupToAktoUserRoleMap }
+        const data = {
+            oktaGroupToAktoUserRoleMap,
+            syncGroupsToUserTags: opts.syncGroupsToUserTags === true,
+        }
         if (Object.prototype.hasOwnProperty.call(opts, 'managementApiToken')) {
             const t = opts.managementApiToken
             // Struts cannot distinguish JSON null from omitted String fields; send "" to mean "clear stored token".
@@ -905,18 +908,19 @@ const settingRequests = {
             data: { moduleIds }
         })
     },
-    async updateUserDeviceTag(username, team, userRole) {
+    /** tags: { [key]: string[] } — only the keys present are touched; other tags are left alone. */
+    async updateUserDeviceTag(username, tags) {
         return await request({
             url: '/api/updateUserDeviceTag',
             method: 'post',
-            data: { username, team, userRole }
+            data: { username, tags }
         })
     },
-    async bulkUpdateUserDeviceTag(usernames, team, userRole) {
+    async bulkUpdateUserDeviceTag(usernames, tags) {
         return await request({
             url: '/api/bulkUpdateUserDeviceTag',
             method: 'post',
-            data: { usernames, team, userRole }
+            data: { usernames, tags }
         })
     },
     async fetchAgenticUsers(params = {}) {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/integrations/OktaIntegration.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/integrations/OktaIntegration.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import CopyCommand from '../../../components/shared/CopyCommand';
 import IntegrationsLayout from './IntegrationsLayout';
-import { Autocomplete, Badge, Box, Button, Divider, Form, FormLayout, HorizontalStack, LegacyCard, Link, Text, TextField, VerticalStack } from '@shopify/polaris';
+import { Autocomplete, Badge, Box, Button, Checkbox, Divider, Form, FormLayout, HorizontalStack, LegacyCard, Link, Text, TextField, VerticalStack } from '@shopify/polaris';
 import { DeleteMinor, EditMinor, PlusMinor } from '@shopify/polaris-icons';
 import func from "@/util/func"
 import settingRequests from '../api';
@@ -52,6 +52,10 @@ function OktaIntegration() {
     /** Text shown in Akto role Autocomplete (matches Okta group name field UX). */
     const [aktoRoleText, setAktoRoleText] = useState('')
     const [savedOktaGroupToAktoUserRoleMap, setSavedOktaGroupToAktoUserRoleMap] = useState({})
+
+    /** Master on/off switch for the background sync that writes Okta groups into device tags for
+     * every org user. Disabled until a Management API token exists, since the sync needs one. */
+    const [syncGroupsToUserTags, setSyncGroupsToUserTags] = useState(false)
     /** Fetched from Okta Management API (all groups) when Edit + API token; used to autosuggest group name. */
     const [oktaGroupNames, setOktaGroupNames] = useState([])
     const [loadingOktaGroups, setLoadingOktaGroups] = useState(false)
@@ -137,6 +141,7 @@ function OktaIntegration() {
                 const grpMap = resp.oktaGroupToAktoUserRoleMap || {}
                 setOktaGroupToAktoUserRoleMap(grpMap)
                 setSavedOktaGroupToAktoUserRoleMap(grpMap)
+                setSyncGroupsToUserTags(resp.syncGroupsToUserTags === true)
                 setComponentType(2)
             }
         } catch {
@@ -183,20 +188,21 @@ function OktaIntegration() {
         try {
             let toastMsg = 'Group mappings saved successfully!'
             let resp
+            const baseOpts = { syncGroupsToUserTags }
             if (!hasSavedManagementToken) {
                 const t = editApiToken.trim()
                 resp = await settingRequests.saveOktaGroupRoleMapping(
                     oktaGroupToAktoUserRoleMap,
-                    t ? { managementApiToken: t } : {}
+                    t ? { ...baseOpts, managementApiToken: t } : baseOpts
                 )
                 if (t) toastMsg = 'Group mappings and API token saved.'
             } else {
                 const trimmed = editApiToken.trim()
                 if (trimmed === '') {
-                    resp = await settingRequests.saveOktaGroupRoleMapping(oktaGroupToAktoUserRoleMap, { managementApiToken: null })
+                    resp = await settingRequests.saveOktaGroupRoleMapping(oktaGroupToAktoUserRoleMap, { ...baseOpts, managementApiToken: null })
                     toastMsg = 'Group mappings saved. Management API token removed.'
                 } else {
-                    resp = await settingRequests.saveOktaGroupRoleMapping(oktaGroupToAktoUserRoleMap, { managementApiToken: trimmed })
+                    resp = await settingRequests.saveOktaGroupRoleMapping(oktaGroupToAktoUserRoleMap, { ...baseOpts, managementApiToken: trimmed })
                     const unchangedMask = managementApiTokenMasked != null && trimmed === String(managementApiTokenMasked).trim()
                     toastMsg = unchangedMask
                         ? 'Group mappings saved successfully!'
@@ -270,7 +276,15 @@ function OktaIntegration() {
 
     useEffect(() => { fetchData() }, [])
 
+    // Clearing the API token mid-edit must turn group sync back off — it cannot run without one.
+    useEffect(() => {
+        if (editApiToken.trim() === '' && syncGroupsToUserTags) {
+            setSyncGroupsToUserTags(false)
+        }
+    }, [editApiToken])
+
     const hasGroupMappings = Object.keys(oktaGroupToAktoUserRoleMap).length > 0
+    const tokenWillBePresentInEdit = editApiToken.trim() !== ''
 
     const mappingRows = Object.entries(oktaGroupToAktoUserRoleMap).map(([name, role], index) => (
         <React.Fragment key={name}>
@@ -321,8 +335,25 @@ function OktaIntegration() {
                 <Badge status={hasSavedManagementToken ? 'success' : 'info'}>
                     {hasSavedManagementToken ? 'Configured' : 'Not set'}
                 </Badge>
-                <Text variant="bodySm" color="subdued">Used only when the access token has no groups claim.</Text>
+                <Text variant="bodySm" color="subdued">
+                    {hasSavedManagementToken
+                        ? 'Required for the group sync setting below.'
+                        : 'Set a token to unlock the group sync setting below.'}
+                </Text>
             </HorizontalStack>
+            {hasSavedManagementToken && (
+                <HorizontalStack gap="2" blockAlign="center" wrap>
+                    <Text variant="bodySm" fontWeight="semibold" color="subdued">Sync Okta groups to device tags</Text>
+                    <Badge status={syncGroupsToUserTags ? 'success' : 'info'}>
+                        {syncGroupsToUserTags ? 'On' : 'Off'}
+                    </Badge>
+                    <Text variant="bodySm" color="subdued">
+                        {syncGroupsToUserTags
+                            ? 'Every Okta group is kept in sync as a "group" tag for every user in the background.'
+                            : 'Off — no group tags are written.'}
+                    </Text>
+                </HorizontalStack>
+            )}
         </VerticalStack>
     )
 
@@ -418,9 +449,9 @@ function OktaIntegration() {
                 <Box paddingBlockStart="6"><Button onClick={handleAddMapping}>Add</Button></Box>
             </HorizontalStack>
             <Divider />
-            <Text fontWeight="semibold" variant="headingXs">Management API token (optional)</Text>
+            <Text fontWeight="semibold" variant="headingXs">Management API token</Text>
             <Text variant="bodySm" color="subdued">
-                Akto uses groups from the access token first. If that claim is empty, a saved SSWS token loads group membership at login (Okta: Security → API → Tokens).
+                Optional (Okta: Security → API → Tokens). Required to enable group sync below.
             </Text>
             <TextField
                 label="API token"
@@ -430,7 +461,16 @@ function OktaIntegration() {
                 autoComplete="new-password"
                 name="okta-sso-management-api-token-edit"
                 placeholder={hasSavedManagementToken ? undefined : 'Paste SSWS token if needed'}
-                helpText={hasSavedManagementToken ? undefined : 'Optional. Paste SSWS token from Okta if users access tokens do not include a groups claim.'}
+                helpText={hasSavedManagementToken ? undefined : 'Paste an SSWS token from Okta to unlock group sync below.'}
+            />
+            <Checkbox
+                label="Sync Okta groups to device tags"
+                checked={syncGroupsToUserTags}
+                onChange={setSyncGroupsToUserTags}
+                disabled={!tokenWillBePresentInEdit}
+                helpText={tokenWillBePresentInEdit
+                    ? 'Every Okta group is kept in sync as a "group" tag for every user in the background.'
+                    : 'Set a Management API token above to enable this.'}
             />
             <HorizontalStack align="end" gap="2">
                 <Button onClick={handleCancelEdit}>Cancel</Button>
@@ -447,7 +487,7 @@ function OktaIntegration() {
                         <VerticalStack gap="1">
                             <Text fontWeight="semibold" variant="headingSm">Group mapping &amp; API access</Text>
                             <Text variant="bodyMd" color="subdued">
-                                Map Okta groups to Akto roles and optionally set a Management API token. Edit updates everything in one place.
+                                Map Okta groups to Akto roles and device tags, and optionally set a Management API token. Edit updates everything in one place.
                             </Text>
                         </VerticalStack>
                         {!editMode && (

--- a/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
@@ -1,137 +1,96 @@
 package com.akto.dao;
 
 import com.akto.dao.context.Context;
+import com.akto.dao.monitoring.ModuleInfoDao;
 import com.akto.dto.AgenticUsers;
+import com.akto.dto.DeviceTag;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
     public static final AgentUsersDao instance = new AgentUsersDao();
+    private static final Logger logger = LoggerFactory.getLogger(AgentUsersDao.class);
+    private static final int MAX_TAGS_PER_SOURCE = 50;
 
     public void createIndicesIfAbsent() {
-        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
-            new String[]{AgenticUsers.TEAM_NAME, AgenticUsers.USER_ROLE}, false);
-
         MCollection.createIndexIfAbsent(getDBName(), getCollName(),
             new String[]{AgenticUsers.USER_NAME}, false);
 
         MCollection.createIndexIfAbsent(getDBName(), getCollName(),
             new String[]{AgenticUsers.USER_EMAIL}, false);
+
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+            new String[]{AgenticUsers.DEVICE_TAGS + "." + DeviceTag.KEY,
+                    AgenticUsers.DEVICE_TAGS + "." + DeviceTag.VALUE}, false);
     }
 
     /**
-     * Dashboard write — overwrites team/role and pins source to "manual" only for fields
-     * whose value actually changed. Unchanged fields keep their existing source (e.g. "sso").
+     * Full replace of a source's tags with the given key→values set — deleting any key not
+     * reported, so stale groups don't linger. Correct for SSO, which always reports the
+     * identity's *complete* current group membership on every login. Wrong for a dashboard edit,
+     * which only ever touches specific fields — see mergeDeviceTags for that case.
      */
-    public void upsertTagFromDashboard(String userName, String userEmail, String teamName, String userRole, String lastUpdatedBy) {
-        if (userName == null || userName.trim().isEmpty()) return;
-        String trimmedName = userName.trim();
-        String trimmedEmail = userEmail == null ? "" : userEmail.trim();
-        AgenticUsers existing = instance.findOne(Filters.eq(AgenticUsers.USER_NAME, trimmedName));
-        String existingTeam = existing != null && existing.getTeamName() != null ? existing.getTeamName().trim() : "";
-        String existingRole = existing != null && existing.getUserRole() != null ? existing.getUserRole().trim() : "";
-
-        String newTeam = teamName == null ? "" : teamName.trim();
-        String newRole = userRole == null ? "" : userRole.trim();
-
-        List<Bson> updates = new ArrayList<>();
-        // When admin clears a field, fall back to the last SSO value immediately.
-        String effectiveTeam = newTeam;
-        String effectiveRole = newRole;
-        String teamSourceToWrite = null;
-        String roleSourceToWrite = null;
-
-        if (!newTeam.equals(existingTeam)) {
-            if (newTeam.isEmpty()) {
-                effectiveTeam = existing != null && existing.getSsoTeamName() != null ? existing.getSsoTeamName() : "";
-                teamSourceToWrite = AgenticUsers.SOURCE_SSO;
-            } else {
-                teamSourceToWrite = AgenticUsers.SOURCE_MANUAL;
-            }
-        }
-        if (!newRole.equals(existingRole)) {
-            if (newRole.isEmpty()) {
-                effectiveRole = existing != null && existing.getSsoUserRole() != null ? existing.getSsoUserRole() : "";
-                roleSourceToWrite = AgenticUsers.SOURCE_SSO;
-            } else {
-                roleSourceToWrite = AgenticUsers.SOURCE_MANUAL;
-            }
-        }
-
-        if (!trimmedEmail.isEmpty()) {
-            updates.add(Updates.set(AgenticUsers.USER_EMAIL, trimmedEmail));
-        }
-        updates.add(Updates.set(AgenticUsers.TEAM_NAME, effectiveTeam));
-        updates.add(Updates.set(AgenticUsers.USER_ROLE, effectiveRole));
-        updates.add(Updates.set(AgenticUsers.LAST_UPDATED_AT, Context.now()));
-        updates.add(Updates.set(AgenticUsers.LAST_UPDATED_BY, lastUpdatedBy));
-        if (teamSourceToWrite != null) updates.add(Updates.set(AgenticUsers.TEAM_SOURCE, teamSourceToWrite));
-        if (roleSourceToWrite != null) updates.add(Updates.set(AgenticUsers.ROLE_SOURCE, roleSourceToWrite));
-
-        if (existing == null) {
-            AgenticUsers newUser = new AgenticUsers();
-            newUser.setUserName(trimmedName);
-            if (!trimmedEmail.isEmpty()) {
-                newUser.setUserEmail(trimmedEmail);
-            }
-            newUser.setTeamName(effectiveTeam);
-            newUser.setUserRole(effectiveRole);
-            // A brand-new doc with no actual team/role value was never manually set — leave it open for SSO.
-            newUser.setTeamSource(teamSourceToWrite != null ? teamSourceToWrite
-                    : (effectiveTeam.isEmpty() ? AgenticUsers.SOURCE_SSO : AgenticUsers.SOURCE_MANUAL));
-            newUser.setRoleSource(roleSourceToWrite != null ? roleSourceToWrite
-                    : (effectiveRole.isEmpty() ? AgenticUsers.SOURCE_SSO : AgenticUsers.SOURCE_MANUAL));
-            newUser.setLastUpdatedAt(Context.now());
-            newUser.setLastUpdatedBy(lastUpdatedBy);
-            instance.insertOne(newUser);
-        } else {
-            // updateMany still covers multiple devices legitimately sharing this exact username.
-            instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, trimmedName), Updates.combine(updates));
-        }
+    public void upsertDeviceTags(String identityUserName, String source, Map<String, List<String>> keyValues, String lastUpdatedBy) {
+        writeDeviceTags(identityUserName, source, keyValues, lastUpdatedBy, t -> !source.equals(t.getSource()));
     }
 
     /**
-     * SSO write — skips team/role if pinned "manual" with a real value. Renames every matching
-     * doc onto the email-derived username so identity fragments converge over time.
+     * Only touches the keys present in keyValues — other tags from the same source are left
+     * alone. Used by the dashboard, where a single edit only ever sets specific fields, not the
+     * admin's complete tag set (unlike SSO, which always reports everything every login).
      */
-    public void upsertTagFromSso(String userName, String userEmail, String teamName, String userRole, String lastUpdatedBy) {
-        if (userName == null || userName.trim().isEmpty()) return;
-        String trimmedName = userName.trim();
-        String trimmedEmail = userEmail == null ? "" : userEmail.trim();
-        String derivedUsername = deriveUsernameFromEmail(trimmedEmail);
+    public void mergeDeviceTags(String identityUserName, String source, Map<String, List<String>> keyValues, String lastUpdatedBy) {
+        Set<String> touchedKeys = new HashSet<>();
+        for (String key : keyValues.keySet()) {
+            if (key != null && !key.trim().isEmpty()) touchedKeys.add(key.trim().toLowerCase());
+        }
+        writeDeviceTags(identityUserName, source, keyValues, lastUpdatedBy,
+                t -> !(source.equals(t.getSource()) && touchedKeys.contains(t.getKey())));
+    }
 
-        List<AgenticUsers> matches = findAllIdentityMatches(trimmedName, trimmedEmail, derivedUsername);
-        // Canonicalize on the email's local part (stable OS identifier), not the raw SSO username
-        // (often a full email) — matches get renamed to it below so fragments self-heal.
-        String identityUserName = derivedUsername != null ? derivedUsername : trimmedName;
+    private void writeDeviceTags(String identityUserName, String source, Map<String, List<String>> keyValues,
+            String lastUpdatedBy, java.util.function.Predicate<DeviceTag> keepExisting) {
+        if (identityUserName == null || identityUserName.trim().isEmpty() || source == null || source.trim().isEmpty()) return;
+        int now = Context.now();
 
-        String ssoTeam = teamName == null ? "" : teamName.trim();
-        String ssoRole = userRole == null ? "" : userRole.trim();
-
-        List<Bson> baseUpdates = Arrays.asList(
-                Updates.set(AgenticUsers.USER_NAME, identityUserName),
-                Updates.set(AgenticUsers.USER_EMAIL, trimmedEmail),
-                Updates.set(AgenticUsers.LAST_UPDATED_AT, Context.now()),
-                Updates.set(AgenticUsers.LAST_UPDATED_BY, lastUpdatedBy));
-        if (matches.isEmpty()) {
-            // First-ever login for this identity — nothing to updateMany yet, so upsert the doc.
-            instance.updateOne(Filters.eq(AgenticUsers.USER_NAME, identityUserName), Updates.combine(baseUpdates));
-        } else {
-            // Rename every matched doc onto the canonical identity.
-            List<String> matchedUsernames = matches.stream().map(AgenticUsers::getUserName).distinct().collect(Collectors.toList());
-            instance.updateMany(Filters.in(AgenticUsers.USER_NAME, matchedUsernames), Updates.combine(baseUpdates));
+        List<DeviceTag> newTags = new ArrayList<>();
+        outer:
+        for (Map.Entry<String, List<String>> entry : keyValues.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || key.trim().isEmpty() || entry.getValue() == null) continue;
+            for (String rawValue : entry.getValue()) {
+                if (rawValue == null || rawValue.trim().isEmpty()) continue;
+                if (newTags.size() >= MAX_TAGS_PER_SOURCE) {
+                    logger.warn("[{}] tag cap ({}) reached for {} — remaining values dropped", source, MAX_TAGS_PER_SOURCE, identityUserName);
+                    break outer;
+                }
+                newTags.add(new DeviceTag(key.trim().toLowerCase(), rawValue.trim().toLowerCase(), source, now, lastUpdatedBy));
+            }
         }
 
-        // Re-scope by the canonical name — the rename above already covers every fragment.
-        Bson canonicalFilter = Filters.eq(AgenticUsers.USER_NAME, identityUserName);
-        applySsoTeamOrRole(canonicalFilter, AgenticUsers.TEAM_NAME, AgenticUsers.TEAM_SOURCE, AgenticUsers.SSO_TEAM_NAME, ssoTeam);
-        applySsoTeamOrRole(canonicalFilter, AgenticUsers.USER_ROLE, AgenticUsers.ROLE_SOURCE, AgenticUsers.SSO_USER_ROLE, ssoRole);
+        // Baseline: any one doc already sharing this identity has the same deviceTags as its
+        // siblings — this method always writes them identically via updateMany below.
+        AgenticUsers existing = instance.findOne(Filters.eq(AgenticUsers.USER_NAME, identityUserName));
+        List<DeviceTag> existingTags = existing != null && existing.getDeviceTags() != null
+                ? existing.getDeviceTags() : Collections.emptyList();
+
+        List<DeviceTag> merged = existingTags.stream().filter(keepExisting).collect(Collectors.toCollection(ArrayList::new));
+        merged.addAll(newTags);
+
+        instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, identityUserName),
+                Updates.set(AgenticUsers.DEVICE_TAGS, merged));
     }
 
     /** Union of every doc matching username, email, or derived username — not first-tier-wins. */
@@ -147,53 +106,119 @@ public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
         return instance.findAll(Filters.or(identityMatchers));
     }
 
-    /**
-     * Shadow field (e.g. ssoTeamName) always updates. Real field only updates where it isn't
-     * pinned "manual" with a real value — checked live by Mongo, not a stale Java snapshot.
-     */
-    private void applySsoTeamOrRole(Bson identityFilter, String field, String sourceField, String shadowField, String ssoValue) {
-        instance.updateMany(identityFilter, Updates.set(shadowField, ssoValue));
-
-        Bson notPinned = Filters.or(
-                Filters.ne(sourceField, AgenticUsers.SOURCE_MANUAL),
-                Filters.in(field, Arrays.asList(null, "")));
-        instance.updateMany(Filters.and(identityFilter, notPinned), Updates.combine(
-                Updates.set(field, ssoValue),
-                Updates.set(sourceField, AgenticUsers.SOURCE_SSO)));
-    }
-
     private static String deriveUsernameFromEmail(String email) {
         if (email == null || email.isEmpty() || !email.contains("@")) return null;
         String local = email.substring(0, email.indexOf('@')).trim();
         return local.isEmpty() ? null : local;
     }
 
-    public List<String> findDeviceIdsByTeamsAndRoles(List<String> teams, List<String> roles) {
+    /**
+     * Resolves this SSO identity (union-match across username/email/derived-username,
+     * canonicalizing every match onto the email-derived username so fragments converge over
+     * time), ensures a doc exists, and refreshes email/timestamp. Callers apply tags afterward
+     * via upsertDeviceTags using the returned canonical username.
+     */
+    public String syncSsoIdentity(String userName, String userEmail, String lastUpdatedBy) {
+        if (userName == null || userName.trim().isEmpty()) return null;
+        String trimmedName = userName.trim();
+        String trimmedEmail = userEmail == null ? "" : userEmail.trim();
+        String derivedUsername = deriveUsernameFromEmail(trimmedEmail);
+
+        List<AgenticUsers> matches = findAllIdentityMatches(trimmedName, trimmedEmail, derivedUsername);
+        String identityUserName = derivedUsername != null ? derivedUsername : trimmedName;
+
+        List<Bson> baseUpdates = Arrays.asList(
+                Updates.set(AgenticUsers.USER_NAME, identityUserName),
+                Updates.set(AgenticUsers.USER_EMAIL, trimmedEmail),
+                Updates.set(AgenticUsers.LAST_UPDATED_AT, Context.now()),
+                Updates.set(AgenticUsers.LAST_UPDATED_BY, lastUpdatedBy));
+        if (matches.isEmpty()) {
+            instance.updateOne(Filters.eq(AgenticUsers.USER_NAME, identityUserName), Updates.combine(baseUpdates));
+        } else {
+            List<String> matchedUsernames = matches.stream().map(AgenticUsers::getUserName).distinct().collect(Collectors.toList());
+            instance.updateMany(Filters.in(AgenticUsers.USER_NAME, matchedUsernames), Updates.combine(baseUpdates));
+        }
+        return identityUserName;
+    }
+
+    /**
+     * Exact-username lookup only — the dashboard always sends back the live device-reported
+     * username round-tripped from this DAO's own data, so broader matching (needed for SSO,
+     * where the caller only has an email) doesn't help here. Ensures a doc exists.
+     */
+    public String ensureDashboardIdentity(String userName, String userEmail, String lastUpdatedBy) {
+        if (userName == null || userName.trim().isEmpty()) return null;
+        String trimmedName = userName.trim();
+        String trimmedEmail = userEmail == null ? "" : userEmail.trim();
+
+        AgenticUsers existing = instance.findOne(Filters.eq(AgenticUsers.USER_NAME, trimmedName));
+        if (existing == null) {
+            AgenticUsers newUser = new AgenticUsers();
+            newUser.setUserName(trimmedName);
+            if (!trimmedEmail.isEmpty()) newUser.setUserEmail(trimmedEmail);
+            newUser.setLastUpdatedAt(Context.now());
+            newUser.setLastUpdatedBy(lastUpdatedBy);
+            instance.insertOne(newUser);
+        } else {
+            List<Bson> updates = new ArrayList<>();
+            updates.add(Updates.set(AgenticUsers.LAST_UPDATED_AT, Context.now()));
+            updates.add(Updates.set(AgenticUsers.LAST_UPDATED_BY, lastUpdatedBy));
+            if (!trimmedEmail.isEmpty()) updates.add(Updates.set(AgenticUsers.USER_EMAIL, trimmedEmail));
+            instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, trimmedName), Updates.combine(updates));
+        }
+        return trimmedName;
+    }
+
+    /**
+     * Generalizes findDeviceIdsByTeamsRolesAndDeviceIds to arbitrary tag keys: entries in
+     * tagFilters AND together; within one key, any of its values match (OR).
+     */
+    public List<String> findDeviceIdsByTags(Map<String, List<String>> tagFilters, List<String> deviceIds) {
         List<Bson> conditions = new ArrayList<>();
-        if (teams != null && !teams.isEmpty()) {
-            conditions.add(Filters.or(
-                Filters.and(Filters.eq(AgenticUsers.TEAM_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.TEAM_NAME, teams)),
-                Filters.and(Filters.ne(AgenticUsers.TEAM_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.SSO_TEAM_NAME, teams))
-            ));
+        if (tagFilters != null) {
+            for (Map.Entry<String, List<String>> entry : tagFilters.entrySet()) {
+                if (entry.getKey() == null || entry.getValue() == null) continue;
+                List<String> values = entry.getValue().stream()
+                        .filter(v -> v != null && !v.trim().isEmpty())
+                        .map(v -> v.trim().toLowerCase())
+                        .collect(Collectors.toList());
+                if (values.isEmpty()) continue;
+                conditions.add(Filters.elemMatch(AgenticUsers.DEVICE_TAGS, Filters.and(
+                        Filters.eq(DeviceTag.KEY, entry.getKey().trim().toLowerCase()),
+                        Filters.in(DeviceTag.VALUE, values))));
+            }
         }
-        if (roles != null && !roles.isEmpty()) {
-            conditions.add(Filters.or(
-                Filters.and(Filters.eq(AgenticUsers.ROLE_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.USER_ROLE, roles)),
-                Filters.and(Filters.ne(AgenticUsers.ROLE_SOURCE, AgenticUsers.SOURCE_MANUAL), Filters.in(AgenticUsers.SSO_USER_ROLE, roles))
-            ));
-        }
-        if (conditions.isEmpty()) {
+        boolean hasTagFilters = !conditions.isEmpty();
+        boolean hasDeviceIds = deviceIds != null && !deviceIds.isEmpty();
+        if (!hasTagFilters && !hasDeviceIds) {
             return new ArrayList<>();
         }
 
+        // Device IDs come straight from a dropdown built off live module_info data at pick time —
+        // trust them directly rather than re-deriving through a username/tag join.
+        if (!hasTagFilters) {
+            return new ArrayList<>(new HashSet<>(deviceIds));
+        }
+
+        // module_info is updated on every heartbeat, unlike AgenticUsers.devices which is only
+        // ever backfilled once — resolve devices live instead of trusting the stored field.
+        Map<String, Set<String>> liveDevicesByUsername = ModuleInfoDao.instance.fetchUsernameToDeviceIdsForEndpointShield();
         Bson userFilter = conditions.size() == 1 ? conditions.get(0) : Filters.and(conditions);
-        List<String> deviceIds = new ArrayList<>();
+        Set<String> tagDeviceIds = new HashSet<>();
         for (AgenticUsers user : instance.findAll(userFilter)) {
-            if (user.getDevices() != null) {
-                deviceIds.addAll(user.getDevices());
+            Set<String> liveDevices = liveDevicesByUsername.get(user.getUserName());
+            if (liveDevices != null) {
+                tagDeviceIds.addAll(liveDevices);
             }
         }
-        return deviceIds;
+
+        if (!hasDeviceIds) {
+            return new ArrayList<>(tagDeviceIds);
+        }
+
+        // Both dimensions given — a device must satisfy the tag match AND be explicitly picked.
+        tagDeviceIds.retainAll(new HashSet<>(deviceIds));
+        return new ArrayList<>(tagDeviceIds);
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/monitoring/ModuleInfoDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/monitoring/ModuleInfoDao.java
@@ -4,6 +4,14 @@ package com.akto.dao.monitoring;
 import com.akto.dao.AccountsContextDao;
 import com.akto.dao.MCollection;
 import com.akto.dto.monitoring.ModuleInfo;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class ModuleInfoDao extends AccountsContextDao<ModuleInfo> {
     @Override
@@ -27,5 +35,30 @@ public class ModuleInfoDao extends AccountsContextDao<ModuleInfo> {
         // moduleType + lastHeartbeatReceived — used in heartbeat threshold queries
         MCollection.createIndexIfAbsent(getDBName(), getCollName(),
             new String[]{ ModuleInfo.MODULE_TYPE, ModuleInfo.LAST_HEARTBEAT_RECEIVED }, false);
+    }
+
+    // Computed fresh on every call from module_info (updated every heartbeat) rather than
+    // from AgenticUsers.devices, which is only ever backfilled once by a startup migration
+    // and never kept in sync with devices that report in afterwards.
+    //
+    // Uses ModuleInfo.name (== the Go agent's GetDeviceLabel(), "{hostname}-{first8ofMachineID}"),
+    // NOT additionalData.deviceId (the raw machine ID) — the enforcement layer's
+    // filterPoliciesByDeviceId (guardrails-service/.../validator/service.go) matches
+    // ApplyToDeviceIds against the device-label prefix parsed out of mcpServerName, which is
+    // built from GetDeviceLabel(), never the raw machine ID. Using additionalData.deviceId here
+    // would silently make Team/Role/Device targeting match nothing at enforcement time.
+    public Map<String, Set<String>> fetchUsernameToDeviceIdsForEndpointShield() {
+        List<ModuleInfo> modules = findAll(Filters.eq(ModuleInfo.MODULE_TYPE, ModuleInfo.ModuleType.MCP_ENDPOINT_SHIELD),
+            Projections.include(ModuleInfo.NAME, ModuleInfo.ADDITIONAL_DATA));
+        Map<String, Set<String>> result = new HashMap<>();
+        for (ModuleInfo m : modules) {
+            Map<String, Object> ad = m.getAdditionalData();
+            if (ad == null || ad.get("username") == null) continue;
+            String username = String.valueOf(ad.get("username")).trim();
+            String deviceId = m.getName() == null ? "" : m.getName().trim();
+            if (username.isEmpty() || deviceId.isEmpty()) continue;
+            result.computeIfAbsent(username, k -> new HashSet<>()).add(deviceId);
+        }
+        return result;
     }
 }

--- a/libs/dao/src/main/java/com/akto/dto/AgenticUsers.java
+++ b/libs/dao/src/main/java/com/akto/dto/AgenticUsers.java
@@ -15,30 +15,17 @@ public class AgenticUsers {
 
     public static final String USER_NAME = "userName";
     public static final String USER_EMAIL = "userEmail";
-    public static final String USER_ROLE = "userRole";
-    public static final String TEAM_NAME = "teamName";
     public static final String LAST_UPDATED_AT = "lastUpdatedAt";
     public static final String LAST_UPDATED_BY = "lastUpdatedBy";
-    public static final String TEAM_SOURCE = "teamSource";
-    public static final String ROLE_SOURCE = "roleSource";
-    public static final String SSO_TEAM_NAME = "ssoTeamName";
-    public static final String SSO_USER_ROLE = "ssoUserRole";
 
-    public static final String SOURCE_SSO = "sso";
-    public static final String SOURCE_MANUAL = "manual";
+    public static final String DEVICE_TAGS = "deviceTags";
 
     private String userName;
     private String userEmail;
-    private String userRole;
-    private String teamName;
     private int lastUpdatedAt;
     private String lastUpdatedBy;
     private List<String> devices;
-    // "sso" or "manual" — SSO writes are skipped when source is "manual".
-    private String teamSource;
-    private String roleSource;
-    // Last values provided by SSO — always kept up-to-date regardless of manual pin.
-    // Used to restore the effective value immediately when an admin clears a manual override.
-    private String ssoTeamName;
-    private String ssoUserRole;
+
+    // Generic key-value tags (team, role, department, arbitrary Okta groups, ...).
+    private List<DeviceTag> deviceTags;
 }

--- a/libs/dao/src/main/java/com/akto/dto/BackwardCompatibility.java
+++ b/libs/dao/src/main/java/com/akto/dto/BackwardCompatibility.java
@@ -130,6 +130,17 @@ public class BackwardCompatibility {
     public static final String CLEANUP_API_INFO_TAGS = "cleanupApiInfoTags";
     private int cleanupApiInfoTags;
 
+    // One-time conversion of the old fixed teamName/userRole fields (pre-DeviceTag redesign) into
+    // AgenticUsers.deviceTags. See BackwardCompatibilityUtils.
+    public static final String MIGRATE_TEAM_ROLE_TO_DEVICE_TAGS = "migrateTeamRoleToDeviceTags";
+    private int migrateTeamRoleToDeviceTags;
+
+    // One-time conversion of GuardrailPolicies' old fixed targetTeams/targetRoles fields into the
+    // generic targetTags model. Must run after MIGRATE_TEAM_ROLE_TO_DEVICE_TAGS so the "team"/
+    // "role" tag keys line up with what that migration writes onto agent_users.
+    public static final String MIGRATE_GUARDRAIL_TARGET_TEAMS_ROLES_TO_TAGS = "migrateGuardrailTargetTeamsRolesToTags";
+    private int migrateGuardrailTargetTeamsRolesToTags;
+
     public BackwardCompatibility(int id, int dropFilterSampleData, int resetSingleTypeInfoCount, int dropWorkflowTestResult,
                                  int readyForNewTestingFramework,int addAktoDataTypes, boolean deploymentStatusUpdated,
                                  int authMechanismData, boolean mirroringLambdaTriggered, int deleteAccessListFromApiToken,

--- a/libs/dao/src/main/java/com/akto/dto/Config.java
+++ b/libs/dao/src/main/java/com/akto/dto/Config.java
@@ -417,6 +417,15 @@ public abstract class Config {
         private String managementApiToken;
         /** Okta group name → Akto user role. Stored in Mongo as {@code oktaGroupToAktoUserRoleMap}. */
         private Map<String, String> oktaGroupToAktoUserRoleMap;
+        /**
+         * Master on/off switch for the periodic org-wide cron that syncs Okta groups into
+         * AgenticUsers as a "group" device tag for every org user, not just people who log in.
+         * Requires {@link #managementApiToken} — the cron has no login session to read a JWT
+         * groups claim from, so the Management API is the only way it can enumerate users/groups.
+         * Defaults to false; the dashboard UI keeps this disabled until a token is saved.
+         */
+        public static final String SYNC_GROUPS_TO_USER_TAGS = "syncGroupsToUserTags";
+        private boolean syncGroupsToUserTags = false;
 
         public static final String CONFIG_ID = ConfigType.OKTA.name() + CONFIG_SALT;
 
@@ -505,6 +514,13 @@ public abstract class Config {
         }
         public void setOktaGroupToAktoUserRoleMap(Map<String, String> oktaGroupToAktoUserRoleMap) {
             this.oktaGroupToAktoUserRoleMap = oktaGroupToAktoUserRoleMap;
+        }
+
+        public boolean isSyncGroupsToUserTags() {
+            return syncGroupsToUserTags;
+        }
+        public void setSyncGroupsToUserTags(boolean syncGroupsToUserTags) {
+            this.syncGroupsToUserTags = syncGroupsToUserTags;
         }
     }
 

--- a/libs/dao/src/main/java/com/akto/dto/DeviceTag.java
+++ b/libs/dao/src/main/java/com/akto/dto/DeviceTag.java
@@ -1,0 +1,29 @@
+package com.akto.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeviceTag {
+
+    public static final String SOURCE_MANUAL = "manual";
+
+    public static final String KEY = "key";
+    public static final String VALUE = "value";
+    public static final String SOURCE = "source";
+    public static final String LAST_UPDATED_AT = "lastUpdatedAt";
+    public static final String LAST_UPDATED_BY = "lastUpdatedBy";
+
+    private String key;
+    private String value;
+    // Free-form, not an enum — e.g. "manual", "okta", and any future identity provider,
+    // added with no schema change.
+    private String source;
+    private int lastUpdatedAt;
+    private String lastUpdatedBy;
+}

--- a/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
+++ b/libs/dao/src/main/java/com/akto/dto/GuardrailPolicies.java
@@ -80,11 +80,16 @@ public class GuardrailPolicies {
     private boolean applyOnRequest;
     private boolean applyToAllServers;
 
-    // Team/Role targeting — controls which agentic users this policy applies to.
+    // Tag/Device targeting — controls which agentic users/devices this policy applies to.
+    // targetDeviceIds holds explicitly-picked device IDs (dropdown shows them labeled by username,
+    // but the stored value is the device ID itself — usernames aren't a reliable unique identity).
     // applyToDeviceIds is resolved at fetch time (not stored) by the dashboard before serving to the enforcement layer.
-    private List<String> targetTeams;
-    private List<String> targetRoles;
-    // null (never set) = targetTeams/targetRoles both empty, no targeting configured → apply to all devices.
+    private List<String> targetDeviceIds;
+    // Arbitrary device-tag key → values — AND across keys, OR within one key's values. See
+    // scripts/migrate_guardrail_target_teams_roles_to_tags.js for converting pre-existing
+    // policies that used the old fixed targetTeams/targetRoles fields.
+    private Map<String, List<String>> targetTags;
+    // null (never set) = targetTags/targetDeviceIds all empty, no targeting configured → apply to all devices.
     // Non-null (possibly empty) List = targeting configured → apply only to these device labels;
     // an empty List means targeting resolved to zero matching devices, so apply to none.
     // null and an empty List are NOT interchangeable — consumers must not use a collapsed

--- a/libs/utils/src/main/resources/db/changelog/account/014-agent-users-migrate-team-role-to-device-tags.xml
+++ b/libs/utils/src/main/resources/db/changelog/account/014-agent-users-migrate-team-role-to-device-tags.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:mongodb="http://www.liquibase.org/xml/ns/mongodb"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+        http://www.liquibase.org/xml/ns/mongodb
+        http://www.liquibase.org/xml/ns/mongodb/liquibase-mongodb-latest.xsd">
+
+    <!--
+        AgenticUsers dropped the old fixed teamName/userRole/ssoTeamName/ssoUserRole/teamSource/
+        roleSource fields in favor of the generic deviceTags model. Those fields still exist on
+        documents written before this change and are otherwise invisible to the app going
+        forward, so backfill them into deviceTags here.
+
+        Only touches documents that still carry a legacy field (ssoTeamName/ssoUserRole/
+        teamSource/roleSource exists) rather than ones with empty deviceTags, because deviceTags
+        can already be non-empty from an unrelated source (e.g. Okta group sync) while the legacy
+        team/role fields are still unconverted — filtering on "deviceTags empty" would silently
+        skip those forever since this changeset only ever runs once per account.
+
+        For the same reason this merges into any existing deviceTags instead of overwriting: a
+        legacy value is only appended where its (key, source) pair isn't already present, so a
+        tag already synced live or already set through the new UI before this migration runs is
+        never duplicated or clobbered. Different sources for the same key (e.g. a manual "team"
+        and an Okta "team") simply coexist afterwards — deviceTags has no single "effective" value
+        to resolve to; every source's tags are used directly wherever tags are read.
+
+        Idempotent: a second run recomputes deviceTags to the same values, and the legacy fields
+        are left in place (harmless, no longer read by the app) so nothing here depends on a prior
+        run having stripped them.
+
+        Not reversible — the merge can't tell which entries came from this backfill afterwards.
+    -->
+
+    <changeSet id="014-account-agent-users-migrate-team-role-to-device-tags" author="akto">
+        <preConditions onFail="MARK_RAN">
+            <mongodb:collectionExists collectionName="agent_users"/>
+        </preConditions>
+        <mongodb:runCommand>
+            <mongodb:command>{
+                "update": "agent_users",
+                "updates": [
+                    {
+                        "q": {
+                            "$or": [
+                                { "ssoTeamName": { "$exists": true } },
+                                { "ssoUserRole": { "$exists": true } },
+                                { "teamSource": { "$exists": true } },
+                                { "roleSource": { "$exists": true } }
+                            ]
+                        },
+                        "u": [
+                            {
+                                "$set": {
+                                    "__legacyTags": {
+                                        "$filter": {
+                                            "input": [
+                                                { "$cond": [ { "$and": [ { "$eq": [ { "$type": "$ssoTeamName" }, "string" ] }, { "$gt": [ { "$strLenCP": { "$trim": { "input": "$ssoTeamName" } } }, 0 ] } ] },
+                                                    { "key": "team", "value": { "$toLower": { "$trim": { "input": "$ssoTeamName" } } }, "source": "okta", "lastUpdatedAt": { "$toLong": { "$divide": [ { "$toLong": "$$NOW" }, 1000 ] } }, "lastUpdatedBy": "migration" }, null ] },
+                                                { "$cond": [ { "$and": [ { "$eq": [ { "$type": "$ssoUserRole" }, "string" ] }, { "$gt": [ { "$strLenCP": { "$trim": { "input": "$ssoUserRole" } } }, 0 ] } ] },
+                                                    { "key": "role", "value": { "$toLower": { "$trim": { "input": "$ssoUserRole" } } }, "source": "okta", "lastUpdatedAt": { "$toLong": { "$divide": [ { "$toLong": "$$NOW" }, 1000 ] } }, "lastUpdatedBy": "migration" }, null ] },
+                                                { "$cond": [ { "$and": [ { "$eq": [ "$teamSource", "manual" ] }, { "$eq": [ { "$type": "$teamName" }, "string" ] }, { "$gt": [ { "$strLenCP": { "$trim": { "input": "$teamName" } } }, 0 ] } ] },
+                                                    { "key": "team", "value": { "$toLower": { "$trim": { "input": "$teamName" } } }, "source": "manual", "lastUpdatedAt": { "$toLong": { "$divide": [ { "$toLong": "$$NOW" }, 1000 ] } }, "lastUpdatedBy": "migration" }, null ] },
+                                                { "$cond": [ { "$and": [ { "$eq": [ "$roleSource", "manual" ] }, { "$eq": [ { "$type": "$userRole" }, "string" ] }, { "$gt": [ { "$strLenCP": { "$trim": { "input": "$userRole" } } }, 0 ] } ] },
+                                                    { "key": "role", "value": { "$toLower": { "$trim": { "input": "$userRole" } } }, "source": "manual", "lastUpdatedAt": { "$toLong": { "$divide": [ { "$toLong": "$$NOW" }, 1000 ] } }, "lastUpdatedBy": "migration" }, null ] }
+                                            ],
+                                            "as": "t",
+                                            "cond": { "$ne": [ "$$t", null ] }
+                                        }
+                                    }
+                                }
+                            },
+                            { "$set": { "__existingTags": { "$ifNull": [ "$deviceTags", [] ] } } },
+                            { "$set": { "__existingKeySource": { "$map": { "input": "$__existingTags", "as": "e", "in": { "$concat": [ "$$e.key", "|", "$$e.source" ] } } } } },
+                            {
+                                "$set": {
+                                    "__newLegacyTags": {
+                                        "$filter": {
+                                            "input": "$__legacyTags",
+                                            "as": "lt",
+                                            "cond": { "$not": [ { "$in": [ { "$concat": [ "$$lt.key", "|", "$$lt.source" ] }, "$__existingKeySource" ] } ] }
+                                        }
+                                    }
+                                }
+                            },
+                            { "$set": { "deviceTags": { "$concatArrays": [ "$__existingTags", "$__newLegacyTags" ] } } },
+                            { "$unset": [ "__legacyTags", "__existingTags", "__existingKeySource", "__newLegacyTags" ] }
+                        ],
+                        "multi": true
+                    }
+                ]
+            }</mongodb:command>
+        </mongodb:runCommand>
+        <rollback/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/libs/utils/src/main/resources/db/changelog/account/015-guardrail-policies-migrate-target-teams-roles-to-tags.xml
+++ b/libs/utils/src/main/resources/db/changelog/account/015-guardrail-policies-migrate-target-teams-roles-to-tags.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:mongodb="http://www.liquibase.org/xml/ns/mongodb"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+        http://www.liquibase.org/xml/ns/mongodb
+        http://www.liquibase.org/xml/ns/mongodb/liquibase-mongodb-latest.xsd">
+
+    <!--
+        GuardrailPolicies dropped the old fixed targetTeams/targetRoles fields in favor of the
+        generic targetTags model. A policy scoped to a team/role via the old fields has no
+        targetTags after upgrade, and GuardrailPoliciesAction treats a policy with no targeting
+        configured as "apply to all devices" — without this backfill, a previously scoped policy
+        would silently start applying everywhere. Run after 014 so the "team"/"role" tag keys
+        line up with what that migration writes onto agent_users.
+
+        Only touches documents that still carry a non-empty targetTeams/targetRoles array, and
+        merges into any existing targetTags rather than overwriting: an existing key already set
+        (e.g. through the new UI before this migration runs) always wins over the legacy value, so
+        nothing already configured is clobbered. A policy whose legacy arrays are both empty is
+        left untouched even if the fields still exist on the document.
+
+        Idempotent: a second run leaves targetTags unchanged since every legacy key it would add
+        is already present.
+
+        Not reversible — the merge can't tell which keys came from this backfill afterwards.
+    -->
+
+    <changeSet id="015-account-guardrail-policies-migrate-target-teams-roles-to-tags" author="akto">
+        <preConditions onFail="MARK_RAN">
+            <mongodb:collectionExists collectionName="guardrail_policies"/>
+        </preConditions>
+        <mongodb:runCommand>
+            <mongodb:command>{
+                "update": "guardrail_policies",
+                "updates": [
+                    {
+                        "q": {
+                            "$or": [
+                                { "targetTeams": { "$exists": true } },
+                                { "targetRoles": { "$exists": true } }
+                            ]
+                        },
+                        "u": [
+                            {
+                                "$set": {
+                                    "targetTags": {
+                                        "$mergeObjects": [
+                                            { "$cond": [ { "$gt": [ { "$size": { "$ifNull": [ "$targetTeams", [] ] } }, 0 ] },
+                                                { "team": { "$map": { "input": "$targetTeams", "as": "t", "in": { "$toLower": { "$trim": { "input": "$$t" } } } } } }, {} ] },
+                                            { "$cond": [ { "$gt": [ { "$size": { "$ifNull": [ "$targetRoles", [] ] } }, 0 ] },
+                                                { "role": { "$map": { "input": "$targetRoles", "as": "r", "in": { "$toLower": { "$trim": { "input": "$$r" } } } } } }, {} ] },
+                                            { "$ifNull": [ "$targetTags", {} ] }
+                                        ]
+                                    }
+                                }
+                            }
+                        ],
+                        "multi": true
+                    }
+                ]
+            }</mongodb:command>
+        </mongodb:runCommand>
+        <rollback/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
…ers and GuardrailPolicies

This commit introduces a migration process that converts legacy fields (team and role) in AgenticUsers and GuardrailPolicies into a new device tag structure. The migration ensures that existing data is preserved while transitioning to a more flexible tagging system. Additionally, updates are made to the frontend components to support the new targetTags structure for user targeting in guardrail policies, enhancing the overall targeting capabilities.