### PR TITLE
Refactor test result handling and improve JSON deserialization

### DIFF
--- a/apps/mini-testing/src/main/java/com/akto/testing/TestCompletion.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/TestCompletion.java
@@ -108,7 +108,8 @@ public class TestCompletion {
         }
 
         Map<ObjectId, TestingRunResultSummary> summaryMap = dataActor.fetchTestingRunResultSummaryMap(testingRun.getId().toHexString());
-        TestingRunResultSummary testingRunResultSummary = summaryMap != null ? summaryMap.get(summaryId) : null;
+
+        TestingRunResultSummary testingRunResultSummary = summaryMap != null ? summaryMap.get(testingRun.getId()) : null;
         if (testingRunResultSummary == null) {
             return;
         }

--- a/libs/dao/src/main/java/com/akto/dto/testing/GenericTestResult.java
+++ b/libs/dao/src/main/java/com/akto/dto/testing/GenericTestResult.java
@@ -3,7 +3,9 @@ package com.akto.dto.testing;
 import java.util.List;
 
 import com.akto.dto.testing.TestResult.Confidence;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+@JsonDeserialize(using = GenericTestResultDeserializer.class)
 public abstract class GenericTestResult {
 
     private boolean vulnerable;

--- a/libs/dao/src/main/java/com/akto/dto/testing/GenericTestResultDeserializer.java
+++ b/libs/dao/src/main/java/com/akto/dto/testing/GenericTestResultDeserializer.java
@@ -1,0 +1,27 @@
+package com.akto.dto.testing;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// The MongoDB POJO codec discriminates GenericTestResult subtypes via BSON's "_t" field, but that's
+// invisible once these objects are re-serialized to plain JSON over HTTP (e.g. database-abstractor's
+// responses) - there's no type marker left for Jackson to key off. MultiExecTestResult is the only
+// subtype with an "executionOrder" field (its getter never returns null, so it's always present),
+// so its presence is a reliable structural discriminator; everything else is a TestResult.
+public class GenericTestResultDeserializer extends JsonDeserializer<GenericTestResult> {
+
+    @Override
+    public GenericTestResult deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+        JsonNode node = mapper.readTree(parser);
+        if (node.has("executionOrder")) {
+            return mapper.treeToValue(node, MultiExecTestResult.class);
+        }
+        return mapper.treeToValue(node, TestResult.class);
+    }
+}

--- a/libs/dao/src/main/java/com/akto/dto/testing/MultiExecTestResult.java
+++ b/libs/dao/src/main/java/com/akto/dto/testing/MultiExecTestResult.java
@@ -8,7 +8,12 @@ import com.akto.dto.testing.TestResult.TestError;
 
 import com.akto.dto.testing.TestResult.Confidence;
 import com.akto.dto.testing.WorkflowTestResult.NodeResult;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+// Cancels the custom @JsonDeserialize inherited from GenericTestResult - without this, deserializing
+// this concrete class re-enters GenericTestResultDeserializer and recurses infinitely.
+@JsonDeserialize(using = JsonDeserializer.None.class)
 public class MultiExecTestResult extends GenericTestResult {
 
     Map<String, NodeResult> nodeResultMap;

--- a/libs/dao/src/main/java/com/akto/dto/testing/TestResult.java
+++ b/libs/dao/src/main/java/com/akto/dto/testing/TestResult.java
@@ -9,6 +9,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+// Cancels the custom @JsonDeserialize inherited from GenericTestResult - without this, deserializing
+// this concrete class re-enters GenericTestResultDeserializer and recurses infinitely.
+@JsonDeserialize(using = JsonDeserializer.None.class)
 public class TestResult extends GenericTestResult {
 
     public static final String _MESSAGE = "message";

--- a/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
@@ -47,6 +47,7 @@ import com.akto.testing.ApiExecutor;
 import com.akto.util.Constants;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
@@ -2012,8 +2013,14 @@ public class ClientActor extends DataActor {
             BasicDBObject payloadObj;
             try {
                 payloadObj =  BasicDBObject.parse(responsePayload);
-                BasicDBObject testingRunResultsummaryMap = (BasicDBObject) payloadObj.get("testingRunResultsummaryMap");
-                return objectMapper.readValue(testingRunResultsummaryMap.toJson(), Map.class);
+                BasicDBObject testingRunResultSummaryMap = (BasicDBObject) payloadObj.get("testingRunResultSummaryMap");
+                Map<String, TestingRunResultSummary> rawMap = objectMapper.readValue(testingRunResultSummaryMap.toJson(),
+                        new TypeReference<Map<String, TestingRunResultSummary>>() {});
+                Map<ObjectId, TestingRunResultSummary> summaryMap = new HashMap<>();
+                for (Map.Entry<String, TestingRunResultSummary> entry : rawMap.entrySet()) {
+                    summaryMap.put(new ObjectId(entry.getKey()), entry.getValue());
+                }
+                return summaryMap;
             } catch(Exception e) {
                 return null;
             }

--- a/libs/utils/src/main/java/com/akto/metrics/AllMetrics.java
+++ b/libs/utils/src/main/java/com/akto/metrics/AllMetrics.java
@@ -29,7 +29,7 @@ public class AllMetrics {
         this.accountId = accountId;
 
         Organization organization = OrgUtils.getOrganizationCached(accountId);
-        String orgId = organization.getId();
+        String orgId = organization == null ? null : organization.getId();
         this.orgId = orgId;
 
         if(LogDb.RUNTIME.equals(module)){


### PR DESCRIPTION
- Updated `TestCompletion` to correctly fetch `TestingRunResultSummary` using the testing run ID.
- Added `GenericTestResultDeserializer` to handle deserialization of `GenericTestResult` subclasses based on the presence of the `executionOrder` field.
- Modified `MultiExecTestResult` and `TestResult` to prevent infinite recursion during deserialization by canceling inherited deserialization behavior.
- Enhanced `ClientActor` to properly parse and convert testing run result summaries into a map of `ObjectId` to `TestingRunResultSummary`.
- Updated `AllMetrics` to handle potential null values for organization ID.