### PR TITLE
fix: stop bouncing Atlas device drill-downs off /inventory before the endpoint tree can render

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/ApiCollectionsAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/ApiCollectionsAction.java
@@ -488,6 +488,62 @@ public class ApiCollectionsAction extends UserAction {
         return Action.NONE;
     }
 
+    // Deliberately NOT named "hostNames"/"hostnames" — this class already has an unrelated
+    // "hostnames" field (line ~2348, on-demand icon fetching) and Struts binds request params by
+    // exact property name, so a near-identical name here would be a silent footgun.
+    @Setter
+    private List<String> deviceHostNames;
+
+    // Same response shape as fetchAllCollectionsBasic (reuses ApiCollectionBasicMixin so the
+    // frontend's existing transformRawCollectionData/categorizeCollections pipeline needs no
+    // changes), but scoped to a specific hostName list via a real DB-level $in filter instead of
+    // findAll(Filters.empty()) — for callers that only need a handful of collections (e.g. one
+    // device's endpoint tree in ApiCollections.jsx/AgentEndpointTreeTable.jsx) and shouldn't pay
+    // for loading the whole account, which doesn't scale to accounts with thousands of collections.
+    public String fetchCollectionsBasicForHostNames() throws Exception {
+        long start = System.currentTimeMillis();
+        if (deviceHostNames == null || deviceHostNames.isEmpty()) {
+            HttpServletResponse httpResponse = ServletActionContext.getResponse();
+            httpResponse.setContentType("application/json");
+            httpResponse.setCharacterEncoding("UTF-8");
+            new ObjectMapper().writeValue(httpResponse.getOutputStream(), Collections.singletonMap("apiCollections", Collections.emptyList()));
+            return Action.NONE;
+        }
+
+        this.apiCollections = ApiCollectionsDao.instance.findAll(Filters.in(ApiCollection.HOST_NAME, deviceHostNames), Projections.exclude(
+                "urls", "conditions", "serviceGraphEdges", "hostNames", "serviceTag",
+                "sampleCollectionsDropped", "redact", "runDependencyAnalyser",
+                "matchDependencyWithOtherCollections", "sseCallbackUrl", "mcpTransportType",
+                "mcpMaliciousnessLastCheck", "vxlanId", "userSetEnvType"
+        ));
+
+        this.apiCollections = fillApiCollectionsUrlCount(this.apiCollections, Filters.nin(SingleTypeInfo._API_COLLECTION_ID, deactivatedCollections));
+
+        for (ApiCollection c : this.apiCollections) {
+            List<CollectionTags> tags = c.getTagsList();
+            if (tags != null) {
+                for (CollectionTags tag : tags) {
+                    tag.setLastUpdatedTs(0);
+                    tag.setSource(null);
+                }
+            }
+        }
+
+        com.akto.util.IconUtils.processIconsForCollections(this.apiCollections);
+
+        HttpServletResponse httpResponse = ServletActionContext.getResponse();
+        httpResponse.setContentType("application/json");
+        httpResponse.setCharacterEncoding("UTF-8");
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(ApiCollection.class, ApiCollectionBasicMixin.class);
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("apiCollections", this.apiCollections);
+        mapper.writeValue(httpResponse.getOutputStream(), responseBody);
+
+        loggerMaker.infoAndAddToDb("[fetchCollectionsBasicForHostNames] TOTAL took " + (System.currentTimeMillis() - start) + "ms, hostNames=" + deviceHostNames.size() + ", found=" + this.apiCollections.size());
+        return Action.NONE;
+    }
+
     public String fetchCollection() {
         this.apiCollections = new ArrayList<>();
         ApiCollection c = ApiCollectionsDao.instance.findOne(Filters.eq(Constants.ID, apiCollectionId));

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -2997,6 +2997,26 @@
             </result>
         </action>
 
+        <action name="api/fetchCollectionsBasicForHostNames" class="com.akto.action.ApiCollectionsAction" method="fetchCollectionsBasicForHostNames">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <interceptor-ref name="roleAccessInterceptor">
+                <param name="featureLabel">API_COLLECTIONS</param>
+                <param name="accessType">READ</param>
+            </interceptor-ref>
+            <result name="FORBIDDEN" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="SUCCESS" type="json" />
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/fetchIconsForHostnames" class="com.akto.action.ApiCollectionsAction" method="fetchIconsForHostnames">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api.js
@@ -239,6 +239,17 @@ export default {
             data: {}
         })
     },
+    // Same response shape as getAllCollectionsBasic (apiCollections array), scoped to a specific
+    // hostName list via a server-side $in query — for ApiCollections.jsx's device-tree drill-down
+    // (see UsersAndDevices.jsx's row click), which only needs one device's handful of collections
+    // and shouldn't pay for loading the whole account's collections to get there.
+    async fetchCollectionsBasicForHostNames(deviceHostNames) {
+        return await request({
+            url: '/api/fetchCollectionsBasicForHostNames',
+            method: 'post',
+            data: { deviceHostNames }
+        })
+    },
     // Paginated, sorted, searchable grouped-asset rows for the Agentic Assets "New Layout" table —
     // replaces computing all ~800 grouped rows client-side on every load (see
     // atlas-scale-test/DASHBOARD_OPTIMIZATION.md's "paginated server-side aggregation rebuild").

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -37,7 +37,7 @@ import ReactFlow, {
 import SetUserEnvPopupComponent from "./component/SetUserEnvPopupComponent";
 import { getDashboardCategory, mapLabel, isMCPSecurityCategory, isAgenticSecurityCategory, isEndpointSecurityCategory, isApiSecurityCategory, isDastCategory } from "../../../../main/labelHelper";
 import useAgenticFilter, { FILTER_TYPES } from "./useAgenticFilter";
-import { AGENTIC_OBSERVE_BACK_PATHS, INVENTORY_FILTER_KEY, fetchAndCacheSkillApiData } from "../agentic/constants";
+import { AGENTIC_OBSERVE_BACK_PATHS, INVENTORY_FILTER_KEY, fetchAndCacheSkillApiData, fetchAndCacheAgenticTrafficRiskBundle, fetchAndCacheAgenticSensitiveInfo } from "../agentic/constants";
 import AgentEndpointTreeTable from "./AgentEndpointTreeTable";
 import { fetchEndpointShieldUsernameMap, getUsernameForCollection } from "./endpointShieldHelper";
 import { sendQuery } from "../../agentic/services/agenticService";
@@ -535,6 +535,14 @@ function ApiCollections(props) {
     // discarding the filter/context — so redirect only when there's no such filter, i.e. a stale
     // link/bookmark/back-button, not a drill-down.
     const inventoryPageFilters = PersistStore(state => state.filtersMap)?.[INVENTORY_FILTER_KEY];
+    // The specific device/agent hostName list from that filter, when present — lets fetchData's
+    // mount effect below take a scoped path (fetchCollectionsBasicForHostNames, a real DB $in
+    // query) instead of api.getAllCollectionsBasic()'s whole-account fetch, which doesn't scale to
+    // accounts with thousands of devices/collections just to filter down to one device's handful
+    // client-side afterward (useAgenticFilter's hostName branch). Only hostName-type filters have
+    // this scoped alternative; envType/tag-based filters still need the full account fetch to
+    // match tag values, so they keep going through fetchData unchanged.
+    const deviceHostNamesFilter = inventoryPageFilters?.filters?.find(f => f.key === 'hostName' && !f.value?.negated)?.value?.values;
     useEffect(() => {
         if (!onlyShowCollectionsTable && isEndpointSecurityCategory() && !inventoryPageFilters) {
             navigate("/dashboard/observe/agentic-assets", { replace: true });
@@ -1130,6 +1138,54 @@ function ApiCollections(props) {
         }
     }
 
+    // Lightweight counterpart to fetchData() above, for the device-tree drill-down (see
+    // deviceHostNamesFilter/useTreeView) — fetches just this device's own collections via a scoped
+    // $in query (fetchCollectionsBasicForHostNames) instead of the whole account
+    // (api.getAllCollectionsBasic()), matching the server-side-scoped pattern already used
+    // elsewhere on Atlas (AgenticAssetsPage.jsx, Endpoints.jsx, UsersAndDevices.jsx). Traffic/risk/
+    // sensitive-data maps still come from the same shared, cached, account-wide bundles those
+    // pages use (fetchAndCacheAgenticTrafficRiskBundle/fetchAndCacheAgenticSensitiveInfo) — those
+    // are already cheap (small id->value maps, not full documents) and likely already warm from
+    // the UsersAndDevices.jsx page the user just navigated from.
+    // Deliberately does NOT touch the global collectionsMap/hostNameMap/tagCollectionsMap/
+    // registryStatusMap PersistStore caches fetchData populates below — those are account-wide by
+    // contract, and overwriting them with just this one device's handful of collections would
+    // corrupt them for every other page that reads them.
+    async function fetchTargetedDeviceCollections(deviceHostNames, isMountedRef) {
+        try {
+            setLoading(true);
+            const [collectionsResp, trafficRiskBundle, sensitiveMap, endpointUsernameMap] = await Promise.all([
+                api.fetchCollectionsBasicForHostNames(deviceHostNames),
+                fetchAndCacheAgenticTrafficRiskBundle({ api, PersistStore }),
+                fetchAndCacheAgenticSensitiveInfo({ api, PersistStore }),
+                fetchEndpointShieldUsernameMap(),
+            ]);
+            if (!isMountedRef.current) return;
+
+            const cacheMaps = {
+                trafficInfoMap: trafficRiskBundle?.trafficMap || {},
+                coverageMap: {},
+                riskScoreMap: trafficRiskBundle?.riskScoreMap || {},
+                severityInfoMap: {},
+                sensitiveInfoMap: sensitiveMap || {},
+                usernameMap: endpointUsernameMap || {},
+            };
+
+            const lightweightData = (collectionsResp?.apiCollections || []).map(c => transformRawCollectionData(c, cacheMaps));
+            const { categorized, envTypeObj } = categorizeCollections(lightweightData);
+
+            setData(categorized);
+            setNormalData(lightweightData);
+            setEnvTypeMap(envTypeObj);
+            setUsernameMap(endpointUsernameMap || {});
+            setSummaryData({ totalEndpoints: 0, totalTestedEndpoints: 0, totalSensitiveEndpoints: 0, totalCriticalEndpoints: 0, totalAllowedForTesting: 0 });
+            setHasUsageEndpoints(true);
+            setLoading(false);
+        } catch (error) {
+            if (isMountedRef.current) setLoading(false);
+        }
+    }
+
     function disambiguateLabel(key, value) {
         return func.convertToDisambiguateLabelObj(value, null, 2)
     }
@@ -1186,7 +1242,11 @@ function ApiCollections(props) {
     useEffect(() => {
         const isMountedRef = { current: true };
 
-        fetchData(isMountedRef, false); // Use cache on mount
+        if (isEndpointSecurityCategory() && deviceHostNamesFilter?.length > 0) {
+            fetchTargetedDeviceCollections(deviceHostNamesFilter, isMountedRef);
+        } else {
+            fetchData(isMountedRef, false); // Use cache on mount
+        }
         resetFunc();
 
         // Cleanup function to prevent state updates after unmount

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiCollections.jsx
@@ -527,11 +527,19 @@ function ApiCollections(props) {
     // McpSecurityPage's tab). Argus has NO equivalent grouped page — its own left-nav intentionally
     // sends it to /inventory, and this component's isArgus-conditional rendering below is its real
     // view, so it must not be redirected away from itself.
+    //
+    // Exception within Atlas itself: UsersAndDevices.jsx's row click stores a device/agent filter
+    // under INVENTORY_FILTER_KEY *before* navigating here, so this page can render that device's
+    // endpoint tree (AgentEndpointTreeTable, see useTreeView below). Redirecting unconditionally
+    // skipped that tree entirely and sent the user straight to the grouped assets page instead,
+    // discarding the filter/context — so redirect only when there's no such filter, i.e. a stale
+    // link/bookmark/back-button, not a drill-down.
+    const inventoryPageFilters = PersistStore(state => state.filtersMap)?.[INVENTORY_FILTER_KEY];
     useEffect(() => {
-        if (!onlyShowCollectionsTable && isEndpointSecurityCategory()) {
+        if (!onlyShowCollectionsTable && isEndpointSecurityCategory() && !inventoryPageFilters) {
             navigate("/dashboard/observe/agentic-assets", { replace: true });
         }
-    }, [navigate]);
+    }, [navigate, inventoryPageFilters]);
 
     const getAgenticObserveBackUrl = () => {
         if (!isEndpointSecurityCategory()) return undefined;


### PR DESCRIPTION
## Summary
- `5d32fc2068` (already on master) made `/dashboard/observe/inventory` unconditionally redirect Atlas to `/dashboard/observe/agentic-assets`.
- Atlas's own left-nav never targets `/inventory` directly — but `UsersAndDevices.jsx`'s row click does: it stores a device/agent filter under `INVENTORY_FILTER_KEY` and *then* navigates here, so this page can render that device's endpoint tree (`AgentEndpointTreeTable`, gated by `useTreeView`).
- The unconditional redirect skipped that tree every time and bounced straight to the grouped assets page instead, discarding the filter/context — "clicking any endpoint" appeared to just redirect away instead of showing the tree it used to show.
- Fix: only redirect when there's no such filter present (i.e. a stale link/bookmark, not a device drill-down).

**Follow-up (2nd commit)**: once the redirect was fixed, the drill-down still called `api.getAllCollectionsBasic()` on mount — loading every collection in the whole account just to filter it down to one device's handful client-side. Doesn't scale to accounts with thousands of devices/collections. Added `fetchCollectionsBasicForHostNames` (`ApiCollectionsAction.java`), a server-side `$in` query scoped to the clicked device's own hostNames, reusing the exact same response shape as `getAllCollectionsBasic` so the frontend's transform pipeline needs no changes. `ApiCollections.jsx` now takes this scoped path whenever a hostName-type filter is present; envType/tag-based filters still go through the full account fetch (a tag match can't be reduced to a hostName list). Traffic/risk/sensitive-data maps still come from the same shared, cached, account-wide bundles other Atlas pages already use.

Related: #6085 fixes the Argus half of the original over-eager redirect; this one fixes an Atlas-specific case the Argus fix doesn't touch. Expect a small merge overlap between the two — trivial to resolve either order.

## Test plan
- [x] Verified live on the `Restored 1779231193` account (Atlas category): clicking a device row on `/dashboard/observe/users-and-devices` (Devices tab) now stays on `/dashboard/observe/inventory` with the device's filter applied, instead of bouncing to `/agentic-assets`.
- [x] Verified via network trace: clicking a device row no longer calls `getAllCollectionsBasic`; only the new scoped `fetchCollectionsBasicForHostNames` fires, correctly returning all of that device's real collections (confirmed 28/28 present in the response for a test device).
- [x] Zero console errors after either change.
- [ ] **Found while verifying, NOT caused by this PR**: even with all 28 collections now correctly delivered to the frontend, the tree view itself still only renders 1 of them ("Showing 1-1 of 1"). This is a separate, pre-existing bug in `useAgenticFilter.js`'s hostName-filter branch (or `AgentEndpointTreeTable.jsx`'s consumption of it) — confirmed NOT a data-availability issue since the full 28 arrive correctly now. Flagging as a follow-up, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)