### PR TITLE
Fix NPE on first-user email signup (null scopeRoleMapping)

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
@@ -1517,6 +1517,12 @@ public class SignupAction implements Action, ServletResponseAware, ServletReques
                 Account oldAccount = AccountsDao.instance.findOne("_id", invitationToAccount);
                 user = AccountAction.initializeAccount(userEmail, invitationToAccount, oldAccount.getName(), false, this.scopeRoleMapping);
             }else {
+                // For a brand-new org (e.g. the first user signing up via email), the email
+                // signup path does not initialize scopeRoleMapping, so it can be null here.
+                // Guard against an NPE before assigning the default ADMIN scopes.
+                if (this.scopeRoleMapping == null) {
+                    this.scopeRoleMapping = new HashMap<>();
+                }
                 this.scopeRoleMapping.put("API", RBAC.Role.ADMIN.name());
                 this.scopeRoleMapping.put("ENDPOINT", RBAC.Role.ADMIN.name());
                 this.scopeRoleMapping.put("DAST", RBAC.Role.ADMIN.name());


### PR DESCRIPTION
### Problem

On a fresh self-hosted deployment, creating the **first user via email signup** fails with a 500:

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.put(Object, Object)" because "this.scopeRoleMapping" is null
    at com.akto.action.SignupAction.createUserAndRedirect(SignupAction.java:1520)
```

### Root cause

`createUserAndRedirect()` assumes `this.scopeRoleMapping` is non-null in the new-org (`newOrgSetup`) branch and calls `.put(...)` on it directly:

```java
} else {
    this.scopeRoleMapping.put("API", RBAC.Role.ADMIN.name());   // NPE when null
    ...
}
```

But `registerViaEmail()` only initializes `scopeRoleMapping` for the **pending-invite** path. For a brand-new org's first user (no invite), it reaches `createUserAndRedirect(...)` with `scopeRoleMapping` still `null`.

The SSO signup paths (Google/GitHub/Azure) are unaffected because they go through `createUserAndRedirectWithDefaultRole()`, which initializes the map first — which is why only **email** first-user signup breaks.

### Fix

Guard the map before assigning the default ADMIN scopes in the `newOrgSetup` branch (one localized null-check; no behavior change for existing callers).

### Testing

Reproduced on a clean `mongo` volume: first email signup returned 500 with the NPE above. After the patch, the first user is created with an ADMIN RBAC (`API/ENDPOINT/DAST/AGENTIC → ADMIN`) and can log in normally.