### PR TITLE
feat: implement Okta user synchronization cron job

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
+++ b/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
@@ -234,6 +234,7 @@ import com.akto.utils.crons.SyncCron;
 import com.akto.utils.crons.TokenGeneratorCron;
 import com.akto.utils.crons.UpdateSensitiveInfoInApiInfo;
 import com.akto.utils.crons.AgentBasePromptDetectionCron;
+import com.akto.utils.crons.OktaUserSyncCron;
 import com.akto.utils.jobs.CleanInventory;
 import com.akto.utils.jobs.DeactivateCollections;
 import com.akto.utils.jobs.JobUtils;
@@ -293,6 +294,7 @@ public class InitializerListener implements ServletContextListener {
     TokenGeneratorCron tokenGeneratorCron = new TokenGeneratorCron();
     UpdateSensitiveInfoInApiInfo updateSensitiveInfoInApiInfo = new UpdateSensitiveInfoInApiInfo();
     AgentBasePromptDetectionCron agentBasePromptDetectionCron = new AgentBasePromptDetectionCron();
+    OktaUserSyncCron oktaUserSyncCron = new OktaUserSyncCron();
 
     private static String domain = null;
     public static String subdomain = "https://app.akto.io";
@@ -2711,6 +2713,7 @@ public class InitializerListener implements ServletContextListener {
                         updateSensitiveInfoInApiInfo.setUpSensitiveMapInApiInfoScheduler();
                         syncCronInfo.setUpUpdateCronScheduler();
                         agentBasePromptDetectionCron.setUpAgentBasePromptDetectionScheduler();
+                        oktaUserSyncCron.setUpOktaUserSyncScheduler();
                         updateApiGroupsForAccounts();
                         setupAutomatedApiGroupsScheduler();
                         trimCappedCollectionsJob();

--- a/apps/dashboard/src/main/java/com/akto/utils/crons/OktaUserSyncCron.java
+++ b/apps/dashboard/src/main/java/com/akto/utils/crons/OktaUserSyncCron.java
@@ -1,0 +1,130 @@
+package com.akto.utils.crons;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import com.akto.dao.AgentUsersDao;
+import com.akto.dao.ConfigsDao;
+import com.akto.dao.context.Context;
+import com.akto.dto.Account;
+import com.akto.dto.Config.OktaConfig;
+import com.akto.log.LoggerMaker;
+import com.akto.log.LoggerMaker.LogDb;
+import com.akto.task.Cluster;
+import com.akto.util.AccountTask;
+import com.akto.util.Constants;
+import com.akto.util.http_request.OktaApiClient;
+import com.akto.util.http_request.OktaApiClient.OktaGroupRef;
+import com.akto.util.http_request.OktaApiClient.OktaUserRef;
+import com.mongodb.client.model.Filters;
+
+import static com.akto.task.Cluster.callDibs;
+
+/**
+ * Periodically syncs every Okta org user's group membership into AgenticUsers as "group" device
+ * tags — not just the people who happen to log into Akto via Okta. This is the *only* place
+ * device tags get written from Okta group data; SignupAction.registerViaOkta still resolves
+ * groups at login, but only to drive Akto RBAC role assignment, not device tags.
+ *
+ * Only runs for accounts whose OktaConfig has syncGroupsToUserTags=true AND a managementApiToken
+ * set — the dashboard UI (OktaSsoAction.saveOktaGroupRoleMapping) rejects enabling the former
+ * without the latter, but this cron re-checks both since config can change between the UI
+ * validation and this cron's next tick.
+ */
+public class OktaUserSyncCron {
+    private static final LoggerMaker logger = new LoggerMaker(OktaUserSyncCron.class, LogDb.DASHBOARD);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    private static final String SYNC_SOURCE = "okta";
+    private static final String GROUP_TAG_KEY = "group";
+
+    public void setUpOktaUserSyncScheduler() {
+        scheduler.scheduleAtFixedRate(new Runnable() {
+            public void run() {
+                try {
+                    Context.accountId.set(1_000_000);
+                    // expiryPeriod (55 min) comfortably covers a slow run without overlapping the
+                    // next hourly tick; freqInSeconds (30 min) just needs to be under that.
+                    boolean dibs = callDibs(Cluster.OKTA_USER_SYNC_CRON, 55 * 60, 30 * 60);
+                    if (!dibs) {
+                        logger.debugAndAddToDb("Okta user sync cron dibs not acquired, skipping", LogDb.DASHBOARD);
+                        return;
+                    }
+                    AccountTask.instance.executeTask(new Consumer<Account>() {
+                        @Override
+                        public void accept(Account account) {
+                            syncAccountIfEnabled(account.getId());
+                        }
+                    }, "okta-user-sync");
+                } catch (Exception e) {
+                    logger.errorAndAddToDb(e, "Error in Okta user sync scheduler", LogDb.DASHBOARD);
+                }
+            }
+        }, 0, 1, TimeUnit.HOURS);
+    }
+
+    private void syncAccountIfEnabled(int accountId) {
+        try {
+            OktaConfig oktaConfig = (OktaConfig) ConfigsDao.instance.findOne(
+                    Filters.eq(Constants.ID, OktaConfig.getOktaId(accountId)));
+            if (oktaConfig == null || !oktaConfig.isSyncGroupsToUserTags()) return;
+            String token = oktaConfig.getManagementApiToken();
+            if (token == null || token.trim().isEmpty()) {
+                logger.errorAndAddToDb(
+                        "[Okta] group sync enabled for account " + accountId + " but no management token set — skipping",
+                        LogDb.DASHBOARD);
+                return;
+            }
+            syncAccount(accountId, oktaConfig, token);
+        } catch (Exception e) {
+            logger.errorAndAddToDb(e, "Error syncing Okta users for account " + accountId, LogDb.DASHBOARD);
+        }
+    }
+
+    private void syncAccount(int accountId, OktaConfig oktaConfig, String token) {
+        String baseUrl = oktaConfig.getManagementBaseUrl();
+
+        List<OktaGroupRef> groups = OktaApiClient.fetchAllGroups(baseUrl, token);
+
+        // Okta user id -> group names, accumulated across every group's member roster. Fetching
+        // group-by-group (rather than per-user) keeps call volume proportional to group count,
+        // which is normally far smaller than user count.
+        Map<String, List<String>> groupNamesByUserId = new HashMap<>();
+        for (OktaGroupRef group : groups) {
+            List<OktaUserRef> members = OktaApiClient.fetchGroupMembers(baseUrl, token, group.id);
+            for (OktaUserRef member : members) {
+                if (member.id == null) continue;
+                groupNamesByUserId.computeIfAbsent(member.id, k -> new ArrayList<>()).add(group.name);
+            }
+        }
+
+        // Every active org user is visited — including those in zero groups — so
+        // upsertDeviceTags' full-replace-by-source semantics correctly clear a user's stale
+        // "okta" group tag once they've left every group, not just add new ones.
+        List<OktaUserRef> allUsers = OktaApiClient.fetchAllUsers(baseUrl, token);
+        int syncedCount = 0;
+        for (OktaUserRef user : allUsers) {
+            String username = user.login != null && !user.login.trim().isEmpty() ? user.login : user.email;
+            if (username == null || username.trim().isEmpty()) continue;
+
+            String identityUserName = AgentUsersDao.instance.syncSsoIdentity(username, user.email, SYNC_SOURCE);
+            if (identityUserName == null) continue;
+
+            // syncAccountIfEnabled already confirmed isSyncGroupsToUserTags() before calling here.
+            List<String> groupNames = groupNamesByUserId.getOrDefault(user.id, Collections.emptyList());
+            AgentUsersDao.instance.upsertDeviceTags(identityUserName, SYNC_SOURCE,
+                    Collections.singletonMap(GROUP_TAG_KEY, groupNames), SYNC_SOURCE);
+            syncedCount++;
+        }
+
+        logger.infoAndAddToDb("[Okta] periodic sync complete for account " + accountId + ": "
+                + syncedCount + " users, " + groups.size() + " groups", LogDb.DASHBOARD);
+    }
+}

--- a/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/AgentUsersDao.java
@@ -2,12 +2,25 @@ package com.akto.dao;
 
 import com.akto.dao.context.Context;
 import com.akto.dto.AgenticUsers;
+import com.akto.dto.DeviceTag;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
     public static final AgentUsersDao instance = new AgentUsersDao();
+    private static final Logger logger = LoggerFactory.getLogger(AgentUsersDao.class);
+    // Ported from the dashboard's DeviceTag redesign, for the periodic Okta user-sync cron only.
+    private static final int MAX_TAGS_PER_SOURCE = 50;
 
     public void createIndicesIfAbsent() {
         MCollection.createIndexIfAbsent(getDBName(), getCollName(),
@@ -15,6 +28,95 @@ public class AgentUsersDao extends AccountsContextDao<AgenticUsers>{
 
         MCollection.createIndexIfAbsent(getDBName(), getCollName(),
             new String[]{AgenticUsers.USER_NAME}, false);
+
+        MCollection.createIndexIfAbsent(getDBName(), getCollName(),
+            new String[]{AgenticUsers.DEVICE_TAGS + "." + DeviceTag.KEY,
+                    AgenticUsers.DEVICE_TAGS + "." + DeviceTag.VALUE}, false);
+    }
+
+    /**
+     * Full replace of a source's tags with the given key→values set — deleting any key not
+     * reported, so stale groups don't linger. Correct for SSO, which always reports the
+     * identity's *complete* current group membership on every sync.
+     */
+    public void upsertDeviceTags(String identityUserName, String source, Map<String, List<String>> keyValues, String lastUpdatedBy) {
+        if (identityUserName == null || identityUserName.trim().isEmpty() || source == null || source.trim().isEmpty()) return;
+        int now = Context.now();
+
+        List<DeviceTag> newTags = new ArrayList<>();
+        outer:
+        for (Map.Entry<String, List<String>> entry : keyValues.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || key.trim().isEmpty() || entry.getValue() == null) continue;
+            for (String rawValue : entry.getValue()) {
+                if (rawValue == null || rawValue.trim().isEmpty()) continue;
+                if (newTags.size() >= MAX_TAGS_PER_SOURCE) {
+                    logger.warn("[{}] tag cap ({}) reached for {} — remaining values dropped", source, MAX_TAGS_PER_SOURCE, identityUserName);
+                    break outer;
+                }
+                newTags.add(new DeviceTag(key.trim().toLowerCase(), rawValue.trim().toLowerCase(), source, now, lastUpdatedBy));
+            }
+        }
+
+        AgenticUsers existing = instance.findOne(Filters.eq(AgenticUsers.USER_NAME, identityUserName));
+        List<DeviceTag> existingTags = existing != null && existing.getDeviceTags() != null
+                ? existing.getDeviceTags() : Collections.emptyList();
+
+        List<DeviceTag> merged = existingTags.stream()
+                .filter(t -> !source.equals(t.getSource()))
+                .collect(Collectors.toCollection(ArrayList::new));
+        merged.addAll(newTags);
+
+        instance.updateMany(Filters.eq(AgenticUsers.USER_NAME, identityUserName),
+                Updates.set(AgenticUsers.DEVICE_TAGS, merged));
+    }
+
+    /** Union of every doc matching username, email, or derived username — not first-tier-wins. */
+    private List<AgenticUsers> findAllIdentityMatches(String userName, String userEmail, String derivedUsername) {
+        List<Bson> identityMatchers = new ArrayList<>();
+        identityMatchers.add(Filters.eq(AgenticUsers.USER_NAME, userName));
+        if (userEmail != null && !userEmail.isEmpty()) {
+            identityMatchers.add(Filters.eq(AgenticUsers.USER_EMAIL, userEmail));
+        }
+        if (derivedUsername != null) {
+            identityMatchers.add(Filters.eq(AgenticUsers.USER_NAME, derivedUsername));
+        }
+        return instance.findAll(Filters.or(identityMatchers));
+    }
+
+    private static String deriveUsernameFromEmail(String email) {
+        if (email == null || email.isEmpty() || !email.contains("@")) return null;
+        String local = email.substring(0, email.indexOf('@')).trim();
+        return local.isEmpty() ? null : local;
+    }
+
+    /**
+     * Resolves this SSO identity (union-match across username/email/derived-username,
+     * canonicalizing every match onto the email-derived username so fragments converge over
+     * time), ensures a doc exists, and refreshes email/timestamp. Callers apply tags afterward
+     * via upsertDeviceTags using the returned canonical username.
+     */
+    public String syncSsoIdentity(String userName, String userEmail, String lastUpdatedBy) {
+        if (userName == null || userName.trim().isEmpty()) return null;
+        String trimmedName = userName.trim();
+        String trimmedEmail = userEmail == null ? "" : userEmail.trim();
+        String derivedUsername = deriveUsernameFromEmail(trimmedEmail);
+
+        List<AgenticUsers> matches = findAllIdentityMatches(trimmedName, trimmedEmail, derivedUsername);
+        String identityUserName = derivedUsername != null ? derivedUsername : trimmedName;
+
+        List<Bson> baseUpdates = Arrays.asList(
+                Updates.set(AgenticUsers.USER_NAME, identityUserName),
+                Updates.set(AgenticUsers.USER_EMAIL, trimmedEmail),
+                Updates.set(AgenticUsers.LAST_UPDATED_AT, Context.now()),
+                Updates.set(AgenticUsers.LAST_UPDATED_BY, lastUpdatedBy));
+        if (matches.isEmpty()) {
+            instance.updateOne(Filters.eq(AgenticUsers.USER_NAME, identityUserName), Updates.combine(baseUpdates));
+        } else {
+            List<String> matchedUsernames = matches.stream().map(AgenticUsers::getUserName).distinct().collect(Collectors.toList());
+            instance.updateMany(Filters.in(AgenticUsers.USER_NAME, matchedUsernames), Updates.combine(baseUpdates));
+        }
+        return identityUserName;
     }
 
     public void upsertTag(String userName, String userEmail, String teamName, String userRole, String lastUpdatedBy) {

--- a/libs/dao/src/main/java/com/akto/dto/AgenticUsers.java
+++ b/libs/dao/src/main/java/com/akto/dto/AgenticUsers.java
@@ -20,6 +20,8 @@ public class AgenticUsers {
     public static final String LAST_UPDATED_AT = "lastUpdatedAt";
     public static final String LAST_UPDATED_BY = "lastUpdatedBy";
 
+    public static final String DEVICE_TAGS = "deviceTags";
+
     private String userName;
     private String userEmail;
     private String userRole;
@@ -27,4 +29,11 @@ public class AgenticUsers {
     private int lastUpdatedAt;
     private String lastUpdatedBy;
     private List<String> devices;
+
+    // Generic key-value tags (e.g. Okta groups under key "group"). One entry per (key, value,
+    // source) — see AgentUsersDao.upsertDeviceTags. Ported for the periodic Okta user-sync cron;
+    // unrelated to the legacy teamName/userRole fields above. Multiple sources (or multiple
+    // values from the same source) for the same key all coexist — this is the single source of
+    // truth read directly wherever tags are used, no separate resolved field.
+    private List<DeviceTag> deviceTags;
 }

--- a/libs/dao/src/main/java/com/akto/dto/Config.java
+++ b/libs/dao/src/main/java/com/akto/dto/Config.java
@@ -367,6 +367,17 @@ public abstract class Config {
         private String organizationDomain;
         public static final String ACCOUNT_ID = "accountId";
         private int accountId;
+        /** BSON key for the Okta Management API (SSWS) token. Ported for the periodic user-sync cron. */
+        public static final String MANAGEMENT_API_TOKEN = "managementApiToken";
+        /** SSWS token; persisted in Mongo under {@link #MANAGEMENT_API_TOKEN}. */
+        private String managementApiToken;
+        /**
+         * Master on/off switch for the periodic org-wide cron that syncs Okta groups into
+         * AgenticUsers as a "group" device tag for every org user, not just people who log in.
+         * Requires {@link #managementApiToken}. Defaults to false; the dashboard UI keeps this
+         * disabled until a token is saved.
+         */
+        private boolean syncGroupsToUserTags = false;
 
         public static final String CONFIG_ID = ConfigType.OKTA.name() + CONFIG_SALT;
 
@@ -431,6 +442,24 @@ public abstract class Config {
         }
         public void setAccountId(int accountId) {
             this.accountId = accountId;
+        }
+
+        public String getManagementApiToken() {
+            return managementApiToken;
+        }
+        public void setManagementApiToken(String managementApiToken) {
+            this.managementApiToken = managementApiToken;
+        }
+
+        public boolean isSyncGroupsToUserTags() {
+            return syncGroupsToUserTags;
+        }
+        public void setSyncGroupsToUserTags(boolean syncGroupsToUserTags) {
+            this.syncGroupsToUserTags = syncGroupsToUserTags;
+        }
+
+        public String getManagementBaseUrl() {
+            return "https://" + oktaDomainUrl;
         }
     }
 

--- a/libs/dao/src/main/java/com/akto/dto/DeviceTag.java
+++ b/libs/dao/src/main/java/com/akto/dto/DeviceTag.java
@@ -1,0 +1,29 @@
+package com.akto.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeviceTag {
+
+    public static final String SOURCE_MANUAL = "manual";
+
+    public static final String KEY = "key";
+    public static final String VALUE = "value";
+    public static final String SOURCE = "source";
+    public static final String LAST_UPDATED_AT = "lastUpdatedAt";
+    public static final String LAST_UPDATED_BY = "lastUpdatedBy";
+
+    private String key;
+    private String value;
+    // Free-form, not an enum — e.g. "manual", "okta", and any future identity provider,
+    // added with no schema change.
+    private String source;
+    private int lastUpdatedAt;
+    private String lastUpdatedBy;
+}

--- a/libs/utils/src/main/java/com/akto/task/Cluster.java
+++ b/libs/utils/src/main/java/com/akto/task/Cluster.java
@@ -27,6 +27,7 @@ public class Cluster {
     public static final String DEPENDENCY_FLOW_CRON= "dependency-flow-cron";
     public static final String DELETE_TESTING_RUN_RESULTS = "delete-testing-run-results";
     public static final String ALERTS_CRON = "alerts-cron";
+    public static final String OKTA_USER_SYNC_CRON = "okta-user-sync-cron";
 
     public static final String winnerId = UUID.randomUUID().toString();
 

--- a/libs/utils/src/main/java/com/akto/util/http_request/OktaApiClient.java
+++ b/libs/utils/src/main/java/com/akto/util/http_request/OktaApiClient.java
@@ -1,0 +1,203 @@
+package com.akto.util.http_request;
+
+import com.akto.log.LoggerMaker;
+import com.akto.log.LoggerMaker.LogDb;
+import com.akto.util.http_util.CoreHTTPClient;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.http.HttpHeaders;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Okta Management API client for the periodic user-sync cron. Separate from
+ * {@link CustomHttpRequest}'s single-page helpers (used by the login-time fallback in
+ * SignupAction) because bulk sync needs two things those don't have: pagination (Okta's
+ * Link response header) and basic 429 backoff — both required once you're listing an
+ * entire org's users/groups instead of one user's groups at login.
+ */
+public class OktaApiClient {
+
+    private static final LoggerMaker loggerMaker = new LoggerMaker(OktaApiClient.class, LogDb.DASHBOARD);
+    private static final OkHttpClient httpClient = CoreHTTPClient.client;
+    private static final Type LIST_OF_MAPS = new TypeToken<List<Map<String, Object>>>() {}.getType();
+
+    // Safety caps so a misbehaving org/token can't spin this forever.
+    private static final int MAX_PAGES = 500;
+    private static final int MAX_RETRIES_ON_429 = 4;
+    private static final int PAGE_SIZE = 200;
+
+    public static class OktaGroupRef {
+        public final String id;
+        public final String name;
+        public OktaGroupRef(String id, String name) { this.id = id; this.name = name; }
+    }
+
+    public static class OktaUserRef {
+        public final String id;
+        public final String login;
+        public final String email;
+        public OktaUserRef(String id, String login, String email) {
+            this.id = id;
+            this.login = login;
+            this.email = email;
+        }
+    }
+
+    /** GET /api/v1/groups — every group in the org, id + name, fully paginated. */
+    public static List<OktaGroupRef> fetchAllGroups(String managementBaseUrl, String apiToken) {
+        List<OktaGroupRef> groups = new ArrayList<>();
+        String url = managementBaseUrl + "/api/v1/groups?limit=" + PAGE_SIZE;
+        int pages = 0;
+        while (url != null && pages < MAX_PAGES) {
+            PagedResponse resp = getPaged(url, apiToken);
+            if (resp == null) break;
+            for (Map<String, Object> item : resp.items) {
+                String id = asString(item.get("id"));
+                Object profileObj = item.get("profile");
+                String name = profileObj instanceof Map ? asString(((Map<?, ?>) profileObj).get("name")) : null;
+                if (id != null && name != null) groups.add(new OktaGroupRef(id, name));
+            }
+            url = resp.nextUrl;
+            pages++;
+        }
+        return groups;
+    }
+
+    /** GET /api/v1/groups/{groupId}/users — every member of one group, fully paginated. */
+    public static List<OktaUserRef> fetchGroupMembers(String managementBaseUrl, String apiToken, String groupId) {
+        return fetchUserPages(managementBaseUrl + "/api/v1/groups/" + groupId + "/users?limit=" + PAGE_SIZE, apiToken);
+    }
+
+    /**
+     * GET /api/v1/users — every active user in the org, fully paginated. Needed alongside
+     * fetchGroupMembers: upsertDeviceTags does a full-replace-by-source, so a user who dropped
+     * out of every group still needs to be visited (with an empty group list) for their stale
+     * "okta"-sourced tag to actually clear — group rosters alone would just silently skip them.
+     */
+    public static List<OktaUserRef> fetchAllUsers(String managementBaseUrl, String apiToken) {
+        String filter = "status eq \"ACTIVE\"";
+        String url = managementBaseUrl + "/api/v1/users?limit=" + PAGE_SIZE + "&filter=" + urlEncode(filter);
+        return fetchUserPages(url, apiToken);
+    }
+
+    private static List<OktaUserRef> fetchUserPages(String startUrl, String apiToken) {
+        List<OktaUserRef> users = new ArrayList<>();
+        String url = startUrl;
+        int pages = 0;
+        while (url != null && pages < MAX_PAGES) {
+            PagedResponse resp = getPaged(url, apiToken);
+            if (resp == null) break;
+            for (Map<String, Object> item : resp.items) {
+                users.add(toUserRef(item));
+            }
+            url = resp.nextUrl;
+            pages++;
+        }
+        return users;
+    }
+
+    private static OktaUserRef toUserRef(Map<String, Object> item) {
+        String id = asString(item.get("id"));
+        Object profileObj = item.get("profile");
+        String login = null, email = null;
+        if (profileObj instanceof Map) {
+            Map<?, ?> profile = (Map<?, ?>) profileObj;
+            login = asString(profile.get("login"));
+            email = asString(profile.get("email"));
+        }
+        return new OktaUserRef(id, login, email);
+    }
+
+    private static String asString(Object o) {
+        return o == null ? null : String.valueOf(o);
+    }
+
+    private static String urlEncode(String s) {
+        try {
+            return java.net.URLEncoder.encode(s, "UTF-8");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+
+    private static class PagedResponse {
+        List<Map<String, Object>> items;
+        String nextUrl;
+    }
+
+    private static PagedResponse getPaged(String url, String apiToken) {
+        Request request = new Request.Builder()
+                .url(url)
+                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                .header(HttpHeaders.AUTHORIZATION, "SSWS " + apiToken)
+                .build();
+
+        for (int attempt = 0; attempt <= MAX_RETRIES_ON_429; attempt++) {
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (response.code() == 429) {
+                    long backoffMs = retryAfterMillis(response, attempt);
+                    loggerMaker.infoAndAddToDb("[Okta] 429 rate-limited on " + url + ", backing off " + backoffMs + "ms", LogDb.DASHBOARD);
+                    sleep(backoffMs);
+                    continue;
+                }
+                if (!response.isSuccessful()) {
+                    loggerMaker.errorAndAddToDb("[Okta] request failed (" + response.code() + "): " + url, LogDb.DASHBOARD);
+                    return null;
+                }
+                String body = response.body() != null ? response.body().string() : "[]";
+                List<Map<String, Object>> items = new Gson().fromJson(body, LIST_OF_MAPS);
+                PagedResponse result = new PagedResponse();
+                result.items = items != null ? items : Collections.emptyList();
+                result.nextUrl = parseNextLink(response.header("Link"));
+                return result;
+            } catch (Exception e) {
+                loggerMaker.errorAndAddToDb(e, "[Okta] error calling " + url + ": " + e.getMessage(), LogDb.DASHBOARD);
+                return null;
+            }
+        }
+        loggerMaker.errorAndAddToDb("[Okta] giving up after repeated 429s: " + url, LogDb.DASHBOARD);
+        return null;
+    }
+
+    /** Okta's Link header looks like: {@code <url1>; rel="self", <url2>; rel="next"}. */
+    private static String parseNextLink(String linkHeader) {
+        if (linkHeader == null) return null;
+        for (String part : linkHeader.split(",")) {
+            if (part.contains("rel=\"next\"")) {
+                int start = part.indexOf('<');
+                int end = part.indexOf('>');
+                if (start >= 0 && end > start) return part.substring(start + 1, end);
+            }
+        }
+        return null;
+    }
+
+    private static long retryAfterMillis(Response response, int attempt) {
+        String retryAfter = response.header("Retry-After");
+        if (retryAfter != null) {
+            try {
+                return Long.parseLong(retryAfter.trim()) * 1000L;
+            } catch (NumberFormatException ignored) {
+                // fall through to exponential backoff
+            }
+        }
+        return (long) Math.pow(2, attempt) * 1000L;
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
Added a new cron job to periodically sync Okta user group memberships into AgenticUsers as device tags. This includes the creation of the OktaUserSyncCron class, enhancements to the AgentUsersDao for device tag management, and updates to the configuration to support Okta API integration. The implementation ensures that user tags are accurately maintained based on Okta group data, improving user management capabilities.