### PR TITLE
Revert "Last 1 month" date range and default changes

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/GithubServerTable.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/GithubServerTable.js
@@ -52,7 +52,7 @@ function GithubServerTable(props) {
     setSearchParams(newSearchParams, { replace: true });
   };
 
-  const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"))
+  const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[5])
   const [hideFilter, setHideFilter] = useState(false)
   const filtersWrapRef = useRef(null)
   const [exportPortalTarget, setExportPortalTarget] = useState(null)

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/AgenticDashboard.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/AgenticDashboard.jsx
@@ -76,7 +76,7 @@ const AgenticDashboard = () => {
     const dashboardCategory = getDashboardCategory();
     const [loading, setLoading] = useState(true);
     const [overallStats, setOverallStats] = useState([])
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"))
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[3])
     const containerRef = useRef(null);
     const [popoverActive, setPopoverActive] = useState(false);
     const [gridWidth, setGridWidth] = useState(1200);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/EndpointPosture.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/EndpointPosture.jsx
@@ -95,7 +95,7 @@ function EndpointPosture() {
     const [loading, setLoading] = useState(true)
 
     // Date range filter state
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"))
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[3])
 
     const [gridWidth, setGridWidth] = useState(1200)
     const resizeObserverRef = useRef(null)

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/HomeDashboard.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/dashboard/HomeDashboard.jsx
@@ -123,7 +123,7 @@ function HomeDashboard() {
         navigate('/dashboard/observe/audit');
     }, [navigate])
 
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"));
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[4]);
 
     const getTimeEpoch = (key) => {
         return Math.floor(Date.parse(currDateRange.period[key]) / 1000)

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailDetection.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailDetection.jsx
@@ -42,7 +42,7 @@ function GuardrailDetection() {
                 period: { since: new Date(startTs * 1000), until: new Date(endTs * 1000) },
             };
         }
-        return values.getRange("last1month");
+        return values.ranges[3];
     }, [searchParams]);
     const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), initialVal);
     const [moreActions, setMoreActions] = useState(false);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailDetectionDemo.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/GuardrailDetectionDemo.jsx
@@ -77,7 +77,7 @@ const sortOptions = [
 
 function GuardrailDetectionDemo() {
 
-    const initialVal = values.getRange("last1month")
+    const initialVal = values.ranges[3]
     const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), initialVal);
     const [moreActions, setMoreActions] = useState(false);
     const [showDetails, setShowDetails] = useState(false);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
@@ -678,7 +678,7 @@ function Violations() {
 
     const [currDateRange, dispatchCurrDateRange] = useReducer(
         produce((draft, action) => func.dateRangeReducer(draft, action)),
-        values.getRange("last1month"),
+        values.ranges[4],
     );
 
     const getTimeEpoch = useCallback((key) => {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/CompliancePage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/CompliancePage.jsx
@@ -213,7 +213,7 @@ function CompliancePage() {
                 return { alias: "custom", title, period: { since: sinceDate, until: untilDate } };
             }
         }
-        return values.getRange("last1month");
+        return values.ranges[5];
     };
     const initialDateRange = getInitialDateRange();
     const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), initialDateRange)

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/IssuesPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/IssuesPage.jsx
@@ -235,7 +235,7 @@ function IssuesPage() {
                 return { alias: "custom", title, period: { since: sinceDate, until: untilDate } };
             }
         }
-        return values.getRange("last1month");
+        return values.ranges[5];
     };
     const initialDateRange = getInitialDateRange();
     const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), initialDateRange)

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/ThreatCompliancePage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/issues/IssuesPage/ThreatCompliancePage.jsx
@@ -149,7 +149,7 @@ function ThreatCompliancePage() {
 
     const [currDateRange, dispatchCurrDateRange] = useReducer(
         produce((draft, action) => func.dateRangeReducer(draft, action)),
-        values.getRange("last1month")
+        values.ranges.find((r) => r.alias === 'last7days') || values.ranges[2]
     );
 
     const getTimeEpoch = (key) => {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/nhi_governance/IdentitiesPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/nhi_governance/IdentitiesPage.jsx
@@ -156,7 +156,7 @@ export default function IdentitiesPage() {
     const [showDetailsPanel, setShowDetailsPanel]   = useState(false);
     const [currDateRange, dispatchCurrDateRange] = useReducer(
         produce((draft, action) => func.dateRangeReducer(draft, action)),
-        values.getRange("last1month")
+        values.ranges[2]
     );
 
     const startTimestamp = parseInt(currDateRange.period.since.getTime() / 1000);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/nhi_governance/ViolationsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/nhi_governance/ViolationsPage.jsx
@@ -188,7 +188,7 @@ export default function ViolationsPage() {
 
     const [currDateRange, dispatchCurrDateRange] = useReducer(
         produce((draft, action) => func.dateRangeReducer(draft, action)),
-        values.getRange("last1month")
+        values.ranges[2]
     );
 
     const startTimestamp = parseInt(currDateRange.period.since.getTime() / 1000);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/AuditData.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/AuditData.jsx
@@ -416,7 +416,7 @@ function AuditData() {
     // When opening conditional approval from bulk selection (1+ MCP server rows); same approval applies to each.
     const [conditionalBulkRows, setConditionalBulkRows] = useState(null);
 
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"));
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[5]);
     const getTimeEpoch = (key) => {
         return Math.floor(Date.parse(currDateRange.period[key]) / 1000)
     }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/SensitiveDataExposure/SensitiveDataExposure.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/SensitiveDataExposure/SensitiveDataExposure.jsx
@@ -204,7 +204,7 @@ function SensitiveDataExposure() {
         
     }
 
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"));
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[5]);
     const getTimeEpoch = (key) => {
         return Math.floor(Date.parse(currDateRange.period[key]) / 1000)
     }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
@@ -313,7 +313,7 @@ export default function AgenticAssetsPage() {
   // traffic, so a narrower default (e.g. Last 1 year) would silently drop them.
   const [currDateRange, dispatchCurrDateRange] = useReducer(
     produce((draft, action) => func.dateRangeReducer(draft, action)),
-    values.getRange("last1month"),
+    values.ranges[5],
   );
   const rawStart = Math.floor(Date.parse(currDateRange.period.since) / 1000);
   const startTimestamp = rawStart <= 1 ? 0 : rawStart;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceEndpoints.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceEndpoints.jsx
@@ -413,7 +413,7 @@ export default function DeviceEndpoints() {
 
     const [currDateRange, dispatchCurrDateRange] = useReducer(
         produce((draft, action) => func.dateRangeReducer(draft, action)),
-        values.getRange("last1month"),
+        values.ranges[4],
     );
     const startTimestamp = Math.floor(Date.parse(currDateRange.period.since) / 1000);
     const endTimestamp = Math.floor(Date.parse(currDateRange.period.until) / 1000);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiChanges.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/ApiChanges.jsx
@@ -61,7 +61,7 @@ function ApiChanges() {
                 return { alias: "custom", title, period: { since: sinceDate, until: untilDate } };
             }
         }
-        return values.getRange("last1month");
+        return values.ranges[3];
     };
 
     const initialVal = getInitialDateRange();

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
@@ -188,7 +188,7 @@ const mapModuleToAgent = (module) => ({
 function EndpointShieldMetadata() {
 
     const [loading, setLoading] = useState(false);
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"));
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[5]);
     const dashboardCategory = PersistStore((state) => state.dashboardCategory) || "API Security";
     const allCollections = PersistStore((state) => state.allCollections) || [];
     const [selectedAgent, setSelectedAgent] = useState(null);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/llm/LLMObservability.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/llm/LLMObservability.jsx
@@ -52,7 +52,7 @@ export default function LLMObservability() {
 
     const [currDateRange, dispatchCurrDateRange] = useReducer(
         produce((draft, action) => func.dateRangeReducer(draft, action)),
-        values.getRange("last1month")
+        values.ranges[5]
     );
     const [selectedSession, setSelectedSession] = useState(null);
     const [selectedTrace, setSelectedTrace]     = useState(null);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/audit_logs/AuditLogs.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/audit_logs/AuditLogs.jsx
@@ -70,7 +70,7 @@ const AuditLogs = () => {
     const [tableLoading, setTableLoading] = useState(false)
     const [auditLogsData, setAuditLogsData] = useState([])
     
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"))
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[2])
     const getTimeEpoch = (key) => {
         return Math.floor(Date.parse(currDateRange.period[key]) / 1000)
     }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/metrics/Metrics.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/metrics/Metrics.jsx
@@ -80,7 +80,7 @@ function Metrics() {
     const [hostsActive, setHostsActive] = useState(false)
     const [currentHost, setCurrentHost] = useState(null)
 
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"));
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[2]);
     const getTimeEpoch = (key) => {
         return Math.floor(Date.parse(currDateRange.period[key]) / 1000)
     }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/metrics/ModuleMetrics.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/metrics/ModuleMetrics.jsx
@@ -99,7 +99,7 @@ function ModuleMetrics({ config }) {
 
     const [currDateRange, dispatchCurrDateRange] = useReducer(
         produce((draft, action) => func.dateRangeReducer(draft, action)),
-        values.getRange("last1month")
+        values.ranges[2]
     )
 
     const getTimeEpoch = (key) => {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TrendChart.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/SingleTestRunPage/TrendChart.jsx
@@ -23,7 +23,7 @@ import SummaryTable from "./SummaryTable";
 function TrendChart(props) {
 
     const { hexId, setSummary, show } = props;
-    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"));
+    const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[2]);
     const [appliedFilters, setAppliedFilters] = useState([]);
     const [testingRunResultSummaries, setTestingRunResultSummaries] = useState([]);
     const [metadataFilterData, setMetadataFilterData] = useState([]);
@@ -249,7 +249,7 @@ function TrendChart(props) {
             return filter.key != key
         })
         if (key == "dateRange") {
-            getDate({ type: "update", period: values.getRange("last1month") });
+            getDate({ type: "update", period: values.ranges[2] });
         } else {
             setAppliedFilters(temp);
         }
@@ -284,7 +284,7 @@ function TrendChart(props) {
 
     const handleFiltersClearAll = useCallback(() => {
         setAppliedFilters([])
-        getDate({ type: "update", period: values.getRange("last1month") });
+        getDate({ type: "update", period: values.ranges[2] });
     }, []);
 
     const metadataFilters = processMetadataFilters(metadataFilterData);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/TestRunsPage.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/testing/TestRunsPage/TestRunsPage.js
@@ -163,7 +163,7 @@ function TestRunsPage(props) {
 
   filters = func.getCollectionFilters(filters)
 
-const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.getRange("last1month"));
+const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), values.ranges[5]);
 const getTimeEpoch = (key) => {
     return Math.floor(Date.parse(currDateRange.period[key]) / 1000)
 }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatActorPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatActorPage.jsx
@@ -73,7 +73,8 @@ function ThreatActorPage() {
         return { alias: "custom", title, period: { since: sinceDate, until: untilDate } };
       }
     }
-    return values.getRange("last1month");
+    const specialAccounts = [1776384040, 1776625569, 1776626846];
+    return specialAccounts.includes(Number(window.ACTIVE_ACCOUNT)) ? values.ranges[4] : values.ranges[2];
   };
   const initialDateRange = getInitialDateRange();
   const [currDateRange, dispatchCurrDateRange] = useReducer(

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatApiPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatApiPage.jsx
@@ -45,7 +45,7 @@ function ThreatApiPage() {
         return { alias: "custom", title, period: { since: sinceDate, until: untilDate } };
       }
     }
-    return values.getRange("last1month");
+    return values.ranges[3];
   };
   const initialDateRange = getInitialDateRange();
   const [currDateRange, dispatchCurrDateRange] = useReducer(

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDashboardPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDashboardPage.jsx
@@ -50,7 +50,7 @@ function ThreatDashboardPage() {
                 return { alias: "custom", title, period: { since: sinceDate, until: untilDate } };
             }
         }
-        return values.getRange("last1month");
+        return values.ranges[2];
     };
     const initialDateRange = getInitialDateRange();
     const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), initialDateRange);

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDetectionPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatDetectionPage.jsx
@@ -324,7 +324,8 @@ function ThreatDetectionPage() {
                 return { alias: 'custom', title, period: { since: sinceDate, until: untilDate } };
             }
         }
-            return values.getRange("last1month");
+        const specialAccounts = [1776384040, 1776625569, 1776626846];
+        return specialAccounts.includes(Number(window.ACTIVE_ACCOUNT)) ? values.ranges[4] : values.ranges[2];
     }, [location.state, searchParams]);
     const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), initialVal);
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatPolicyPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/threat_detection/ThreatPolicyPage.jsx
@@ -10,7 +10,7 @@ import {HorizontalGrid} from "@shopify/polaris";
 
 function ThreatPolicyPage() {
 
-    const initialVal = values.getRange("last1month")
+    const initialVal = values.ranges[3]
     const [currDateRange, dispatchCurrDateRange] = useReducer(produce((draft, action) => func.dateRangeReducer(draft, action)), initialVal);
 
     const horizontalComponent = <HorizontalGrid columns={1} gap={2}>

--- a/apps/dashboard/web/polaris_web/web/src/util/values.js
+++ b/apps/dashboard/web/polaris_web/web/src/util/values.js
@@ -1,5 +1,3 @@
-import func from "./func";
-
 const today = new Date(new Date().setHours(0, 0, 0, 0));
 const todayDayEnd = new Date(new Date().setHours(23, 59, 59, 999));
 const yesterday = new Date(
@@ -32,21 +30,6 @@ const ranges = [
         period: {
             since: new Date(
                 new Date(new Date().setDate(today.getDate() - 6)).setHours(
-                    0,
-                    0,
-                    0,
-                    0
-                )
-            ),
-            until: todayDayEnd,
-        },
-    },
-    {
-        title: "Last 1 month",
-        alias: "last1month",
-        period: {
-            since: new Date(
-                new Date(new Date().setDate(today.getDate() - 30)).setHours(
                     0,
                     0,
                     0,
@@ -96,17 +79,7 @@ const ranges = [
     }
 ];
 
-// Look up a preset by alias. Call sites must use this rather than ranges[i] —
-// inserting a preset shifts every index and silently changes page defaults.
-// The demo account always opens on All time: its seeded data spans years, so the
-// normal default would land most pages on an empty range. Doing it here covers
-// every date picker at once instead of a per-page override.
-const getRange = (alias) => {
-    const wanted = func.isDemoAccount() ? "allTime" : alias;
-    return ranges.find((r) => r.alias === wanted) || ranges[0];
-};
-
 const skipList = ["GENERIC", "TRUE", "FALSE","INTEGER_32", "INTEGER_64", "NULL", "OTHER", "DICT", "FLOAT"]
 const DISABLED_AUTO_ACCOUNT_REFRESH = [1747820267,1731351930,1736798101]
 
-export default { today, yesterday, ranges, getRange, yesterdayDayEnd, todayDayEnd , skipList, DISABLED_AUTO_ACCOUNT_REFRESH};
+export default { today, yesterday, ranges, yesterdayDayEnd, todayDayEnd , skipList, DISABLED_AUTO_ACCOUNT_REFRESH};


### PR DESCRIPTION
Restores the original per-page date-picker defaults and values.ranges[i] indexing. Also drops the getRange() helper and the demo-account All time override that were built on it.