### PR TITLE
Enhance AgentQueryRecord by adding stripAwsMetadata method to remove …

### DIFF
--- a/apps/mini-runtime/src/main/java/com/akto/hybrid_parsers/HttpCallParser.java
+++ b/apps/mini-runtime/src/main/java/com/akto/hybrid_parsers/HttpCallParser.java
@@ -670,6 +670,37 @@ public class HttpCallParser {
         }
     }
 
+    /**
+     * awsMetadata is already fully captured as structured Trace/Span/service-graph data by
+     * BedrockAgentTraceParser by the time this runs — it can embed full tool-call outputs
+     * (file listings, page dumps, etc.), which routinely pushes the sample-data message this
+     * account's Kafka producer ships to database-abstractor past Kafka's default 1MB
+     * max.request.size. That failure is silent (KafkaProducer.doSend() swallows
+     * RecordTooLargeException internally and only logs via a bare, non-persisted
+     * logger.error in the producer callback), so oversized samples vanish with no trace
+     * instead of erroring — stripping it here, before it reaches httpResponseParam.getOrig()
+     * (what APICatalogSync.recordMessage() captures as the sample), avoids that outcome.
+     */
+    private void stripAwsMetadataFromSample(HttpResponseParams httpResponseParam) {
+        try {
+            String updatedPayload = JSONUtils.removeKey(httpResponseParam.getPayload(), "awsMetadata");
+            if (updatedPayload == null || updatedPayload.equals(httpResponseParam.getPayload())) {
+                return;
+            }
+            httpResponseParam.setPayload(updatedPayload);
+            Map<String, Object> origMap = JSONUtils.getMap(httpResponseParam.getOrig());
+            if (origMap != null) {
+                origMap.put("responsePayload", updatedPayload);
+                String updatedOrig = JSONUtils.getString(origMap);
+                if (updatedOrig != null) {
+                    httpResponseParam.setOrig(updatedOrig);
+                }
+            }
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb(e, "Error stripping awsMetadata from sample payload: " + e.getMessage());
+        }
+    }
+
     private void parseCopilotTrace(HttpResponseParams httpResponseParam) {
         try {
             String traces = httpResponseParam.getTraces();
@@ -1863,6 +1894,7 @@ public class HttpCallParser {
             // Parse Bedrock Agent trace metadata if this is Bedrock Agent traffic
             if (isBedrockAgentTraffic(tagsMap)) {
                 parseBedrockAgentTrace(httpResponseParam);
+                stripAwsMetadataFromSample(httpResponseParam);
             }
 
             // Build service graph edges for Arcade traffic

--- a/libs/dao/src/main/java/com/akto/util/JSONUtils.java
+++ b/libs/dao/src/main/java/com/akto/util/JSONUtils.java
@@ -256,4 +256,21 @@ public class JSONUtils {
             return null;
         }
     }
+
+    /**
+     * Returns json with the given top-level key removed, or the original string
+     * unchanged if it isn't a JSON object, doesn't parse, or doesn't have that key.
+     */
+    public static String removeKey(String json, String key) {
+        if (json == null || json.isEmpty()) {
+            return json;
+        }
+        Map<String, Object> map = getMap(json);
+        if (map == null || !map.containsKey(key)) {
+            return json;
+        }
+        map.remove(key);
+        String updated = getString(map);
+        return updated != null ? updated : json;
+    }
 }

--- a/libs/utils/src/main/java/com/akto/utils/elasticsearch/AgentQueryRecord.java
+++ b/libs/utils/src/main/java/com/akto/utils/elasticsearch/AgentQueryRecord.java
@@ -208,7 +208,7 @@ public class AgentQueryRecord {
                 : "span_" + UUID.randomUUID().toString();
 
         String requestPayload  = p.getRequestParams().getPayload();
-        String responsePayload = p.getPayload() != null ? p.getPayload() : "";
+        String responsePayload = stripAwsMetadata(p.getPayload() != null ? p.getPayload() : "");
         int inputTokens  = resolveTokenCount(responsePayload, requestPayload, true);
         int outputTokens = resolveTokenCount(responsePayload, responsePayload, false);
 
@@ -262,6 +262,28 @@ public class AgentQueryRecord {
         if (headers == null) return null;
         List<String> values = headers.get(name);
         return (values != null && !values.isEmpty()) ? values.get(0) : null;
+    }
+
+    /**
+     * awsMetadata duplicates what's already captured as structured Trace/Span data by
+     * BedrockAgentTraceParser — it can embed full tool-call outputs (file listings,
+     * page dumps, etc.), so keeping a second raw copy here needlessly bloats the batch
+     * sent to the agent-query-logs service.
+     */
+    private static String stripAwsMetadata(String responsePayload) {
+        if (responsePayload == null || responsePayload.isEmpty()) {
+            return responsePayload;
+        }
+        try {
+            JSONObject obj = new JSONObject(responsePayload);
+            if (!obj.has("awsMetadata")) {
+                return responsePayload;
+            }
+            obj.remove("awsMetadata");
+            return obj.toString();
+        } catch (Exception ignored) {
+            return responsePayload;
+        }
     }
 
     /** Prefer usage block from LLM response JSON; fall back to payload string length. */

--- a/libs/utils/src/main/java/com/akto/utils/elasticsearch/AgentQueryRecord.java
+++ b/libs/utils/src/main/java/com/akto/utils/elasticsearch/AgentQueryRecord.java
@@ -5,6 +5,7 @@ import com.akto.dto.HttpResponseParams;
 import com.akto.dto.billing.Organization;
 import com.akto.usage.OrgUtils;
 import com.akto.util.Constants;
+import com.akto.util.JSONUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -208,7 +209,11 @@ public class AgentQueryRecord {
                 : "span_" + UUID.randomUUID().toString();
 
         String requestPayload  = p.getRequestParams().getPayload();
-        String responsePayload = stripAwsMetadata(p.getPayload() != null ? p.getPayload() : "");
+        // awsMetadata duplicates what's already captured as structured Trace/Span data by
+        // BedrockAgentTraceParser — it can embed full tool-call outputs (file listings, page
+        // dumps, etc.), so keeping a second raw copy here needlessly bloats the batch sent
+        // to the agent-query-logs service.
+        String responsePayload = JSONUtils.removeKey(p.getPayload() != null ? p.getPayload() : "", "awsMetadata");
         int inputTokens  = resolveTokenCount(responsePayload, requestPayload, true);
         int outputTokens = resolveTokenCount(responsePayload, responsePayload, false);
 
@@ -262,28 +267,6 @@ public class AgentQueryRecord {
         if (headers == null) return null;
         List<String> values = headers.get(name);
         return (values != null && !values.isEmpty()) ? values.get(0) : null;
-    }
-
-    /**
-     * awsMetadata duplicates what's already captured as structured Trace/Span data by
-     * BedrockAgentTraceParser — it can embed full tool-call outputs (file listings,
-     * page dumps, etc.), so keeping a second raw copy here needlessly bloats the batch
-     * sent to the agent-query-logs service.
-     */
-    private static String stripAwsMetadata(String responsePayload) {
-        if (responsePayload == null || responsePayload.isEmpty()) {
-            return responsePayload;
-        }
-        try {
-            JSONObject obj = new JSONObject(responsePayload);
-            if (!obj.has("awsMetadata")) {
-                return responsePayload;
-            }
-            obj.remove("awsMetadata");
-            return obj.toString();
-        } catch (Exception ignored) {
-            return responsePayload;
-        }
     }
 
     /** Prefer usage block from LLM response JSON; fall back to payload string length. */


### PR DESCRIPTION
…awsMetadata from response payload, reducing unnecessary data bloat in agent-query-logs.