### PR TITLE
Add disabled state handling for insights and update severity logic

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/service/insights/AbstractInsightProvider.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/AbstractInsightProvider.java
@@ -28,6 +28,7 @@ public abstract class AbstractInsightProvider implements InsightProvider {
         r.setCategory(id.getCategory().name());
         r.setGroup(id.getGroup().name());
         r.setStatus(InsightResult.Status.NO_DATA.name());
+        r.setDisabled(id.isDisabled());
         return r;
     }
 

--- a/apps/dashboard/src/main/java/com/akto/service/insights/InsightId.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/InsightId.java
@@ -9,35 +9,45 @@ import lombok.Getter;
  */
 @Getter
 public enum InsightId {
-    MALICIOUS_COMPONENT_IN_USE("Malicious component in active use", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
+    MALICIOUS_COMPONENT_IN_USE("Malicious component in active use", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY, true),
     UNGOVERNED_AI_RATIO("Ungoverned AI ratio", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
     GUARDRAIL_COVERAGE_GAP("Guardrail coverage gap", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
     SENSITIVE_DATA_DESTINATIONS("Where sensitive data is actually going", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
     EXPOSURE_CONCENTRATION("Exposure concentration", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
     PERSONAL_USE_OF_ENTERPRISE_AI("Enterprise AI used for personal purposes", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
-    OFF_DOMAIN_TOKEN_BURN("Off-domain token burn", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
+    OFF_DOMAIN_TOKEN_BURN("Off-domain token burn", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY, true),
     DANGEROUS_CAPABILITY_EXPOSURE("Dangerous capability exposure", InsightId.Category.ACTIONABLE, InsightId.Group.ATLAS_DISCOVERY),
     MCP_SPRAWL("Unapproved & local MCP sprawl", InsightId.Category.READ_ONLY, InsightId.Group.ATLAS_DISCOVERY),
     WHAT_CHANGED_THIS_WEEK("What changed this week", InsightId.Category.READ_ONLY, InsightId.Group.ATLAS_DISCOVERY),
 
     // — guardrail/violation insights (feature/dashbaord/guardrail-insights) —
-    ALERT_FATIGUE("Alert fatigue — same user, same policy, over and over", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
-    TEST_POLICIES_ON_PROD("Test policies running against production users", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
-    SKILL_EVALUATION_CONCENTRATION("One user, one class, flooding the queue", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
-    CREDENTIAL_EXPOSURE("Credentials and secrets — separated from PII", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
-    PROMPT_INJECTION_REPEATS("Prompt injection attempts, grouped by source", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
-    LIKELY_FALSE_POSITIVES("Likely false positives — flag as min risk, don't hide", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
-    ALERT_MODE_REAL_HITS("Policies in alert mode that are catching real things", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
-    POLICY_HYGIENE("Policy hygiene — dead policies and uncovered assets", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS);
+    ALERT_FATIGUE("Alert fatigue", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
+    TEST_POLICIES_ON_PROD("Test policies on production", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
+    EVALUATION_CONCENTRATION("Evaluation concentration", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS, true),
+    CREDENTIAL_EXPOSURE("Credential exposure", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS, true),
+    PROMPT_INJECTION_REPEATS("Prompt injection repeats", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS, true),
+    LIKELY_FALSE_POSITIVES("Likely false positives", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS, true),
+    ALERT_MODE_REAL_HITS("Alert-mode policies catching real hits", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS),
+    POLICY_HYGIENE("Policy hygiene", InsightId.Category.ACTIONABLE, InsightId.Group.GUARDRAIL_VIOLATIONS);
 
     private final String title;
     private final Category category;
     private final Group group;
+    // Static, hand-set "not ready" toggle — true only for an insight whose provider isn't wired up
+    // yet, same value for every account regardless of whether that account happens to have data.
+    // NOT for "this account has no data right now" — that's a real, checked result (see
+    // AbstractInsightProvider.skeleton, InsightResult.disabled), not an unimplemented insight.
+    private final boolean disabled;
 
     InsightId(String title, Category category, Group group) {
+        this(title, category, group, false);
+    }
+
+    InsightId(String title, Category category, Group group, boolean disabled) {
         this.title = title;
         this.category = category;
         this.group = group;
+        this.disabled = disabled;
     }
 
     /** How an insight is presented: ACTIONABLE cards carry CTAs, READ_ONLY cards are context only. */

--- a/apps/dashboard/src/main/java/com/akto/service/insights/InsightResult.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/InsightResult.java
@@ -26,6 +26,11 @@ public class InsightResult {
     private String group;               // InsightId.Group — ATLAS_DISCOVERY | GUARDRAIL_VIOLATIONS
     private String status;              // Status
     private String severity;
+    // Copied straight from InsightId.disabled (see AbstractInsightProvider.skeleton) — a static,
+    // hand-set "this insight's provider isn't wired up yet" toggle, same for every account. NOT a
+    // signal for "this account has no data right now" — a confirmed-zero or NO_DATA result is
+    // still a real, checked outcome and should render normally with no severity badge.
+    private boolean disabled;
     private String headline;            // Java-built one-liner. NEVER from the LLM.
     // concern/impact/remediation: the provider sets a Java-computed, deterministic draft (or
     // leaves it null when there's nothing to flag) — that's the guaranteed fallback shown

--- a/apps/dashboard/src/main/java/com/akto/service/insights/InsightService.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/InsightService.java
@@ -83,9 +83,12 @@ public class InsightService {
             }
         }
         // Worst-first: a reader should see CRITICAL/HIGH cards before LOW ones, not the fixed
-        // cheapest-first build order the registry iterates in. List.sort is stable, so insights
-        // tied on severity keep that original registry order as their tiebreak.
-        results.sort(Comparator.comparingInt(r -> severityRank(r.getSeverity())));
+        // cheapest-first build order the registry iterates in. Disabled ("Coming soon") cards sort
+        // last regardless of severity — there's nothing to act on yet. List.sort is stable, so
+        // insights tied on both keep their original registry order as the final tiebreak.
+        results.sort(Comparator
+                .comparing(InsightResult::isDisabled)
+                .thenComparingInt(r -> severityRank(r.getSeverity())));
         return results;
     }
 
@@ -160,6 +163,7 @@ public class InsightService {
         r.setGroup(provider.id().getGroup().name());
         r.setStatus(InsightResult.Status.NO_DATA.name());
         r.setHeadline("This insight could not be computed.");
+        r.setDisabled(provider.id().isDisabled());
         return r;
     }
 

--- a/apps/dashboard/src/main/java/com/akto/service/insights/InsightUtil.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/InsightUtil.java
@@ -227,13 +227,14 @@ public final class InsightUtil {
         }
     }
 
-    // ── CTA deep-link params — only these two mechanisms actually work on the frontend today ──
+    // ── CTA deep-link params — only these mechanisms actually work on the frontend today ──
     // (verified against the live pages, not assumed): Users and Devices reads a single `filters`
-    // query param shaped `key__v1,v2,...` (GithubServerTable's convention; `groupName` is the only
-    // filterKey that page declares — a bare `?username=`/`?host=` param is silently ignored).
-    // Guardrail Policies has no filtered-list deep link, only a single-policy one: `?policy=<exact
-    // name>` opens that policy's edit drawer (GuardrailPolicies.jsx's own `?policy=` handling) —
-    // `policyId`/`policyName`/`policyIds` keys are not read by that page and do nothing.
+    // query param shaped `key__v1,v2,...` (GithubServerTable's convention; `username` is the only
+    // filterKey its Users-tab `fetchData` actually consumes — `groupName` parses into a UI chip but
+    // is silently dropped before it reaches the backend query, so it must not be used here).
+    // Guardrail Policies reads `?policy=<exact name>` (opens that policy's edit drawer) and
+    // `?policyIds=id1,id2,...` (pre-selects those rows for a bulk action) — `policyId`/`policyName`
+    // keys are not read by that page and do nothing.
 
     /** Empty map (falls back to an unfiltered NAVIGATE) if usernames has no non-blank entries. */
     public static Map<String, Object> usersAndDevicesFilterParams(List<String> usernames) {
@@ -242,7 +243,7 @@ public final class InsightUtil {
             for (String u : usernames) if (u != null && !u.isEmpty()) clean.add(u);
         }
         Map<String, Object> params = new HashMap<>();
-        if (!clean.isEmpty()) params.put("filters", "groupName__" + String.join(",", clean));
+        if (!clean.isEmpty()) params.put("filters", "username__" + String.join(",", clean));
         return params;
     }
 

--- a/apps/dashboard/src/main/java/com/akto/service/insights/providers/AlertFatigueProvider.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/providers/AlertFatigueProvider.java
@@ -86,10 +86,16 @@ public class AlertFatigueProvider extends AbstractInsightProvider {
         List<InsightResult.Metric> baseMetrics = new ArrayList<>(Arrays.asList(totalMetric, bucketMetric));
 
         if (scope == Scope.LIST) {
+            // Real repeat-rate still requires collapsing into incidents in the detail view, but a
+            // reader shouldn't see "Coming soon" for a card with real violation volume behind it —
+            // tier by raw volume as a floor; DETAIL can still move this to CRITICAL/HIGH/MEDIUM once
+            // the real per-incident repeat counts are known, same as TestPoliciesOnProdProvider's
+            // LIST-scope severityFromShare vs. its DETAIL CRITICAL override.
             result.setStatus(InsightResult.Status.PARTIAL.name());
             result.setHeadline(InsightUtil.count(totalViolations, "violations") + " across "
                     + InsightUtil.count(distinctBuckets, "combinations")
                     + "; collapsing into per-user incidents requires the detail view.");
+            result.setSeverity(severityFromVolume(totalViolations));
             result.setMetrics(baseMetrics);
             result.setMetricsComplete(false);
             result.setDataGaps(Collections.singletonList(new InsightResult.Gap(
@@ -306,6 +312,17 @@ public class AlertFatigueProvider extends AbstractInsightProvider {
 
     private static String lower(String s) {
         return s == null ? "" : s.trim().toLowerCase(Locale.US);
+    }
+
+    /** LIST-scope approximation from raw volume alone, before incidents are collapsed. */
+    private static String severityFromVolume(long totalViolations) {
+        if (totalViolations >= 100) {
+            return "HIGH";
+        }
+        if (totalViolations >= 20) {
+            return "MEDIUM";
+        }
+        return "LOW";
     }
 
     private static List<InsightResult.Cta> buildCtas(List<Incident> topIncidents) {

--- a/apps/dashboard/src/main/java/com/akto/service/insights/providers/CredentialExposureProvider.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/providers/CredentialExposureProvider.java
@@ -71,9 +71,18 @@ public class CredentialExposureProvider extends AbstractInsightProvider {
         InsightResult result = skeleton();
 
         if (scope == Scope.LIST) {
+            // A real severity when there's already-labeled Secrets volume to show — but this can
+            // only ever be a floor: the mislabeled-credential case this insight exists to catch is,
+            // by definition, NOT counted in labeledSecretsCount, and finding it needs the raw-event
+            // scan below. So unlike most providers here, labeledSecretsCount == 0 does NOT mean
+            // severity stays null out of caution — it stays null because there is genuinely nothing
+            // cheap to show yet, not because it's a confirmed-clean result.
             result.setStatus(InsightResult.Status.PARTIAL.name());
             result.setHeadline(InsightUtil.count(labeledSecretsCount, "violations")
                     + " already labeled Secrets; checking other buckets for mislabeled credentials requires the detail view.");
+            if (labeledSecretsCount > 0) {
+                result.setSeverity("MEDIUM");
+            }
             result.setMetrics(Collections.singletonList(labeledMetric));
             result.setMetricsComplete(false);
             result.setDataGaps(Collections.singletonList(new InsightResult.Gap(
@@ -86,7 +95,10 @@ public class CredentialExposureProvider extends AbstractInsightProvider {
 
         // DETAIL: page the most recent violations account-wide (no subCategory narrowing — the
         // whole point is to find credential-shaped evidence wherever it landed) and pattern-match.
-        List<DashboardMaliciousEvent> events = bundle.fetchViolationEvents(scope, EVENT_PAGE_LIMIT, null, null);
+        // "exclude" drops Skills Evaluations traffic — a skill's own documentation matching a
+        // credential-shaped pattern isn't a live credential leak (same convention as
+        // AlertFatigueProvider and PromptInjectionRepeatsProvider).
+        List<DashboardMaliciousEvent> events = bundle.fetchViolationEvents(scope, EVENT_PAGE_LIMIT, null, "exclude");
         if (events == null) events = new ArrayList<>();
 
         if (events.isEmpty()) {

--- a/apps/dashboard/src/main/java/com/akto/service/insights/providers/LikelyFalsePositivesProvider.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/providers/LikelyFalsePositivesProvider.java
@@ -114,10 +114,14 @@ public class LikelyFalsePositivesProvider extends AbstractInsightProvider {
         List<InsightResult.Metric> baseMetrics = new ArrayList<>(Arrays.asList(totalMetric, policyCountMetric));
 
         if (scope == Scope.LIST) {
+            // Real precision (the false-positive rate) still requires the detail view, but a reader
+            // shouldn't see "Coming soon" for a card with real PII-labeled volume behind it — tier by
+            // volume alone as a floor; DETAIL can move this to CRITICAL once precision is known.
             result.setStatus(InsightResult.Status.PARTIAL.name());
             result.setHeadline(InsightUtil.count(totalPiiViolations, "violations") + " labeled PII across "
                     + InsightUtil.count(policiesWithPii.size(), "policies")
                     + "; a precision estimate requires the detail view.");
+            result.setSeverity(totalPiiViolations >= 20 ? "MEDIUM" : "LOW");
             result.setMetrics(baseMetrics);
             result.setMetricsComplete(false);
             result.setDataGaps(Collections.singletonList(new InsightResult.Gap(
@@ -132,7 +136,9 @@ public class LikelyFalsePositivesProvider extends AbstractInsightProvider {
         // above (the exact type list is per-account/dynamic — see PiiPatterns' doc — so it can't
         // be known in advance; the free aggregate just told us which ones actually occur here).
         // Only rows that are actually PII-<type>-labeled feed this — a piiOnlyPolicyNamesLower
-        // fallback row's subCategory is the policy's own name, not a real PII type.
+        // fallback row's subCategory is the policy's own name, not a real PII type. "exclude" drops
+        // Skills Evaluations traffic — a skill's own documentation matching a PII pattern isn't a
+        // live false-positive-worthy hit (same convention as AlertFatigueProvider).
         List<String> exactSubCategories = piiRows.stream()
                 .map(ThreatCategoryCount::getSubCategory)
                 .filter(sc -> sc != null && sc.regionMatches(true, 0, PII_PREFIX, 0, PII_PREFIX.length()))
@@ -141,7 +147,7 @@ public class LikelyFalsePositivesProvider extends AbstractInsightProvider {
         boolean anyFetchCapped = false;
         if (!exactSubCategories.isEmpty()) {
             List<DashboardMaliciousEvent> labeled = bundle.fetchViolationEvents(scope, EVENT_PAGE_LIMIT,
-                    Collections.singletonMap("subCategory", exactSubCategories), null);
+                    Collections.singletonMap("subCategory", exactSubCategories), "exclude");
             if (labeled != null) {
                 events.addAll(labeled);
                 anyFetchCapped = anyFetchCapped || labeled.size() == EVENT_PAGE_LIMIT;
@@ -155,7 +161,7 @@ public class LikelyFalsePositivesProvider extends AbstractInsightProvider {
                 .distinct().collect(Collectors.toCollection(LinkedHashSet::new));
         if (!fallbackPolicyNames.isEmpty()) {
             List<DashboardMaliciousEvent> fallbackEvents = bundle.fetchViolationEvents(scope, EVENT_PAGE_LIMIT,
-                    Collections.singletonMap("latestAttack", new ArrayList<>(fallbackPolicyNames)), null);
+                    Collections.singletonMap("latestAttack", new ArrayList<>(fallbackPolicyNames)), "exclude");
             if (fallbackEvents != null) {
                 anyFetchCapped = anyFetchCapped || fallbackEvents.size() == EVENT_PAGE_LIMIT;
                 Set<String> seenIds = events.stream().map(DashboardMaliciousEvent::getId).collect(Collectors.toCollection(HashSet::new));

--- a/apps/dashboard/src/main/java/com/akto/service/insights/providers/PromptInjectionRepeatsProvider.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/providers/PromptInjectionRepeatsProvider.java
@@ -100,9 +100,15 @@ public class PromptInjectionRepeatsProvider extends AbstractInsightProvider {
         }
 
         if (scope == Scope.LIST) {
+            // A real, if approximate, severity from the volume alone — the actual repeat pattern
+            // still requires paging raw events (below), but a reader shouldn't see "Coming soon" for
+            // a card that already has real attempts behind it. Same template as
+            // TestPoliciesOnProdProvider's LIST-scope severityFromShare; DETAIL can still move this
+            // up (e.g. to CRITICAL for sustained repeats) or down once the real grouping is known.
             result.setStatus(InsightResult.Status.PARTIAL.name());
             result.setHeadline(InsightUtil.count(totalAttempts, "attempts")
                     + "; grouping by source and finding repeats requires the detail view.");
+            result.setSeverity(severityFromVolume(totalAttempts));
             result.setMetrics(Collections.singletonList(totalMetric));
             result.setMetricsComplete(false);
             result.setDataGaps(Collections.singletonList(new InsightResult.Gap(
@@ -117,7 +123,11 @@ public class PromptInjectionRepeatsProvider extends AbstractInsightProvider {
         // longer narrow the server-side query to subCategory == "PromptInjection" alone (a policy's
         // real hits may not carry that literal) — sweep unfiltered instead, like item #4's
         // credential scan, and keep only events that are actually injection-shaped by either signal.
-        List<DashboardMaliciousEvent> rawEvents = bundle.fetchViolationEvents(scope, EVENT_PAGE_LIMIT, null, null);
+        // "exclude" drops Skills Evaluations traffic — same convention as AlertFatigueProvider (see
+        // its comment): a skill's own safety-scan verdict isn't a live-traffic injection attempt, and
+        // on a real account it can outnumber genuine attempts by 70:1, drowning any real repeat
+        // pattern under near-unique per-skill evidence text that structurally never repeats.
+        List<DashboardMaliciousEvent> rawEvents = bundle.fetchViolationEvents(scope, EVENT_PAGE_LIMIT, null, "exclude");
         if (rawEvents == null) rawEvents = new ArrayList<>();
         boolean rawSweepCapped = rawEvents.size() == EVENT_PAGE_LIMIT;
         List<DashboardMaliciousEvent> events = rawEvents.stream()
@@ -308,6 +318,19 @@ public class PromptInjectionRepeatsProvider extends AbstractInsightProvider {
 
     private static String lower(String s) {
         return s == null ? "" : s.trim().toLowerCase(Locale.US);
+    }
+
+    /** LIST-scope approximation from raw volume alone, before repeats are known — an injection
+     *  attempt is a stronger per-event signal than routine PII noise, so even a single one is
+     *  worth flagging rather than waiting for a volume threshold. */
+    private static String severityFromVolume(long totalAttempts) {
+        if (totalAttempts >= HIGH_SEVERITY_REPEAT_COUNT * 3L) {
+            return "HIGH";
+        }
+        if (totalAttempts >= HIGH_SEVERITY_REPEAT_COUNT) {
+            return "MEDIUM";
+        }
+        return "LOW";
     }
 
 

--- a/apps/dashboard/src/main/java/com/akto/service/insights/providers/SkillEvaluationConcentrationProvider.java
+++ b/apps/dashboard/src/main/java/com/akto/service/insights/providers/SkillEvaluationConcentrationProvider.java
@@ -32,7 +32,7 @@ public class SkillEvaluationConcentrationProvider extends AbstractInsightProvide
     private static final int EVENT_PAGE_LIMIT = 2000;
     private static final int EVIDENCE_ROW_CAP = 20;
 
-    public SkillEvaluationConcentrationProvider() { super(InsightId.SKILL_EVALUATION_CONCENTRATION, 1); }
+    public SkillEvaluationConcentrationProvider() { super(InsightId.EVALUATION_CONCENTRATION, 1); }
 
     @Override
     public InsightResult compute(InsightDataBundle bundle, InsightContext ctx, Scope scope) {
@@ -75,10 +75,15 @@ public class SkillEvaluationConcentrationProvider extends AbstractInsightProvide
         List<InsightResult.Metric> baseMetrics = new ArrayList<>(Arrays.asList(totalMetric, skillCountMetric));
 
         if (scope == Scope.LIST) {
+            // Real per-user concentration still requires the detail view, but a reader shouldn't see
+            // "Coming soon" for a card that already has real evaluations behind it — any Critical-
+            // severity evaluation at all is worth at least a MEDIUM flag even before concentration is
+            // known; DETAIL can still move this to CRITICAL/HIGH once the real top-user share is in.
             result.setStatus(InsightResult.Status.PARTIAL.name());
             result.setHeadline(InsightUtil.count(total, "evaluations") + " across "
                     + InsightUtil.count(perSkill.size(), "skills")
                     + "; per-user concentration requires the detail view.");
+            result.setSeverity(totalCritical > 0 ? "MEDIUM" : "LOW");
             result.setMetrics(baseMetrics);
             result.setMetricsComplete(false);
             result.setDataGaps(Collections.singletonList(new InsightResult.Gap(

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/layouts/style.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/layouts/style.css
@@ -26,6 +26,18 @@
 .insight-row:hover {
     background: #FBFAFF;
 }
+/* status === "NO_DATA" — nothing could be computed (e.g. threat backend unavailable), as
+   opposed to a confirmed-clean READY/PARTIAL result. Not clickable; see .insight-row:hover
+   above for the normal-row hover, intentionally not applied here. */
+.insight-row-disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+/* Two classes so this reliably beats the plain .insight-row:hover rule (there are two
+   duplicate copies of it in this file) regardless of source order. */
+.insight-row.insight-row-disabled:hover {
+    background: none;
+}
 .insight-severity-bar {
     width: 3px;
     border-radius: 2px;

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/insights/InsightsListView.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/insights/InsightsListView.jsx
@@ -5,13 +5,20 @@ import { SeverityBadge } from "../AgenticCellRenderers";
 import "../../../../components/layouts/style.css";
 
 const InsightRow = React.memo(function InsightRow({ insight, onSelect }) {
-    const handleClick = useCallback(() => onSelect(insight.insightId), [insight.insightId, onSelect]);
+    // Backend-computed, straight from InsightId.disabled — a static "not wired up yet" toggle,
+    // same for every account. NOT set for a confirmed-zero or NO_DATA result (those still render
+    // normally with no severity badge — see InsightResult.disabled's own comment).
+    const disabled = !!insight.disabled;
+    const handleClick = useCallback(() => {
+        if (disabled) return;
+        onSelect(insight.insightId);
+    }, [insight.insightId, onSelect, disabled]);
     const headline = insight.headline || (insight.metrics && insight.metrics[0]?.formatted) || "";
     const severity = String(insight.severity || "").toUpperCase();
 
     return (
         <Box
-            className="insight-row"
+            className={`insight-row${disabled ? " insight-row-disabled" : ""}`}
             padding={"3"}
             onClick={handleClick}
         >
@@ -20,15 +27,15 @@ const InsightRow = React.memo(function InsightRow({ insight, onSelect }) {
                 <Box minWidth="0" style={{ flex: 1 }}>
                     <VerticalStack gap="2">
                         <HorizontalStack gap="2" blockAlign="center" wrap>
-                            <Text variant="bodyMd" fontWeight="semibold">{insight.title}</Text>
-                            {insight.severity ? <SeverityBadge severity={insight.severity} /> : <Badge>Coming soon</Badge>}
+                            <Text variant="bodyMd" fontWeight="semibold" color={disabled ? "subdued" : undefined}>{insight.title}</Text>
+                            {disabled ? <Badge>Coming soon</Badge> : (insight.severity ? <SeverityBadge severity={insight.severity} /> : null)}
                         </HorizontalStack>
                         {headline ? (
                             <Text variant="bodySm" color="subdued">{headline}</Text>
                         ) : null}
                     </VerticalStack>
                 </Box>
-                <Icon source={ChevronRightMinor} color="subdued" />
+                {!disabled && <Icon source={ChevronRightMinor} color="subdued" />}
             </HorizontalStack>
         </Box>
     );


### PR DESCRIPTION
- Introduced a `disabled` flag in `InsightId` to indicate insights that are not yet wired up.
- Updated `InsightResult` to include the `disabled` state.
- Modified `AbstractInsightProvider` and various provider classes to set the `disabled` state appropriately.
- Enhanced sorting logic in `InsightService` to prioritize enabled insights.
- Updated UI components to reflect the disabled state visually and prevent interaction with disabled insights.
- Adjusted severity calculations in several providers to account for real data availability.