### PR TITLE
Add fileUpload descriptors to browser extension config (V2)

### DIFF
--- a/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
+++ b/libs/dao/src/main/java/com/akto/dto/BrowserExtensionConfigCommon.java
@@ -94,6 +94,13 @@ public class BrowserExtensionConfigCommon {
     public static final String BLOCK_RESPONSE_FRAMES = "blockResponseFrames";
     private List<Object> blockResponseFrames;
 
+    // file-upload endpoints for this host: an array of self-describing descriptor objects
+    // ({ path, method, transport, encoding, field?, filePath?, contentType?, crossHost?, reportPath? }).
+    // A separate concern from prompt extraction (validates against /validate/file). Mirrored as
+    // stored so the browser extension's GenericRequestInterceptor can read schema.fileUpload.
+    public static final String FILE_UPLOAD = "fileUpload";
+    private List<Object> fileUpload;
+
     public static final String ENFORCE_AT = "enforceAt";
     private String enforceAt;
 
@@ -147,6 +154,7 @@ public class BrowserExtensionConfigCommon {
         config.modelHeader = asMap(doc.get(MODEL_HEADER));
         config.triggerFrame = asMap(doc.get(TRIGGER_FRAME));
         config.blockResponseFrames = asObjectList(doc.get(BLOCK_RESPONSE_FRAMES));
+        config.fileUpload = asObjectList(doc.get(FILE_UPLOAD));
         config.enforceAt = asString(doc.get(ENFORCE_AT));
 
         return config;

--- a/libs/dao/src/test/java/com/akto/dto/TestBrowserExtensionConfigCommon.java
+++ b/libs/dao/src/test/java/com/akto/dto/TestBrowserExtensionConfigCommon.java
@@ -171,6 +171,43 @@ public class TestBrowserExtensionConfigCommon {
         assertNull(config.getFrameMatch());
     }
 
+    @Test
+    public void testFileUploadDescriptorsPreserved() {
+        Document doc = Document.parse("{" +
+                "'host': 'copilot.microsoft.com'," +
+                "'active': true," +
+                "'paths': ['/c/api/chat']," +
+                "'transport': 'websocket'," +
+                "'format': 'ws-frame'," +
+                "'path': 'content[?type=text][*].text'," +
+                "'fileUpload': [" +
+                "  { 'path': '/c/api/attachments', 'method': 'POST', 'transport': 'http', 'encoding': 'multipart' }" +
+                "]" +
+                "}");
+
+        BrowserExtensionConfigCommon config = BrowserExtensionConfigCommon.fromDocument(doc);
+
+        assertNotNull(config);
+        List<Object> fileUpload = config.getFileUpload();
+        assertNotNull(fileUpload);
+        assertEquals(1, fileUpload.size());
+
+        // Descriptor is mirrored as stored (a nested Document), so every field survives the round trip.
+        Document descriptor = (Document) fileUpload.get(0);
+        assertEquals("/c/api/attachments", descriptor.getString("path"));
+        assertEquals("POST", descriptor.getString("method"));
+        assertEquals("http", descriptor.getString("transport"));
+        assertEquals("multipart", descriptor.getString("encoding"));
+    }
+
+    @Test
+    public void testFileUploadAbsentIsNull() {
+        Document doc = Document.parse("{ 'host': 'chatgpt.com', 'active': true, 'paths': ['/x'] }");
+        BrowserExtensionConfigCommon config = BrowserExtensionConfigCommon.fromDocument(doc);
+        assertNotNull(config);
+        assertNull(config.getFileUpload());
+    }
+
     // ---- merge(common, account) ----
 
     private static BrowserExtensionConfigCommon cfg(String host, boolean active) {


### PR DESCRIPTION
BrowserExtensionConfigCommon.fromDocument() maps each field explicitly, so any field absent from the mapper is dropped before reaching the browser extension. Add a fileUpload field (List<Object> of self-describing upload endpoint descriptors: path/method/transport/encoding/field/filePath/ contentType/crossHost/reportPath) so the extension's config-driven file-upload validation can read schema.fileUpload from the V2 catalogue.

Mirrored as stored via asObjectList, same pattern as blockResponseFrames. Tests cover descriptor round-trip and the absent-field (null) case.