### PR TITLE
Fix "Access Restricted" gate blocking open-source local_deploy dashboards

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
@@ -1517,12 +1517,6 @@ public class SignupAction implements Action, ServletResponseAware, ServletReques
                 Account oldAccount = AccountsDao.instance.findOne("_id", invitationToAccount);
                 user = AccountAction.initializeAccount(userEmail, invitationToAccount, oldAccount.getName(), false, this.scopeRoleMapping);
             }else {
-                // For a brand-new org (e.g. the first user signing up via email), the email
-                // signup path does not initialize scopeRoleMapping, so it can be null here.
-                // Guard against an NPE before assigning the default ADMIN scopes.
-                if (this.scopeRoleMapping == null) {
-                    this.scopeRoleMapping = new HashMap<>();
-                }
                 this.scopeRoleMapping.put("API", RBAC.Role.ADMIN.name());
                 this.scopeRoleMapping.put("ENDPOINT", RBAC.Role.ADMIN.name());
                 this.scopeRoleMapping.put("DAST", RBAC.Role.ADMIN.name());

--- a/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/SignupAction.java
@@ -1517,6 +1517,12 @@ public class SignupAction implements Action, ServletResponseAware, ServletReques
                 Account oldAccount = AccountsDao.instance.findOne("_id", invitationToAccount);
                 user = AccountAction.initializeAccount(userEmail, invitationToAccount, oldAccount.getName(), false, this.scopeRoleMapping);
             }else {
+                // For a brand-new org (e.g. the first user signing up via email), the email
+                // signup path does not initialize scopeRoleMapping, so it can be null here.
+                // Guard against an NPE before assigning the default ADMIN scopes.
+                if (this.scopeRoleMapping == null) {
+                    this.scopeRoleMapping = new HashMap<>();
+                }
                 this.scopeRoleMapping.put("API", RBAC.Role.ADMIN.name());
                 this.scopeRoleMapping.put("ENDPOINT", RBAC.Role.ADMIN.name());
                 this.scopeRoleMapping.put("DAST", RBAC.Role.ADMIN.name());

--- a/apps/dashboard/web/polaris_web/web/src/apps/main/index.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/main/index.js
@@ -37,9 +37,15 @@ const currentPath = window.location.pathname;
 const isSignupPage = signupPages.some(page => currentPath.startsWith(page));
 const isWhitelisted = func.isWhiteListedOrganization();
 
+// Open-source self-hosted (local_deploy) deployments have no billing service, so
+// PLAN_TYPE resolves empty and the plan gate below would wrongly block the user.
+// These installs are not SaaS and should never be paywalled.
+const isLocalDeploy = (window.DASHBOARD_MODE || '').toUpperCase() === 'LOCAL_DEPLOY'
+  || window.IS_SAAS === 'false' || window.IS_SAAS === false;
+
 let free = false
-if(isWhitelisted || isSignupPage) {
-  free = false; // Whitelisted users & Signup pages should not block user
+if(isWhitelisted || isSignupPage || isLocalDeploy) {
+  free = false; // Whitelisted users, signup pages & self-hosted local deploys should not block user
 } else {
   // For non-whitelisted, non-signup users, check plan type
   if(window.PLAN_TYPE && ALLOWED_PLANS.includes(window.PLAN_TYPE.toLowerCase())) {


### PR DESCRIPTION
### Problem

On a self-hosted open-source deployment (`DASHBOARD_MODE=local_deploy`, not SaaS), the dashboard shows **"Access Restricted / Contact Sales"** after a successful login, instead of the API Inventory. Reported in #5512.

### Root cause

The SPA access gate in `apps/main/index.js` grants access only when `window.PLAN_TYPE ∈ {enterprise, professional, trial}`:

```js
if(window.PLAN_TYPE && ALLOWED_PLANS.includes(window.PLAN_TYPE.toLowerCase())) {
  free = false;
} else {
  free = true; // blocked
}
```

`PLAN_TYPE` is resolved via the billing service, which does not exist on a self-hosted box, so on a fresh `local_deploy` login `window.PLAN_TYPE === ""` while `window.DASHBOARD_MODE === "LOCAL_DEPLOY"`. The gate never consults `DASHBOARD_MODE`/`IS_SAAS`, so the open-source user is blocked.

### Fix

Treat `local_deploy` / non-SaaS deployments as never-paywalled by adding them to the existing bypass condition (alongside whitelisted orgs and signup pages). No effect on SaaS behavior.

### Testing

Reproduced on `2.19.0_local` (also reported on `2.8.5_local`): fresh signup + login → "Access Restricted". With this change, `local_deploy` logins route straight to the dashboard and all OSS features (API Discovery, Testing, Reports) are accessible.

Fixes #5512