### PR TITLE
fix: stop redirecting Argus off /inventory to the Atlas-only grouped agentic-assets view

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -522,9 +522,13 @@ function ApiCollections(props) {
 
     const navigate = useNavigate();
 
-    // /inventory is deprecated for Atlas/Argus; redirect unless embedded (e.g. McpSecurityPage's tab)
+    // /inventory is deprecated for Atlas (its left-nav always targets /agentic-assets directly, so
+    // reaching /inventory here means a stale link/back-button); redirect unless embedded (e.g.
+    // McpSecurityPage's tab). Argus has NO equivalent grouped page — its own left-nav intentionally
+    // sends it to /inventory, and this component's isArgus-conditional rendering below is its real
+    // view, so it must not be redirected away from itself.
     useEffect(() => {
-        if (!onlyShowCollectionsTable && (isEndpointSecurityCategory() || isAgenticSecurityCategory())) {
+        if (!onlyShowCollectionsTable && isEndpointSecurityCategory()) {
             navigate("/dashboard/observe/agentic-assets", { replace: true });
         }
     }, [navigate]);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/Settings.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/Settings.jsx
@@ -4,7 +4,7 @@ import { Outlet, useNavigate } from "react-router-dom"
 import './settings.css'
 import SettingsLeftNav from "./nav/SettingsLeftNav";
 import { useEffect } from "react";
-import { isEndpointSecurityCategory, isAgenticSecurityCategory } from "../../../main/labelHelper";
+import { isEndpointSecurityCategory } from "../../../main/labelHelper";
 
 function SettingsHeader({ onHandleClose }) {
     const buttonComp = (
@@ -28,7 +28,7 @@ const Settings = () => {
     const navigate = useNavigate();
 
     const handleSettingsClose = () => {
-        if (isEndpointSecurityCategory() || isAgenticSecurityCategory()) {
+        if (isEndpointSecurityCategory()) {
             navigate("/dashboard/observe/agentic-assets");
         } else {
             navigate("/dashboard/observe/inventory");


### PR DESCRIPTION
## Summary
- `5d32fc2068` (already on master) added a redirect sending **both** Atlas and Argus from `/dashboard/observe/inventory` to `/dashboard/observe/agentic-assets`. That redirect was only ever meant for Atlas — its own left-nav already targets `/agentic-assets` directly, so reaching `/inventory` there means a stale link/back-button.
- Argus has no equivalent grouped page. Its left-nav intentionally sends it to `/inventory`, where `ApiCollections.jsx`'s own `isArgus`-conditional rendering is its real, flat, non-grouped view (column ordering, sort options, etc. all already built for it) — the redirect was bouncing Argus away from itself before that view ever got a chance to render.
- The same bug was duplicated in `Settings.jsx`'s "close settings" handler.
- Scoped both redirects back to `isEndpointSecurityCategory()` (Atlas) only, matching pre-regression behavior. Left the unrelated `row.css` ellipsis-overflow fix from that same commit untouched.

## Test plan
- [x] Confirmed via `git show 5d32fc2068` that this reverts exactly the regressive hunks (Argus-affecting `||` clauses), nothing else.
- [x] Rebuilt frontend (webpack --watch), zero console errors.
- [x] Confirmed Atlas still redirects `/inventory` → `/agentic-assets` as before (unaffected).
- [ ] Argus itself couldn't be live-tested locally — every seeded dev account has the `SECURITY_TYPE_AGENTIC` Stigg feature flag ungranted, so the category is greyed out in the switcher. Verifying now with a local-only `func.js` override to force it granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)