### PR TITLE
feat: implement migration of team roles to device tags

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
+++ b/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
@@ -2679,14 +2679,15 @@ public class InitializerListener implements ServletContextListener {
 
                     logger.debug("Starting init functions and scheduling jobs at " + now);
 
+                    logger.warn("Started Okta user sync scheduler", LogDb.DASHBOARD);
+                    oktaUserSyncCron.setUpOktaUserSyncScheduler();
+
                     AccountTask.instance.executeTask(new Consumer<Account>() {
                         @Override
                         public void accept(Account account) {
                             runInitializerFunctions();
                         }
                     }, "context-initializer-secondary");
-                    logger.warn("Started Okta user sync scheduler", LogDb.DASHBOARD);
-                    oktaUserSyncCron.setUpOktaUserSyncScheduler();
                     logger.warn("Started webhook schedulers", LogDb.DASHBOARD);
                     setUpWebhookScheduler();
                     logger.warn("Started threat detection rolling reboot scheduler", LogDb.DASHBOARD);
@@ -3662,6 +3663,24 @@ public class InitializerListener implements ServletContextListener {
         }
     }
 
+    // Individually try/catch'd and called first in setBackwardCompatibilities — that method has no
+    // per-call isolation, so an unrelated hook throwing further down would otherwise silently
+    // prevent every hook after it (including this one) from ever running, with no
+    // migration-specific error logged anywhere.
+    private static void safeMigrateTeamRoleToDeviceTags(BackwardCompatibility backwardCompatibility){
+        try {
+            if(backwardCompatibility.getMigrateTeamRoleToDeviceTags() == 0){
+                BackwardCompatibilityUtils.migrateTeamRoleToDeviceTags();
+                BackwardCompatibilityDao.instance.updateOne(
+                    Filters.eq("_id", backwardCompatibility.getId()),
+                    Updates.set(BackwardCompatibility.MIGRATE_TEAM_ROLE_TO_DEVICE_TAGS, Context.now())
+                );
+            }
+        } catch (Exception e) {
+            logger.errorAndAddToDb(e, "error in migrateTeamRoleToDeviceTags: " + e.getMessage(), LogDb.DASHBOARD);
+        }
+    }
+
 
     private static void removeRagDatabaseTag(BackwardCompatibility backwardCompatibility) {
         int accountId = Context.accountId.get();
@@ -3698,13 +3717,15 @@ public class InitializerListener implements ServletContextListener {
     }
 
     public static void setBackwardCompatibilities(BackwardCompatibility backwardCompatibility){
+        safeMigrateTeamRoleToDeviceTags(backwardCompatibility);
+
         if (DashboardMode.isMetered()) {
             try {
                 setOrganizationsInBilling(backwardCompatibility);
             } catch (Exception e) {
                 e.printStackTrace();
             }
-            
+
         }
         removeRagDatabaseTag(backwardCompatibility);
         setAktoDefaultNewUI(backwardCompatibility);

--- a/apps/dashboard/src/main/java/com/akto/utils/scripts/BackwardCompatibilityUtils.java
+++ b/apps/dashboard/src/main/java/com/akto/utils/scripts/BackwardCompatibilityUtils.java
@@ -15,6 +15,7 @@ import com.akto.dao.context.Context;
 import com.akto.dao.monitoring.ModuleInfoDao;
 import com.akto.dto.AgenticUsers;
 import com.akto.dto.ApiCollection;
+import com.akto.dto.DeviceTag;
 import com.akto.dto.monitoring.ModuleInfo;
 import com.akto.dto.traffic.CollectionTags;
 import com.akto.util.Constants;
@@ -161,6 +162,49 @@ public class BackwardCompatibilityUtils {
             ApiCollectionsDao.instance.getMCollection().deleteMany(
                 Filters.in(Constants.ID, oldIdsToDelete)
             );
+        }
+    }
+
+    /**
+     * One-time, idempotent conversion of agent_users' old teamName/userRole fields (written by
+     * AgentUsersDao.upsertTag, the dashboard's manual-edit path) into deviceTags — the model the
+     * new Okta sync cron (upsertDeviceTags) and any tags-aware UI actually read. teamName/userRole
+     * aren't removed here, just mirrored, so this is safe to run even if some other caller still
+     * writes them. Only adds a manual tag where one isn't already present for that key, so a
+     * fresher manual edit or a synced value from another source is never clobbered or duplicated.
+     */
+    public static void migrateTeamRoleToDeviceTags() {
+        List<AgenticUsers> users = AgentUsersDao.instance.findAll(Filters.or(
+                Filters.exists(AgenticUsers.TEAM_NAME, true),
+                Filters.exists(AgenticUsers.USER_ROLE, true)));
+
+        int now = Context.now();
+        for (AgenticUsers u : users) {
+            String team = u.getTeamName();
+            String role = u.getUserRole();
+            boolean hasTeam = team != null && !team.trim().isEmpty();
+            boolean hasRole = role != null && !role.trim().isEmpty();
+            if (!hasTeam && !hasRole) continue;
+
+            List<DeviceTag> existing = u.getDeviceTags() != null ? u.getDeviceTags() : new ArrayList<>();
+            boolean hasManualTeamTag = existing.stream().anyMatch(t -> "team".equals(t.getKey()) && DeviceTag.SOURCE_MANUAL.equals(t.getSource()));
+            boolean hasManualRoleTag = existing.stream().anyMatch(t -> "role".equals(t.getKey()) && DeviceTag.SOURCE_MANUAL.equals(t.getSource()));
+
+            List<DeviceTag> merged = new ArrayList<>(existing);
+            boolean changed = false;
+            if (hasTeam && !hasManualTeamTag) {
+                merged.add(new DeviceTag("team", team.trim().toLowerCase(), DeviceTag.SOURCE_MANUAL, now, "migration"));
+                changed = true;
+            }
+            if (hasRole && !hasManualRoleTag) {
+                merged.add(new DeviceTag("role", role.trim().toLowerCase(), DeviceTag.SOURCE_MANUAL, now, "migration"));
+                changed = true;
+            }
+            if (!changed) continue;
+
+            AgentUsersDao.instance.updateOne(
+                    Filters.eq(AgenticUsers.USER_NAME, u.getUserName()),
+                    Updates.set(AgenticUsers.DEVICE_TAGS, merged));
         }
     }
 

--- a/libs/dao/src/main/java/com/akto/dto/BackwardCompatibility.java
+++ b/libs/dao/src/main/java/com/akto/dto/BackwardCompatibility.java
@@ -132,6 +132,9 @@ public class BackwardCompatibility {
     public static final String MIGRATE_ORPHAN_SKILL_COLLECTIONS = "migrateOrphanSkillCollections";
     private int migrateOrphanSkillCollections;
 
+    public static final String MIGRATE_TEAM_ROLE_TO_DEVICE_TAGS = "migrateTeamRoleToDeviceTags";
+    private int migrateTeamRoleToDeviceTags;
+
     public BackwardCompatibility(int id, int dropFilterSampleData, int resetSingleTypeInfoCount, int dropWorkflowTestResult,
                                  int readyForNewTestingFramework,int addAktoDataTypes, boolean deploymentStatusUpdated,
                                  int authMechanismData, boolean mirroringLambdaTriggered, int deleteAccessListFromApiToken,
@@ -555,5 +558,13 @@ public class BackwardCompatibility {
 
     public void setMigrateOrphanSkillCollections(int migrateOrphanSkillCollections) {
         this.migrateOrphanSkillCollections = migrateOrphanSkillCollections;
+    }
+
+    public int getMigrateTeamRoleToDeviceTags() {
+        return migrateTeamRoleToDeviceTags;
+    }
+
+    public void setMigrateTeamRoleToDeviceTags(int migrateTeamRoleToDeviceTags) {
+        this.migrateTeamRoleToDeviceTags = migrateTeamRoleToDeviceTags;
     }
 }


### PR DESCRIPTION
Added functionality to migrate old teamName and userRole fields from AgenticUsers to deviceTags, ensuring compatibility with the new Okta sync cron. This change includes a new method in BackwardCompatibilityUtils for the migration process and updates to the BackwardCompatibility class to track migration status. Enhanced error handling during migration to prevent silent failures.