### PR TITLE
Add support for Microsoft Teams alerts in testing runs

### DIFF
--- a/apps/mini-testing/src/main/java/com/akto/testing/TestCompletion.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/TestCompletion.java
@@ -1,11 +1,26 @@
 package com.akto.testing;
 
 import com.akto.billing.UsageMetricUtils;
+import com.akto.dto.ApiCollection;
+import com.akto.dto.OriginalHttpRequest;
+import com.akto.dto.OriginalHttpResponse;
 import com.akto.dto.billing.FeatureAccess;
 import com.akto.dto.jobs.AutoTicketParams;
 import com.akto.dto.jobs.JobExecutorType;
+import com.akto.dto.notifications.CustomWebhook;
+import com.akto.dto.test_run_findings.TestingRunIssues;
+import com.akto.dto.testing.CollectionWiseTestingEndpoints;
+import com.akto.dto.testing.TestingEndpoints;
 import com.akto.dto.testing.TestingRunConfig;
+import com.akto.dto.testing.TestingRunResultSummary;
+import com.akto.notifications.data.TestingAlertData;
+import com.akto.notifications.teams.TeamsAlert;
+import com.akto.util.enums.GlobalEnums;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -40,6 +55,15 @@ public class TestCompletion {
             dataActor.updateTestingRunAndMarkCompleted(testingRun.getId().toHexString(), scheduleTs);
         }
 
+        if (testingRun != null && testingRun.getId() != null && summaryId != null) {
+            try {
+                sendTeamsAlertIfNeeded(testingRun, summaryId);
+            } catch (Exception e) {
+                loggerMaker.errorAndAddToDb(e, "Error sending test completion alerts for testingRunId: "
+                        + testingRun.getId().toHexString() + " summaryId: " + summaryId);
+            }
+        }
+
         if(summaryId != null && testingRun.getTestIdConfig() != 1){
             TestExecutor.updateTestSummary(summaryId);
         }
@@ -67,6 +91,119 @@ public class TestCompletion {
         }
 
         scheduleAutoTicketCreationJob(testingRun, accountId, summaryId);
+    }
+
+    // The mini-testing worker doesn't have direct DB access, so unlike apps/testing's
+    // TeamsSender/WebhookSender (which write straight to Mongo), this composes the alert
+    // locally from data fetched via DataActor and sends the webhook HTTP call itself,
+    // then reports the result back through DataActor for bookkeeping.
+    private void sendTeamsAlertIfNeeded(TestingRun testingRun, ObjectId summaryId) {
+        if (!testingRun.isSendMsTeamsAlert()) {
+            return;
+        }
+
+        List<CustomWebhook> teamsWebhooks = dataActor.fetchTeamsWebhooksForTestResults();
+        if (teamsWebhooks == null || teamsWebhooks.isEmpty()) {
+            return;
+        }
+
+        Map<ObjectId, TestingRunResultSummary> summaryMap = dataActor.fetchTestingRunResultSummaryMap(testingRun.getId().toHexString());
+        TestingRunResultSummary testingRunResultSummary = summaryMap != null ? summaryMap.get(summaryId) : null;
+        if (testingRunResultSummary == null) {
+            return;
+        }
+
+        int totalApis = testingRunResultSummary.getTotalApis();
+        String testType = "ONE_TIME";
+        if (testingRun.getPeriodInSeconds() > 0) {
+            testType = "SCHEDULED";
+        }
+        if (testingRunResultSummary.getMetadata() != null) {
+            testType = "CI_CD";
+        }
+
+        List<TestingRunIssues> testingRunIssuesList = dataActor.fetchOpenIssues(summaryId.toHexString());
+        if (testingRunIssuesList == null) {
+            testingRunIssuesList = new ArrayList<>();
+        }
+
+        Map<String, Integer> severityCount = new HashMap<>();
+        int newIssues = 0;
+        for (TestingRunIssues issue : testingRunIssuesList) {
+            String key = issue.getSeverity().toString();
+            severityCount.put(key, severityCount.getOrDefault(key, 0) + 1);
+            if (issue.getCreationTime() > testingRunResultSummary.getStartTimestamp()) {
+                newIssues++;
+            }
+        }
+
+        String collection = null;
+        TestingEndpoints testingEndpoints = testingRun.getTestingEndpoints();
+        if (testingEndpoints != null && testingEndpoints.getType().equals(TestingEndpoints.Type.COLLECTION_WISE)) {
+            CollectionWiseTestingEndpoints collectionWiseTestingEndpoints = (CollectionWiseTestingEndpoints) testingEndpoints;
+            ApiCollection apiCollection = dataActor.fetchApiCollectionMeta(collectionWiseTestingEndpoints.getApiCollectionId());
+            collection = apiCollection != null ? apiCollection.getName() : null;
+        }
+
+        long currentTime = Context.now();
+        long scanTimeInSeconds = Math.abs(currentTime - testingRunResultSummary.getStartTimestamp());
+        long nextTestRun = testingRun.getPeriodInSeconds() == 0 ? 0
+                : ((long) testingRun.getScheduleTimestamp() + (long) testingRun.getPeriodInSeconds());
+
+        TestingAlertData alertData = new TestingAlertData(
+                collection != null ? collection : testingRun.getName(),
+                severityCount.getOrDefault(GlobalEnums.Severity.CRITICAL.name(), 0),
+                severityCount.getOrDefault(GlobalEnums.Severity.HIGH.name(), 0),
+                severityCount.getOrDefault(GlobalEnums.Severity.MEDIUM.name(), 0),
+                severityCount.getOrDefault(GlobalEnums.Severity.LOW.name(), 0),
+                testingRunIssuesList.size(),
+                newIssues,
+                totalApis,
+                collection,
+                scanTimeInSeconds,
+                testType,
+                nextTestRun,
+                new ArrayList<>(),
+                testingRun.getHexId(),
+                summaryId.toHexString()
+        );
+
+        for (CustomWebhook webhook : teamsWebhooks) {
+            int now = Context.now();
+            List<String> errors = new ArrayList<>();
+            String message = null;
+            OriginalHttpResponse response = null;
+            try {
+                String payload = TeamsAlert.createAndGetBody(alertData, webhook);
+                Map<String, List<String>> headers = OriginalHttpRequest.buildHeadersMap(webhook.getHeaderString());
+                OriginalHttpRequest request = new OriginalHttpRequest(webhook.getUrl(), webhook.getQueryParams(),
+                        webhook.getMethod().toString(), payload, headers, "");
+                try {
+                    response = ApiExecutor.sendRequest(request, true, null, false, new ArrayList<>());
+                    if (response == null || response.getStatusCode() < 200 || response.getStatusCode() >= 300) {
+                        String statusCode = response == null ? "null" : String.valueOf(response.getStatusCode());
+                        errors.add("Webhook endpoint returned non-2xx status: " + statusCode);
+                    }
+                } catch (Exception e) {
+                    loggerMaker.errorAndAddToDb(e, "sendTeamsAlertIfNeeded: ApiExecutor.sendRequest threw for url=" + webhook.getUrl());
+                    errors.add("API execution failed: " + e.getMessage());
+                }
+                message = "url=" + webhook.getUrl() + ", statusCode=" + (response != null ? response.getStatusCode() : "null");
+            } catch (Exception e) {
+                loggerMaker.errorAndAddToDb(e, "sendTeamsAlertIfNeeded: error building/sending Teams alert");
+                errors.add("Error building/sending Teams alert: " + e.getMessage());
+            }
+
+            if (!errors.isEmpty()) {
+                loggerMaker.errorAndAddToDb("sendTeamsAlertIfNeeded: errors=" + errors, LogDb.TESTING);
+            }
+
+            try {
+                dataActor.recordWebhookSendResult(webhook.getId(), webhook.getUserEmail(), now, message, errors);
+            } catch (Exception e) {
+                loggerMaker.errorAndAddToDb(e, "Error recording webhook send result for webhookId: " + webhook.getId());
+            }
+        }
     }
 
     private void scheduleAutoTicketCreationJob(TestingRun testingRun, int accountId, ObjectId summaryId) {

--- a/libs/dao/src/main/java/com/akto/dto/notifications/CustomWebhook.java
+++ b/libs/dao/src/main/java/com/akto/dto/notifications/CustomWebhook.java
@@ -1,6 +1,5 @@
 package com.akto.dto.notifications;
 
-import com.akto.dto.data_types.Conditions;
 import org.bson.codecs.pojo.annotations.BsonId;
 
 import com.akto.dto.type.URLMethods.Method;
@@ -23,12 +22,26 @@ public class CustomWebhook {
     int lastUpdateTime;
     int lastSentTimestamp;
     ActiveStatus activeStatus;
+    final public static String BATCH_SIZE = "batchSize";
+    int batchSize;
     public static final String NEW_ENDPOINT_COLLECTIONS = "newEndpointCollections";
     private List<String> newEndpointCollections;
     public static final String NEW_SENSITIVE_ENDPOINT_COLLECTIONS = "newSensitiveEndpointCollections";
     private List<String> newSensitiveEndpointCollections;
     public static final String SELECTED_WEBHOOK_OPTIONS = "selectedWebhookOptions";
     private List<WebhookOptions> selectedWebhookOptions;
+    public static final String SEND_INSTANTLY = "sendInstantly";
+    private boolean sendInstantly;
+
+    private String dashboardUrl;
+    public static final String DASHBOARD_URL = "dashboardUrl";
+
+    private WebhookType webhookType;
+    public static final String WEBHOOK_TYPE = "webhookType";
+
+    public enum WebhookType {
+        DEFAULT, MICROSOFT_TEAMS, GMAIL
+    }
 
     public enum ActiveStatus{
         ACTIVE,INACTIVE;
@@ -40,7 +53,13 @@ public class CustomWebhook {
         NEW_SENSITIVE_ENDPOINT ("New Sensitive Endpoint", "${AKTO.changes_info.newSensitiveEndpoints}"),
         NEW_SENSITIVE_ENDPOINT_COUNT("New Sensitive Endpoint Count", "${AKTO.changes_info.newSensitiveEndpointsCount}"),
         NEW_PARAMETER_COUNT("New Parameter Count", "${AKTO.changes_info.newParametersCount}"),
-        NEW_SENSITIVE_PARAMETER_COUNT("New Sensitive Parameter Count", "${AKTO.changes_info.newSensitiveParametersCount}");
+        NEW_SENSITIVE_PARAMETER_COUNT("New Sensitive Parameter Count", "${AKTO.changes_info.newSensitiveParametersCount}"),
+        API_THREAT_PAYLOADS("API Threat payloads", "${AKTO.changes_info.apiThreatPayloads}"),
+        // optionReplaceString not being used for Testing Run results.
+        TESTING_RUN_RESULTS("Testing run results", "${AKTO.changes_info.apiTestingRunResults}"),
+        // optionReplaceString not being used for Traffic alerts.
+        TRAFFIC_ALERTS("Traffic alerts", "${AKTO.changes_info.apiTrafficAlerts}"),
+        PENDING_TESTS_ALERTS("Pending tests alerts", "${AKTO.changes_info.apiPendingTestsAlerts}");
 
         final String optionName;
         final String optionReplaceString;
@@ -206,5 +225,36 @@ public class CustomWebhook {
     public void setActiveStatus(ActiveStatus activeStatus) {
         this.activeStatus = activeStatus;
     }
-    
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public WebhookType getWebhookType() {
+        return webhookType;
+    }
+
+    public void setWebhookType(WebhookType webhookType) {
+        this.webhookType = webhookType;
+    }
+
+    public boolean getSendInstantly() {
+        return sendInstantly;
+    }
+
+    public void setSendInstantly(boolean sendInstantly) {
+        this.sendInstantly = sendInstantly;
+    }
+
+    public String getDashboardUrl() {
+        return dashboardUrl;
+    }
+
+    public void setDashboardUrl(String dashboardUrl) {
+        this.dashboardUrl = dashboardUrl;
+    }
 }

--- a/libs/dao/src/main/java/com/akto/dto/testing/TestingRun.java
+++ b/libs/dao/src/main/java/com/akto/dto/testing/TestingRun.java
@@ -34,6 +34,11 @@ public class TestingRun {
     @Setter
     private boolean sendSlackAlert = false;
 
+    public static final String SEND_MS_TEAMS_ALERT = "sendMsTeamsAlert";
+    @Getter
+    @Setter
+    private boolean sendMsTeamsAlert = false;
+
     public static final String SELECTED_SLACK_CHANNEL_ID = "selectedSlackChannelId";
     @Getter
     @Setter

--- a/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
@@ -12,6 +12,7 @@ import com.akto.dto.*;
 import com.akto.dto.ApiInfo.ApiInfoKey;
 import com.akto.utils.elasticsearch.AgentQueryRecord;
 import com.akto.dto.billing.Organization;
+import com.akto.dto.notifications.CustomWebhook;
 import com.akto.dto.billing.Tokens;
 import com.akto.dto.bulk_updates.BulkUpdates;
 import com.akto.dto.data_types.*;
@@ -2176,6 +2177,58 @@ public class ClientActor extends DataActor {
         }
     }
 
+    public List<CustomWebhook> fetchTeamsWebhooksForTestResults() {
+        Map<String, List<String>> headers = buildHeaders();
+        List<CustomWebhook> webhookList = new ArrayList<>();
+        BasicDBObject obj = new BasicDBObject();
+        OriginalHttpRequest request = new OriginalHttpRequest(url + "/fetchTeamsWebhooksForTestResults", "", "POST", obj.toString(), headers, "");
+        try {
+            OriginalHttpResponse response = ApiExecutor.sendRequestBackOff(request, true, null, false, null);
+            String responsePayload = response.getBody();
+            if (response.getStatusCode() != 200 || responsePayload == null) {
+                loggerMaker.errorAndAddToDb("non 2xx response in fetchTeamsWebhooksForTestResults", LoggerMaker.LogDb.RUNTIME);
+                return webhookList;
+            }
+            try {
+                BasicDBObject payloadObj = BasicDBObject.parse(responsePayload);
+                BasicDBList webhooks = (BasicDBList) payloadObj.get("customWebhooks");
+                if (webhooks != null) {
+                    for (Object w : webhooks) {
+                        BasicDBObject obj2 = (BasicDBObject) w;
+                        webhookList.add(objectMapper.readValue(obj2.toJson(), CustomWebhook.class));
+                    }
+                }
+            } catch (Exception e) {
+                loggerMaker.errorAndAddToDb("error extracting response in fetchTeamsWebhooksForTestResults" + e, LoggerMaker.LogDb.RUNTIME);
+            }
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("error in fetchTeamsWebhooksForTestResults" + e, LoggerMaker.LogDb.RUNTIME);
+        }
+        return webhookList;
+    }
+
+    public void recordWebhookSendResult(int webhookId, String userEmail, int timestamp, String message, List<String> errors) {
+        Map<String, List<String>> headers = buildHeaders();
+        BasicDBObject obj = new BasicDBObject();
+        obj.put("webhookId", webhookId);
+        obj.put("userEmail", userEmail);
+        obj.put("timestamp", timestamp);
+        obj.put("message", message);
+        obj.put("errors", errors);
+        OriginalHttpRequest request = new OriginalHttpRequest(url + "/recordWebhookSendResult", "", "POST", obj.toString(), headers, "");
+        try {
+            OriginalHttpResponse response = ApiExecutor.sendRequestBackOff(request, true, null, false, null);
+            String responsePayload = response.getBody();
+            if (response.getStatusCode() != 200 || responsePayload == null) {
+                loggerMaker.errorAndAddToDb("non 2xx response in recordWebhookSendResult", LoggerMaker.LogDb.RUNTIME);
+                return;
+            }
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("error in recordWebhookSendResult " + e, LoggerMaker.LogDb.RUNTIME);
+            return;
+        }
+    }
+
     public List<TestingRunIssues> fetchOpenIssues(String summaryId) {
         Map<String, List<String>> headers = buildHeaders();
         List<TestingRunIssues> issueList = new ArrayList<>();
@@ -2516,13 +2569,17 @@ public class ClientActor extends DataActor {
         OriginalHttpRequest request = new OriginalHttpRequest(url + "/insertTestingRunResults", "", "POST", objString, headers, "");
         try {
             OriginalHttpResponse response = ApiExecutor.sendRequestBackOff(request, true, null, false, null);
+            if (response == null) {
+                loggerMaker.errorAndAddToDb("null response (all retries failed) in insertTestingRunResults", LoggerMaker.LogDb.TESTING);
+                return;
+            }
             String responsePayload = response.getBody();
             if (response.getStatusCode() != 200 || responsePayload == null) {
-                loggerMaker.errorAndAddToDb("non 2xx response in insertTestingRunResults", LoggerMaker.LogDb.RUNTIME);
+                loggerMaker.errorAndAddToDb("non 2xx response in insertTestingRunResults: status=" + response.getStatusCode() + " body=" + responsePayload, LoggerMaker.LogDb.TESTING);
                 return;
             }
         } catch (Exception e) {
-            loggerMaker.errorAndAddToDb("error in insertTestingRunResults" + e, LoggerMaker.LogDb.RUNTIME);
+            loggerMaker.errorAndAddToDb("error in insertTestingRunResults" + e, LoggerMaker.LogDb.TESTING);
             return;
         }
     }

--- a/libs/utils/src/main/java/com/akto/data_actor/DataActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DataActor.java
@@ -6,6 +6,7 @@ import com.akto.dto.billing.Organization;
 import com.akto.dto.billing.Tokens;
 import com.akto.dto.dependency_flow.Node;
 import com.akto.dto.filter.MergedUrls;
+import com.akto.dto.notifications.CustomWebhook;
 import com.akto.dto.jobs.JobExecutorType;
 import com.akto.dto.jobs.JobParams;
 import com.akto.dto.metrics.MetricData;
@@ -170,6 +171,10 @@ public abstract class DataActor {
     public abstract TestSourceConfig findTestSourceConfig(String subType);
 
     public abstract void updateTestingRunAndMarkCompleted(String testingRunId, int scheduleTs);
+
+    public abstract List<CustomWebhook> fetchTeamsWebhooksForTestResults();
+
+    public abstract void recordWebhookSendResult(int webhookId, String userEmail, int timestamp, String message, List<String> errors);
 
     public abstract Map<ObjectId, TestingRunResultSummary> fetchTestingRunResultSummaryMap(String testingRunId);
 

--- a/libs/utils/src/main/java/com/akto/data_actor/DbActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DbActor.java
@@ -9,6 +9,7 @@ import com.akto.utils.elasticsearch.AgentQueryRecord;
 import com.akto.dto.billing.Organization;
 import com.akto.dto.billing.Tokens;
 import com.akto.dto.dependency_flow.Node;
+import com.akto.dto.notifications.CustomWebhook;
 import com.akto.dto.filter.MergedUrls;
 import com.akto.dto.jobs.JobExecutorType;
 import com.akto.dto.jobs.JobParams;
@@ -589,6 +590,14 @@ public class DbActor extends DataActor {
 
     public void updateTestingRunAndMarkCompleted(String testingRunId, int scheduleTs) {
         DbLayer.updateTestingRunAndMarkCompleted(testingRunId, scheduleTs);
+    }
+
+    public List<CustomWebhook> fetchTeamsWebhooksForTestResults() {
+        return DbLayer.fetchTeamsWebhooksForTestResults();
+    }
+
+    public void recordWebhookSendResult(int webhookId, String userEmail, int timestamp, String message, List<String> errors) {
+        DbLayer.recordWebhookSendResult(webhookId, userEmail, timestamp, message, errors);
     }
 
     public void updateTotalApiCountInTestSummary(String summaryId, int totalApiCount) {

--- a/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/DbLayer.java
@@ -5,6 +5,7 @@ import static com.akto.util.Constants.ID;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +17,8 @@ import com.akto.dao.filter.MergedUrlsDao;
 import com.akto.dao.metrics.MetricDataDao;
 import com.akto.dao.monitoring.ModuleInfoDao;
 import com.akto.dao.notifications.SlackWebhooksDao;
+import com.akto.dao.notifications.CustomWebhooksDao;
+import com.akto.dao.notifications.CustomWebhooksResultDao;
 import com.akto.dao.settings.DataControlSettingsDao;
 import com.akto.dao.testing.config.TestSuiteDao;
 import com.akto.dependency_analyser.DependencyAnalyserUtils;
@@ -24,6 +27,8 @@ import com.akto.dto.filter.MergedUrls;
 import com.akto.dto.metrics.MetricData;
 import com.akto.dto.monitoring.ModuleInfo;
 import com.akto.dto.notifications.SlackWebhook;
+import com.akto.dto.notifications.CustomWebhook;
+import com.akto.dto.notifications.CustomWebhookResult;
 import com.akto.dto.settings.DataControlSettings;
 import com.akto.dto.testing.config.TestSuites;
 import com.mongodb.client.model.*;
@@ -788,6 +793,19 @@ public static void createCollectionSimpleForVpc(int vxlanId, String vpcId, List<
         TestingRunDao.instance.getMCollection().findOneAndUpdate(
                 Filters.eq("_id", id),  completedUpdate
         );
+    }
+
+    public static List<CustomWebhook> fetchTeamsWebhooksForTestResults() {
+        return CustomWebhooksDao.instance.findAll(
+                Filters.and(
+                        Filters.eq(CustomWebhook.WEBHOOK_TYPE, CustomWebhook.WebhookType.MICROSOFT_TEAMS.name()),
+                        Filters.in(CustomWebhook.SELECTED_WEBHOOK_OPTIONS, CustomWebhook.WebhookOptions.TESTING_RUN_RESULTS.name())));
+    }
+
+    public static void recordWebhookSendResult(int webhookId, String userEmail, int timestamp, String message, List<String> errors) {
+        CustomWebhooksDao.instance.updateOne(Filters.eq("_id", webhookId), Updates.set("lastSentTimestamp", timestamp));
+        CustomWebhookResult webhookResult = new CustomWebhookResult(webhookId, userEmail, timestamp, message, errors);
+        CustomWebhooksResultDao.instance.insertOne(webhookResult);
     }
 
     public static List<TestingRunIssues> fetchOpenIssues(String summaryId) {

--- a/libs/utils/src/main/java/com/akto/notifications/data/TestingAlertData.java
+++ b/libs/utils/src/main/java/com/akto/notifications/data/TestingAlertData.java
@@ -1,0 +1,93 @@
+package com.akto.notifications.data;
+
+import java.util.List;
+
+import com.akto.notifications.slack.NewIssuesModel;
+
+public class TestingAlertData {
+    private String title;
+    private int critical;
+    private int high;
+    private int medium;
+    private int low;
+    private int vulnerableApis;
+    private int newIssues;
+    private int totalApis;
+    private String collection;
+    private long scanTimeInSeconds;
+    private String testType;
+    private long nextTestRun;
+    private List<NewIssuesModel> newIssuesList;
+    private String viewOnAktoURL;
+    private String exportReportUrl;
+
+    public TestingAlertData(){
+    }
+
+    public TestingAlertData(String title, int critical, int high, int medium, int low, int vulnerableApis,
+                            int newIssues, int totalApis, String collection, long scanTimeInSeconds,
+                            String testType, long nextTestRun, List<NewIssuesModel> newIssuesList,
+                            String viewOnAktoURL, String exportReportUrl) {
+        this.title = title;
+        this.critical = critical;
+        this.high = high;
+        this.medium = medium;
+        this.low = low;
+        this.vulnerableApis = vulnerableApis;
+        this.newIssues = newIssues;
+        this.totalApis = totalApis;
+        this.collection = collection;
+        this.scanTimeInSeconds = scanTimeInSeconds;
+        this.testType = testType;
+        this.nextTestRun = nextTestRun;
+        this.newIssuesList = newIssuesList;
+        this.viewOnAktoURL = viewOnAktoURL;
+        this.exportReportUrl = exportReportUrl;
+    }
+
+    // Getters and setters
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public int getCritical() { return critical; }
+    public void setCritical(int critical) { this.critical = critical; }
+
+    public int getHigh() { return high; }
+    public void setHigh(int high) { this.high = high; }
+
+    public int getMedium() { return medium; }
+    public void setMedium(int medium) { this.medium = medium; }
+
+    public int getLow() { return low; }
+    public void setLow(int low) { this.low = low; }
+
+    public int getVulnerableApis() { return vulnerableApis; }
+    public void setVulnerableApis(int vulnerableApis) { this.vulnerableApis = vulnerableApis; }
+
+    public int getNewIssues() { return newIssues; }
+    public void setNewIssues(int newIssues) { this.newIssues = newIssues; }
+
+    public int getTotalApis() { return totalApis; }
+    public void setTotalApis(int totalApis) { this.totalApis = totalApis; }
+
+    public String getCollection() { return collection; }
+    public void setCollection(String collection) { this.collection = collection; }
+
+    public long getScanTimeInSeconds() { return scanTimeInSeconds; }
+    public void setScanTimeInSeconds(long scanTimeInSeconds) { this.scanTimeInSeconds = scanTimeInSeconds; }
+
+    public String getTestType() { return testType; }
+    public void setTestType(String testType) { this.testType = testType; }
+
+    public long getNextTestRun() { return nextTestRun; }
+    public void setNextTestRun(long nextTestRun) { this.nextTestRun = nextTestRun; }
+
+    public List<NewIssuesModel> getNewIssuesList() { return newIssuesList; }
+    public void setNewIssuesList(List<NewIssuesModel> newIssuesList) { this.newIssuesList = newIssuesList; }
+
+    public String getViewOnAktoURL() { return viewOnAktoURL; }
+    public void setViewOnAktoURL(String viewOnAktoURL) { this.viewOnAktoURL = viewOnAktoURL; }
+
+    public String getExportReportUrl() { return exportReportUrl; }
+    public void setExportReportUrl(String exportReportUrl) { this.exportReportUrl = exportReportUrl; }
+}

--- a/libs/utils/src/main/java/com/akto/notifications/teams/CardDataTable.java
+++ b/libs/utils/src/main/java/com/akto/notifications/teams/CardDataTable.java
@@ -1,0 +1,37 @@
+package com.akto.notifications.teams;
+
+import java.util.List;
+
+public class CardDataTable {
+    public static String createTable(List<List<String>> data) {
+        StringBuilder body = new StringBuilder();
+
+        body.append("        {\n" +
+                "            \"type\": \"Table\",\n" +
+                "            \"columns\": [\n");
+
+        int i = data.size();
+        while (i > 0) {
+            body.append("                {\"width\": 1},\n");
+            i--;
+        }
+        if (!data.isEmpty()) {
+            body.setLength(body.length() - 2); // drop the ",\n" left by the last column
+            body.append("\n");
+        }
+        body.append("            ],\n" +
+                "            \"rows\": [\n");
+        boolean firstRow = true;
+        for (List<String> dataRow : data) {
+            if (!firstRow) body.append(",\n");
+            body.append(CardTableRow.createTableRow(dataRow));
+            firstRow = false;
+        }
+
+        body.append("\n                    ]\n" +
+                "                }");
+
+        return body.toString();
+
+    }
+}

--- a/libs/utils/src/main/java/com/akto/notifications/teams/CardTableRow.java
+++ b/libs/utils/src/main/java/com/akto/notifications/teams/CardTableRow.java
@@ -1,0 +1,37 @@
+package com.akto.notifications.teams;
+
+import java.util.List;
+
+public class CardTableRow {
+    public static String createTableRow(List<String> data) {
+        StringBuilder body = new StringBuilder();
+
+        body.append(
+                "                {\n" +
+                        "                    \"type\": \"TableRow\",\n" +
+                        "                    \"cells\": [\n");
+
+        for (String key : data) {
+            body.append("                        {\n" +
+                    "                            \"type\": \"TableCell\",\n" +
+                    "                            \"items\": [\n" +
+                    "                                {\n" +
+                    "                                    \"type\": \"TextBlock\",\n" +
+                    "                                    \"text\": \"" + key + "\",\n" +
+                    "                                    \"wrap\": true\n" +
+                    "                                }\n" +
+                    "                            ]\n" +
+                    "                        },\n");
+        }
+        if (!data.isEmpty()) {
+            body.setLength(body.length() - 2); // drop the ",\n" left by the last cell
+            body.append("\n");
+        }
+        body.append("                    ]\n" +
+                "                }");
+
+        return body.toString();
+
+    }
+
+}

--- a/libs/utils/src/main/java/com/akto/notifications/teams/CardTextBlock.java
+++ b/libs/utils/src/main/java/com/akto/notifications/teams/CardTextBlock.java
@@ -1,0 +1,27 @@
+package com.akto.notifications.teams;
+
+public class CardTextBlock {
+
+    /*
+     * For reference of values: https://adaptivecards.io/explorer/TextBlock.html
+     */
+    public static String createTextBlock(String text, boolean wrap, String weight) {
+        return createTextBlock(text, wrap, weight, "default");
+    }
+
+    /*
+     * Returns one card element, without a trailing comma. Callers must join
+     * elements with "," themselves.
+     */
+    public static String createTextBlock(String text, boolean wrap, String weight, String color) {
+        String body = "        {\n" +
+                "            \"type\":\"TextBlock\",\n" +
+                "            \"text\":\"" + text + "\",\n" +
+                "            \"weight\": \"" + weight + "\",\n" +
+                "            \"color\": \"" + color + "\",\n" +
+                "            \"wrap\": " + wrap + "\n" +
+                "        }";
+        return body;
+    }
+
+}

--- a/libs/utils/src/main/java/com/akto/notifications/teams/TeamsAlert.java
+++ b/libs/utils/src/main/java/com/akto/notifications/teams/TeamsAlert.java
@@ -1,0 +1,61 @@
+package com.akto.notifications.teams;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.akto.dto.notifications.CustomWebhook;
+import com.akto.notifications.data.TestingAlertData;
+
+public class TeamsAlert {
+
+    public static String createAndGetBody(TestingAlertData data, CustomWebhook webhook) {
+        StringBuilder body = new StringBuilder();
+        body.append("{\n" +
+                "    \"type\": \"message\",\n" +
+                "    \"attachments\": [\n" +
+                "        {\n" +
+                "            \"contentType\": \"application/vnd.microsoft.card.adaptive\",\n" +
+                "            \"content\": {\n" +
+                "                \"type\": \"AdaptiveCard\",\n" +
+                "                \"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\n" +
+                "                \"version\": \"1.5\",\n" +
+                "\"msteams\": { \"width\": \"full\" }," +
+                "                \"body\": [");
+
+        String headingText = "Akto test run results for " + data.getTitle();
+
+        body.append(CardTextBlock.createTextBlock(headingText, true, "bolder"));
+        body.append(",");
+
+        String tableHeading = "Issue list: ";
+        body.append(CardTextBlock.createTextBlock(tableHeading, true, "default"));
+        body.append(",");
+
+        List<List<String>> tableData = new ArrayList<>();
+
+        tableData.add(Arrays.asList("Severity", "No. of issues"));
+        tableData.add(Arrays.asList("Critical", String.valueOf(data.getCritical())));
+        tableData.add(Arrays.asList("High", String.valueOf(data.getHigh())));
+        tableData.add(Arrays.asList("Medium", String.valueOf(data.getMedium())));
+        tableData.add(Arrays.asList("Low", String.valueOf(data.getLow())));
+
+        body.append(CardDataTable.createTable(tableData));
+        body.append(",");
+
+        String dashboardLink = "View the complete results on Akto: " + webhook.getDashboardUrl() + "/dashboard/testing/"
+                + data.getViewOnAktoURL() + "#vulnerable";
+
+        body.append(CardTextBlock.createTextBlock(dashboardLink, true, "default"));
+
+
+        body.append("]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}\n" +
+                "");
+        return body.toString();
+    }
+
+}


### PR DESCRIPTION
- Introduced `sendTeamsAlertIfNeeded` method in `TestCompletion` to handle alert notifications.
- Updated `TestingRun` to include a flag for sending Teams alerts.
- Implemented fetching of Teams webhooks and recording of webhook send results in `ClientActor` and `DbActor`.
- Added new classes for constructing Teams alert messages and data structures for alert content.
- Enhanced `CustomWebhook` to support new properties related to Teams integration.
- Created `TestingAlertData` to encapsulate alert data for Teams notifications.