### PR TITLE
v1 fetchBrowserExtensionConfigs: also return v2 merged catalogue

### DIFF
--- a/apps/database-abstractor/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
+++ b/apps/database-abstractor/src/main/java/com/akto/action/BrowserExtensionConfigAction.java
@@ -29,6 +29,9 @@ public class BrowserExtensionConfigAction extends ActionSupport {
     public String fetchBrowserExtensionConfigs() {
         try {
             this.browserExtensionConfigs = BrowserExtensionConfigDao.instance.findActiveConfigs();
+            // Also surface the v2 merged catalogue so clients pinned to this endpoint can read the
+            // richer per-site configs without switching to api/fetchBrowserExtensionConfigsV2.
+            this.browserExtensionConfigsV2 = BrowserExtensionConfigDao.instance.findActiveConfigsV2();
             return SUCCESS.toUpperCase();
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb("Error fetching browser extension configs: " + e.getMessage(), LogDb.DB_ABS);


### PR DESCRIPTION
The per-account browser_extension_configs collection is empty for most accounts, so v1 returns an empty list. Populate browserExtensionConfigsV2 alongside the legacy field so clients pinned to api/fetchBrowserExtensionConfigs get the merged common catalogue without changing their endpoint. Backward compatible: browserExtensionConfigs stays populated as before.