### PR TITLE
feat: initialize Okta user sync scheduler in context listener

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
+++ b/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
@@ -2685,6 +2685,8 @@ public class InitializerListener implements ServletContextListener {
                             runInitializerFunctions();
                         }
                     }, "context-initializer-secondary");
+                    logger.warn("Started Okta user sync scheduler", LogDb.DASHBOARD);
+                    oktaUserSyncCron.setUpOktaUserSyncScheduler();
                     logger.warn("Started webhook schedulers", LogDb.DASHBOARD);
                     setUpWebhookScheduler();
                     logger.warn("Started threat detection rolling reboot scheduler", LogDb.DASHBOARD);
@@ -2713,7 +2715,6 @@ public class InitializerListener implements ServletContextListener {
                         updateSensitiveInfoInApiInfo.setUpSensitiveMapInApiInfoScheduler();
                         syncCronInfo.setUpUpdateCronScheduler();
                         agentBasePromptDetectionCron.setUpAgentBasePromptDetectionScheduler();
-                        oktaUserSyncCron.setUpOktaUserSyncScheduler();
                         updateApiGroupsForAccounts();
                         setupAutomatedApiGroupsScheduler();
                         trimCappedCollectionsJob();


### PR DESCRIPTION
Added the setup for the Okta user synchronization scheduler in the InitializerListener class. This change ensures that the scheduler is properly initialized during the application startup process, enhancing user management capabilities by maintaining accurate user tags based on Okta group data.