### PR TITLE
Values tab fixes

### DIFF
--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/layouts/style.css
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/layouts/style.css
@@ -193,6 +193,14 @@
     overflow-wrap: break-word;
     word-break: break-word;
 }
+/* Overview tab's evidence excerpt — clamp to 4 lines so a huge captured payload doesn't
+   dominate the tab; the Values tab still shows the full content. */
+.violation-evidence-clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
 /* Avatar + quote row — force top-alignment regardless of content height.
    HorizontalStack blockAlign="start" relies on a CSS custom property pipeline that
    can fail in some Polaris builds; an explicit class is the reliable fallback. */

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationFlyout.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationFlyout.jsx
@@ -26,6 +26,7 @@ import SampleDataList from "@/apps/dashboard/components/shared/SampleDataList";
 import func from "@/util/func";
 import guardrailsApi from "../api";
 import threatDetectionApi from "@/apps/dashboard/pages/threat_detection/api";
+import { redactSampleDataByKeywords } from "@/apps/dashboard/pages/threat_detection/utils/redactSampleData";
 import issuesApi from "@/apps/dashboard/pages/issues/api";
 import settingFunctions from "@/apps/dashboard/pages/settings/module";
 import issuesFunctions from "@/apps/dashboard/pages/issues/module";
@@ -376,13 +377,32 @@ function FlyoutHeader({ row, onClose, onStatusUpdate }) {
 
 export default function ViolationFlyout({ violation, show, onClose, onStatusUpdate }) {
     const [selectedTab, setSelectedTab] = useState(0);
+    const [enrichedPayload, setEnrichedPayload] = useState(null);
 
     useEffect(() => { setSelectedTab(0); }, [violation?.id]);
 
+    // The list endpoint's row doesn't always carry the full captured request/response
+    // (row.payload can be empty even though the event has one) - the same gap the old
+    // Threat Activity flyout covers by fetching it on open via refId/eventType/filterId.
+    // Do the same here, only when the row itself has nothing to show.
+    useEffect(() => {
+        setEnrichedPayload(null);
+        if (violation?.payload || !violation?.refId || !violation?.eventType || !violation?.filterId) return;
+        let cancelled = false;
+        threatDetectionApi.fetchMaliciousRequest(violation.refId, violation.eventType, violation.actor || "", violation.filterId)
+            .then(res => {
+                if (cancelled) return;
+                const orig = res?.maliciousPayloadsResponses?.[0]?.orig;
+                if (orig) setEnrichedPayload(redactSampleDataByKeywords(orig));
+            })
+            .catch(() => {});
+        return () => { cancelled = true; };
+    }, [violation?.id, violation?.refId, violation?.eventType, violation?.filterId, violation?.actor, violation?.payload]);
+
     const detail = useMemo(() => {
         if (!violation) return null;
-        return buildFallbackDetail(violation);
-    }, [violation]);
+        return buildFallbackDetail(enrichedPayload ? { ...violation, payload: enrichedPayload } : violation);
+    }, [violation, enrichedPayload]);
 
     const chatMetadata = useMemo(() => {
         if (!violation || !detail) return null;
@@ -407,9 +427,7 @@ export default function ViolationFlyout({ violation, show, onClose, onStatusUpda
             { id: "promptResponse", content: "Values" },
         ];
         let middle = null;
-        if (detail?.chatSession?.length) middle = "chat";
-        else if (detail?.fileContent && violation?.type !== "Skill") middle = "file";
-        if (middle === "chat") tabs.push({ id: "chat", content: "Chat Session" });
+        if (detail?.fileContent && violation?.type !== "Skill" && violation?.type !== "Tool") middle = "file";
         if (middle === "file") tabs.push({ id: "file", content: detail.fileTabLabel || "File" });
         if (detail?.remediation) tabs.push({ id: "remediation", content: "Remediation" });
         tabs.push({ id: "timeline", content: "Timeline" });

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationFlyout.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationFlyout.jsx
@@ -426,9 +426,9 @@ export default function ViolationFlyout({ violation, show, onClose, onStatusUpda
             { id: "overview", content: "Overview" },
             { id: "promptResponse", content: "Values" },
         ];
+        // "file" middle tab (Config.json/Skill Info/Tool call) is hidden - Config now shows
+        // its full file content inline on the Values tab instead of a separate tab.
         let middle = null;
-        if (detail?.fileContent && violation?.type !== "Skill" && violation?.type !== "Tool") middle = "file";
-        if (middle === "file") tabs.push({ id: "file", content: detail.fileTabLabel || "File" });
         if (detail?.remediation) tabs.push({ id: "remediation", content: "Remediation" });
         tabs.push({ id: "timeline", content: "Timeline" });
         return { tabs, middle };

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationFlyoutSections.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationFlyoutSections.jsx
@@ -65,7 +65,9 @@ export function EvidenceBlock({ evidence }) {
                                     {evidence.time && <Text variant="bodySm" color="subdued">{evidence.time}</Text>}
                                 </HorizontalStack>
                             )}
-                            <HighlightedText text={evidence.text} highlights={evidence.highlights} mono={evidence.mono} />
+                            <Box className="violation-evidence-clamp">
+                                <HighlightedText text={evidence.text} highlights={evidence.highlights} mono={evidence.mono} />
+                            </Box>
                         </VerticalStack>
                     </Box>
                 </Box>
@@ -332,9 +334,26 @@ export function PromptResponseSection({ detail }) {
             <Box padding="4">
                 <VerticalStack gap="3">
                     <Text variant="headingMd" color="subdued">{pr.valueLabel || "Flagged Content"}</Text>
-                    {hasPrompt
-                        ? <HighlightedText text={pr.promptBody} mono />
-                        : <Text variant="bodySm" color="subdued">No content captured for this violation.</Text>}
+                    {!hasPrompt
+                        ? <Text variant="bodySm" color="subdued">No content captured for this violation.</Text>
+                        : pr.valueLabel === "Prompt"
+                            ? <HighlightedText text={pr.promptBody} mono />
+                            : (
+                                <SampleData
+                                    data={{
+                                        message: pr.promptBody,
+                                        vulnerabilitySegments: (pr.highlights || []).map((highlight) =>
+                                            typeof highlight === "string"
+                                                ? { phrase: highlight }
+                                                : { ...highlight, includeKeyInHighlight: true }
+                                        ),
+                                    }}
+                                    editorLanguage="plaintext"
+                                    minHeight="400px"
+                                    readOnly
+                                    wordWrap
+                                />
+                            )}
                 </VerticalStack>
             </Box>
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
@@ -48,7 +48,7 @@ import P95LatencyGraph from "@/apps/dashboard/components/charts/P95LatencyGraph"
 import threatDetectionApi from "@/apps/dashboard/pages/threat_detection/api";
 import { getDashboardCategory, mapLabel } from "@/apps/main/labelHelper";
 import ViolationFlyout from "./ViolationFlyout";
-import { normalizeReasonPunctuation, coerceToText, sanitizeDisplayText } from "./violationsData";
+import { coerceToText, sanitizeDisplayText } from "./violationsData";
 import AdvancedPayloadSearch from "./AdvancedPayloadSearch";
 import { addAdvancedFilter, filterFromEditorSelection, toLatestApiOrigRegex } from "./attributeSearch";
 import InsightsFlyout from "@/apps/dashboard/pages/observe/agentic/insights/InsightsFlyout";
@@ -219,6 +219,9 @@ function buildColDefs(filterValues, showApprove, onApprove) {
             headerName: "Detected",
             minWidth: 150,
             valueFormatter: p => p.value != null ? func.epochToDateTime(p.value) : "",
+            // Most recent first by default. Declared here (rather than defaulting inside
+            // onServerFetch) so the header's sort indicator matches what's actually requested.
+            sort: "desc",
         },
         {
             field: "type",
@@ -256,10 +259,8 @@ function buildColDefs(filterValues, showApprove, onApprove) {
             filter: "agSetColumnFilter",
             filterParams: { values: ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
             cellRenderer: SeverityCellRenderer,
-            // Critical first by default. Declared on the column (rather than defaulting inside
-            // onServerFetch) so the header's sort indicator matches what's actually requested:
-            // asc here means ascending severityRank, and the backend ranks CRITICAL as 1.
-            sort: "asc",
+            // Not sorted by default (detected is) — asc here would mean ascending severityRank,
+            // and the backend ranks CRITICAL as 1, so clicking this header still ranks Critical first.
         },
         // Atlas: username from Endpoint Shield metadata. Argus: identity actor (IAM ARN, etc.),
         // distinct from the Agentic Asset column.
@@ -457,7 +458,7 @@ function transformEvent(event, collectionsMap, usernameMap, guardrailComplianceM
     const typeLabel = deriveAgenticType(event.url, event.method);
     const policyName = meta.rule_violated || meta.npolicy_name || event.filterId || "-";
 
-    const { req: reqPayload, resp: respPayload } = parseAktoPayload(event.payload);
+    const { req: reqPayload, resp: respPayload, raw: rawPayload } = parseAktoPayload(event.payload);
     const rawBehaviour = respPayload?.error?.data?.behaviour || meta.behaviour || meta.nbehaviour || null;
     const action = rawBehaviour === "block" ? "Blocked"
         : (rawBehaviour === "warn" || rawBehaviour === "flag") ? "Flagged"
@@ -473,8 +474,14 @@ function transformEvent(event, collectionsMap, usernameMap, guardrailComplianceM
     const skillOrToolName = deriveSkillOrToolName(event.url);
 
     const isPromptOrTool = typeLabel === "Prompt" || typeLabel === "Tool";
+    // Tool events store the request payload flat (reqPayload *is* the tool args, e.g.
+    // {file_path, content}) rather than wrapped in a {body: ...} envelope, so checking
+    // reqPayload?.body alone finds nothing for those - fall back to the whole object. And
+    // when requestPayload fails to JSON.parse at all (e.g. a captured tool call whose command
+    // text breaks JSON escaping), reqPayload is null even though the raw string has real
+    // content - fall back to that raw string rather than showing nothing.
     const primaryValue = sanitizeDisplayText(coerceToText(isPromptOrTool
-        ? (reqPayload?.body || null)
+        ? (reqPayload?.body || (typeLabel === "Tool" ? reqPayload : null) || rawPayload?.requestPayload || null)
         : typeLabel === "Skill" ? (respPayload?.evidence || null) : (reqPayload?.evidence || null)), 300);
 
     return {
@@ -488,6 +495,10 @@ function transformEvent(event, collectionsMap, usernameMap, guardrailComplianceM
         // for the Needs Approval tab's client-side filter and "Approve server" action, which need
         // the exact values the backend expects (approveServerForPolicy takes policyName + serverId).
         filterId: event.filterId,
+        // refId/eventType: same fields SusDataTable uses to deep-link into fetchMaliciousRequest -
+        // lets the flyout fetch the full captured request/response when row.payload is empty.
+        refId: event.refId,
+        eventType: event.eventType,
         host: rawHost,
         behaviourRaw: rawBehaviour,
         type: typeLabel,
@@ -496,7 +507,9 @@ function transformEvent(event, collectionsMap, usernameMap, guardrailComplianceM
         // Same resolver the old UI and the flyout use, so the column, the flyout and the
         // compliance report all agree on a row's clauses.
         complianceMap: resolveComplianceClauseMap(event, true, {}, guardrailComplianceMap || {}),
-        evidenceText: primaryValue || normalizeReasonPunctuation(meta.reason) || "-",
+        // Request-derived only - never falls back to meta.reason (a response/guardrail
+        // explanation), which would show up as if it were the captured request content.
+        evidenceText: primaryValue || "-",
         riskScore: parseStoredRiskScore(meta),
         actor: event.actor || "",
         user: userDisplay,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/ViolationsPage.jsx
@@ -48,7 +48,7 @@ import P95LatencyGraph from "@/apps/dashboard/components/charts/P95LatencyGraph"
 import threatDetectionApi from "@/apps/dashboard/pages/threat_detection/api";
 import { getDashboardCategory, mapLabel } from "@/apps/main/labelHelper";
 import ViolationFlyout from "./ViolationFlyout";
-import { coerceToText, sanitizeDisplayText } from "./violationsData";
+import { coerceToText, sanitizeDisplayText, extractPromptBody } from "./violationsData";
 import AdvancedPayloadSearch from "./AdvancedPayloadSearch";
 import { addAdvancedFilter, filterFromEditorSelection, toLatestApiOrigRegex } from "./attributeSearch";
 import InsightsFlyout from "@/apps/dashboard/pages/observe/agentic/insights/InsightsFlyout";
@@ -474,14 +474,15 @@ function transformEvent(event, collectionsMap, usernameMap, guardrailComplianceM
     const skillOrToolName = deriveSkillOrToolName(event.url);
 
     const isPromptOrTool = typeLabel === "Prompt" || typeLabel === "Tool";
-    // Tool events store the request payload flat (reqPayload *is* the tool args, e.g.
-    // {file_path, content}) rather than wrapped in a {body: ...} envelope, so checking
-    // reqPayload?.body alone finds nothing for those - fall back to the whole object. And
-    // when requestPayload fails to JSON.parse at all (e.g. a captured tool call whose command
-    // text breaks JSON escaping), reqPayload is null even though the raw string has real
-    // content - fall back to that raw string rather than showing nothing.
+    // extractPromptBody unpacks a chat-shaped body ({messages: [...]}) to the actual last user
+    // message instead of dumping raw {"messages":[{"role":"user",...}]} JSON. Tool events store
+    // the request payload flat (reqPayload *is* the tool args, e.g. {file_path, content}) rather
+    // than wrapped in a {body: ...} envelope, so it finds nothing for those - fall back to the
+    // whole object. And when requestPayload fails to JSON.parse at all (e.g. a captured tool
+    // call whose command text breaks JSON escaping), reqPayload is null even though the raw
+    // string has real content - fall back to that raw string rather than showing nothing.
     const primaryValue = sanitizeDisplayText(coerceToText(isPromptOrTool
-        ? (reqPayload?.body || (typeLabel === "Tool" ? reqPayload : null) || rawPayload?.requestPayload || null)
+        ? (extractPromptBody(reqPayload) ?? (typeLabel === "Tool" ? reqPayload : null) ?? rawPayload?.requestPayload ?? null)
         : typeLabel === "Skill" ? (respPayload?.evidence || null) : (reqPayload?.evidence || null)), 300);
 
     return {

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
@@ -42,9 +42,11 @@ export function coerceToText(value) {
     try { return JSON.stringify(value); } catch { return String(value); }
 }
 
-function _extractPromptBody(req) {
+// Checked before the plain req.body fallback below - a chat-shaped body ({messages: [...]})
+// must be unpacked to the actual last user message text, not dumped as raw
+// {"messages":[{"role":"user",...}]} JSON (which is what req.body != null would otherwise return).
+export function extractPromptBody(req) {
     if (!req) return null;
-    if (req.body != null) return req.body;
     const msgs = req.messages || req?.body?.messages;
     if (Array.isArray(msgs) && msgs.length > 0) {
         const lastUser = [...msgs].reverse().find(m => m.role === "user") || msgs[msgs.length - 1];
@@ -53,6 +55,7 @@ function _extractPromptBody(req) {
         if (Array.isArray(content)) return content.map(c => c.text || "").join("\n");
         return content;
     }
+    if (req.body != null) return req.body;
     return null;
 }
 
@@ -334,13 +337,13 @@ export function buildFallbackDetail(row) {
     const isPromptOrTool = row.type === "Prompt" || row.type === "Tool";
     // Tool events store the request payload flat (req *is* the tool args, e.g.
     // {file_path, content}) rather than wrapped in a {body: ...} envelope, so
-    // _extractPromptBody (which only looks for req.body/req.messages) finds nothing —
+    // extractPromptBody (which only looks for req.messages/req.body) finds nothing —
     // fall back to the whole req object itself for Tool violations. And when
     // outer.requestPayload fails to JSON.parse at all (e.g. a captured tool call whose
     // command text breaks JSON escaping) - req is null even though the raw string has real
     // content - fall back to that raw string rather than showing nothing.
     const rawPrimaryValue = coerceToText(isPromptOrTool
-        ? (_extractPromptBody(req) ?? (row.type === "Tool" ? req : null) ?? outer.requestPayload ?? null)
+        ? (extractPromptBody(req) ?? (row.type === "Tool" ? req : null) ?? outer.requestPayload ?? null)
         : row.type === "Skill" ? (resp?.evidence || null) : (req?.evidence || null));
     // If the value is JSON (or JSON nested inside JSON, e.g. a proxied request captured as a
     // string field), unwrap and pretty-print it instead of showing raw escaped quotes.

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
@@ -389,10 +389,12 @@ export function buildFallbackDetail(row) {
             // promptBody must come only from the request/tool-call payload. Never fall back to
             // `reason` (a response/evidence-derived explanation) here — that leaks response
             // content into what's meant to show what was actually requested; `reason` already
-            // renders in its own "Reason" field below. Config violations show the full captured
-            // config file (with the flagged field highlighted) instead of just the small
-            // evidence excerpt - same content the old separate Config.json tab used to show.
-            const promptBody = (row.type === "Config" ? fileContent : null) || primaryValueFull || undefined;
+            // renders in its own "Reason" field below. Config & Skill violations show the full
+            // captured file (Config.json with the flagged field highlighted / the skill's
+            // name+description+content) instead of just the small evidence excerpt - same
+            // content the old separate Config.json/Skill Info tabs used to show.
+            const showsFullFile = row.type === "Config" || row.type === "Skill";
+            const promptBody = (showsFullFile ? fileContent : null) || primaryValueFull || undefined;
             return {
                 valueLabel: VALUE_SECTION_LABELS[row.type] || VALUE_SECTION_LABELS.Other,
                 promptBody,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
@@ -103,17 +103,55 @@ function _unwrapNestedJsonValue(obj, depth) {
 // literal "\n"/"\t" - do a conservative de-escape for display only. This doesn't attempt to
 // repair or validate the JSON, just make an already-broken/unparsed blob legible.
 function looseUnescapeForDisplay(text) {
-    const trimmed = text.trim();
-    if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return text;
     return text.replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, "\"");
 }
 
+// Bracket-depth indenter for JSON-shaped text that JSON.parse can't fully consume (so
+// JSON.stringify(..., null, 2) isn't an option). Walks the text tracking string/escape state
+// (respecting \" so it doesn't mistake an escaped quote for a string boundary) and inserts a
+// newline + indent at each structural {, [, ,, } and ] outside of a string. It doesn't validate
+// or repair the JSON - just adds the same indentation a valid document would get, so an
+// otherwise-broken blob still reads like structured JSON instead of one dense line.
+function looseFormatJsonText(text) {
+    let out = "";
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    const indent = (d) => "  ".repeat(d);
+    for (const ch of text) {
+        if (inString) {
+            out += ch;
+            if (escape) escape = false;
+            else if (ch === "\\") escape = true;
+            else if (ch === '"') inString = false;
+            continue;
+        }
+        if (ch === '"') { inString = true; out += ch; continue; }
+        if (ch === "{" || ch === "[") { depth++; out += ch + "\n" + indent(depth); continue; }
+        if (ch === "}" || ch === "]") {
+            depth = Math.max(0, depth - 1);
+            out = out.replace(/[ \t]*$/, "") + "\n" + indent(depth) + ch;
+            continue;
+        }
+        if (ch === ",") { out += ",\n" + indent(depth); continue; }
+        if (ch === ":") { out += ": "; continue; }
+        if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") continue; // re-flow, don't keep original spacing
+        out += ch;
+    }
+    return out;
+}
+
 // Returns { text, isJson } — pretty-printed JSON (with nested JSON-strings unwrapped) when
-// the input looks like JSON, otherwise the original text (loosely de-escaped if JSON-shaped).
+// the input looks like JSON, otherwise a best-effort indented + de-escaped version of the
+// original text (when it's JSON-shaped) so a payload that fails to fully parse is still legible.
 export function prettyPrintIfJson(text) {
     if (!text) return { text, isJson: false };
     const unwrapped = _unwrapNestedJson(text);
-    if (unwrapped === text) return { text: looseUnescapeForDisplay(text), isJson: false };
+    if (unwrapped === text) {
+        const trimmed = text.trim();
+        if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return { text, isJson: false };
+        return { text: looseUnescapeForDisplay(looseFormatJsonText(text)), isJson: false };
+    }
     return { text: JSON.stringify(unwrapped, null, 2), isJson: true };
 }
 
@@ -351,11 +389,14 @@ export function buildFallbackDetail(row) {
             // promptBody must come only from the request/tool-call payload. Never fall back to
             // `reason` (a response/evidence-derived explanation) here — that leaks response
             // content into what's meant to show what was actually requested; `reason` already
-            // renders in its own "Reason" field below.
-            const promptBody = primaryValueFull || undefined;
+            // renders in its own "Reason" field below. Config violations show the full captured
+            // config file (with the flagged field highlighted) instead of just the small
+            // evidence excerpt - same content the old separate Config.json tab used to show.
+            const promptBody = (row.type === "Config" ? fileContent : null) || primaryValueFull || undefined;
             return {
                 valueLabel: VALUE_SECTION_LABELS[row.type] || VALUE_SECTION_LABELS.Other,
                 promptBody,
+                highlights: row.type === "Config" ? (fileHighlights || undefined) : undefined,
                 behaviour: row.behaviourRaw || meta.behaviour || meta.nbehaviour || row.action || undefined,
                 blockedAt: resp?.error?.data?.blocked_at || row.detected || undefined,
                 blockedBy: resp?.error?.data?.blocked_by || policyName || undefined,

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/guardrails/violations/violationsData.js
@@ -98,12 +98,22 @@ function _unwrapNestedJsonValue(obj, depth) {
     return out;
 }
 
+// A JSON-shaped string that fails to fully JSON.parse (e.g. a captured tool command whose own
+// escaping breaks the outer JSON) still reads far better with real line breaks instead of
+// literal "\n"/"\t" - do a conservative de-escape for display only. This doesn't attempt to
+// repair or validate the JSON, just make an already-broken/unparsed blob legible.
+function looseUnescapeForDisplay(text) {
+    const trimmed = text.trim();
+    if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return text;
+    return text.replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, "\"");
+}
+
 // Returns { text, isJson } — pretty-printed JSON (with nested JSON-strings unwrapped) when
-// the input looks like JSON, otherwise the original text untouched.
+// the input looks like JSON, otherwise the original text (loosely de-escaped if JSON-shaped).
 export function prettyPrintIfJson(text) {
     if (!text) return { text, isJson: false };
     const unwrapped = _unwrapNestedJson(text);
-    if (unwrapped === text) return { text, isJson: false };
+    if (unwrapped === text) return { text: looseUnescapeForDisplay(text), isJson: false };
     return { text: JSON.stringify(unwrapped, null, 2), isJson: true };
 }
 
@@ -284,8 +294,15 @@ export function buildFallbackDetail(row) {
     const reason = normalizeReasonPunctuation(meta.reason || guardrailReason) || null;
     const policyName = meta.policyName || (row.policyName && row.policyName !== "-" ? row.policyName : null);
     const isPromptOrTool = row.type === "Prompt" || row.type === "Tool";
+    // Tool events store the request payload flat (req *is* the tool args, e.g.
+    // {file_path, content}) rather than wrapped in a {body: ...} envelope, so
+    // _extractPromptBody (which only looks for req.body/req.messages) finds nothing —
+    // fall back to the whole req object itself for Tool violations. And when
+    // outer.requestPayload fails to JSON.parse at all (e.g. a captured tool call whose
+    // command text breaks JSON escaping) - req is null even though the raw string has real
+    // content - fall back to that raw string rather than showing nothing.
     const rawPrimaryValue = coerceToText(isPromptOrTool
-        ? _extractPromptBody(req)
+        ? (_extractPromptBody(req) ?? (row.type === "Tool" ? req : null) ?? outer.requestPayload ?? null)
         : row.type === "Skill" ? (resp?.evidence || null) : (req?.evidence || null));
     // If the value is JSON (or JSON nested inside JSON, e.g. a proxied request captured as a
     // string field), unwrap and pretty-print it instead of showing raw escaped quotes.
@@ -331,14 +348,18 @@ export function buildFallbackDetail(row) {
         fileHighlights: fileHighlights || undefined,
         skillName: skillName || undefined,
         promptResponse: (() => {
-            const promptBody = primaryValueFull || reason || undefined;
+            // promptBody must come only from the request/tool-call payload. Never fall back to
+            // `reason` (a response/evidence-derived explanation) here — that leaks response
+            // content into what's meant to show what was actually requested; `reason` already
+            // renders in its own "Reason" field below.
+            const promptBody = primaryValueFull || undefined;
             return {
                 valueLabel: VALUE_SECTION_LABELS[row.type] || VALUE_SECTION_LABELS.Other,
                 promptBody,
-                behaviour: row.behaviourRaw || meta.behaviour || meta.nbehaviour || undefined,
+                behaviour: row.behaviourRaw || meta.behaviour || meta.nbehaviour || row.action || undefined,
                 blockedAt: resp?.error?.data?.blocked_at || row.detected || undefined,
                 blockedBy: resp?.error?.data?.blocked_by || policyName || undefined,
-                reason: (reason && reason !== promptBody) ? reason : undefined,
+                reason: reason || undefined,
                 message: resp?.error?.message || resp?.message || undefined,
             };
         })(),


### PR DESCRIPTION
Guardrails Violations table/flyout: no more Tool call/Chat Session tabs, Values tab shows real request data instead of leaking the blocked-reason (with a legible fallback for malformed/empty payloads), Behaviour no longer shows N/A when flagged, and rows sort by Detected (newest first) instead of Severity.