### PR TITLE
feat: add safeUnsetApiCollectionDescription migration for backward co…

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
+++ b/apps/dashboard/src/main/java/com/akto/listener/InitializerListener.java
@@ -3707,6 +3707,46 @@ public class InitializerListener implements ServletContextListener {
         }
     }
 
+    // Individually try/catch'd for the same reason as safeMigrateTeamRoleToDeviceTags above.
+    // Prioritized to run early so stale descriptions don't linger while other migrations run.
+    private static void safeUnsetApiCollectionDescription(BackwardCompatibility backwardCompatibility) {
+        int accountId = Context.accountId.get();
+        try {
+            if (backwardCompatibility.getUnsetApiCollectionDescription() == 0) {
+                logger.infoAndAddToDb("unsetApiCollectionDescription: starting migration for accountId=" + accountId, LogDb.DASHBOARD);
+                Bson hasDescription = Filters.and(
+                    Filters.exists(ApiCollection.DESCRIPTION, true),
+                    Filters.nin(ApiCollection.DESCRIPTION, Arrays.asList("", null))
+                );
+                Bson isArgusOrAtlasCollection = Filters.or(
+                    Filters.elemMatch(ApiCollection.TAGS_STRING, Filters.and(
+                        Filters.eq(CollectionTags.KEY_NAME, "source"), Filters.eq(CollectionTags.VALUE, "AGENTIC")
+                    )),
+                    Filters.elemMatch(ApiCollection.TAGS_STRING, Filters.and(
+                        Filters.eq(CollectionTags.KEY_NAME, "source"), Filters.eq(CollectionTags.VALUE, "ENDPOINT")
+                    )),
+                    Filters.in(ApiCollection.TAGS_STRING + "." + CollectionTags.KEY_NAME,
+                        Arrays.asList("gen-ai", "ai-agent", "mcp-server", "mcp-client", "browser-llm"))
+                );
+                Bson filter = Filters.and(hasDescription, isArgusOrAtlasCollection);
+                long count = ApiCollectionsDao.instance.getMCollection().countDocuments(filter);
+                logger.infoAndAddToDb("unsetApiCollectionDescription: found " + count + " argus/atlas collections with description for accountId=" + accountId, LogDb.DASHBOARD);
+                if (count > 0) {
+                    ApiCollectionsDao.instance.updateMany(filter, Updates.unset(ApiCollection.DESCRIPTION));
+                }
+                BackwardCompatibilityDao.instance.updateOne(
+                    Filters.eq("_id", backwardCompatibility.getId()),
+                    Updates.set(BackwardCompatibility.UNSET_API_COLLECTION_DESCRIPTION, Context.now())
+                );
+                logger.infoAndAddToDb("unsetApiCollectionDescription: migration complete for accountId=" + accountId, LogDb.DASHBOARD);
+            } else {
+                logger.infoAndAddToDb("unsetApiCollectionDescription: already executed, skipping for accountId=" + accountId, LogDb.DASHBOARD);
+            }
+        } catch (Exception e) {
+            logger.errorAndAddToDb(e, "error in unsetApiCollectionDescription: " + e.getMessage(), LogDb.DASHBOARD);
+        }
+    }
+
 
     private static void removeRagDatabaseTag(BackwardCompatibility backwardCompatibility) {
         int accountId = Context.accountId.get();
@@ -3748,6 +3788,7 @@ public class InitializerListener implements ServletContextListener {
     }
 
     public static void setBackwardCompatibilities(BackwardCompatibility backwardCompatibility){
+        safeUnsetApiCollectionDescription(backwardCompatibility);
         safeMigrateTeamRoleToDeviceTags(backwardCompatibility);
         safeMigrateGuardrailTargetTeamsRolesToTags(backwardCompatibility);
 

--- a/libs/dao/src/main/java/com/akto/dto/BackwardCompatibility.java
+++ b/libs/dao/src/main/java/com/akto/dto/BackwardCompatibility.java
@@ -138,6 +138,9 @@ public class BackwardCompatibility {
     public static final String MIGRATE_GUARDRAIL_TARGET_TEAMS_ROLES_TO_TAGS = "migrateGuardrailTargetTeamsRolesToTags";
     private int migrateGuardrailTargetTeamsRolesToTags;
 
+    public static final String UNSET_API_COLLECTION_DESCRIPTION = "unsetApiCollectionDescription";
+    private int unsetApiCollectionDescription;
+
     public BackwardCompatibility(int id, int dropFilterSampleData, int resetSingleTypeInfoCount, int dropWorkflowTestResult,
                                  int readyForNewTestingFramework,int addAktoDataTypes, boolean deploymentStatusUpdated,
                                  int authMechanismData, boolean mirroringLambdaTriggered, int deleteAccessListFromApiToken,
@@ -577,5 +580,13 @@ public class BackwardCompatibility {
 
     public void setMigrateGuardrailTargetTeamsRolesToTags(int migrateGuardrailTargetTeamsRolesToTags) {
         this.migrateGuardrailTargetTeamsRolesToTags = migrateGuardrailTargetTeamsRolesToTags;
+    }
+
+    public int getUnsetApiCollectionDescription() {
+        return unsetApiCollectionDescription;
+    }
+
+    public void setUnsetApiCollectionDescription(int unsetApiCollectionDescription) {
+        this.unsetApiCollectionDescription = unsetApiCollectionDescription;
     }
 }


### PR DESCRIPTION
…mpatibility

Implemented a new migration method, safeUnsetApiCollectionDescription, in the InitializerListener class to unset descriptions from specific API collections. This method checks the migration status and logs the process, ensuring that stale descriptions are removed early in the migration sequence. Updated the BackwardCompatibility class to track the migration status for this operation.