### PR TITLE
Feat/testin break down test cost

### DIFF
--- a/apps/mini-testing/src/main/java/com/akto/test_editor/execution/Executor.java
+++ b/apps/mini-testing/src/main/java/com/akto/test_editor/execution/Executor.java
@@ -280,7 +280,9 @@ public class Executor {
                         McpSseEndpointHelper.addSseEndpointHeader(testReq.getRequest(), apiInfoKey.getApiCollectionId());
 
                         requestAttempted = true;
+                        long sendStart = System.nanoTime();
                         testResponse = ApiExecutor.sendRequest(testReq.getRequest(), followRedirect, testingRunConfig, debug, testLogs, Main.SKIP_SSRF_CHECK);
+                        TestPhaseTimer.addSendRequest(System.nanoTime() - sendStart);
                         requestSent = true;
                         ExecutionResult attempt = new ExecutionResult(singleReq.getSuccess(), singleReq.getErrMsg(), testReq.getRequest(), testResponse);
                         res = validate(attempt, sampleRawApi, varMap, logId, validatorNode, apiInfoKey);

--- a/apps/mini-testing/src/main/java/com/akto/test_editor/execution/TestPhaseTimer.java
+++ b/apps/mini-testing/src/main/java/com/akto/test_editor/execution/TestPhaseTimer.java
@@ -1,0 +1,30 @@
+package com.akto.test_editor.execution;
+
+/**
+ * Per-thread accumulator for time spent hitting the API under test within a single {@code runTestNew}.
+ *
+ * <p>Written at the one send call site ({@link Executor} around {@code ApiExecutor.sendRequest}) — not on
+ * {@code ApiExecutor.sendRequest} itself — so it captures only the test's target hits and never the other
+ * callers (auth, status-code analyser, workflow nodes, etc.), and shared libraries stay untouched.
+ *
+ * <p>A test runs synchronously on one worker thread, so the consumer {@link #reset()}s this before
+ * {@code runTestNew} and reads {@link #sendReqNanos()} after. Sends a test fans onto other threads (e.g.
+ * workflow/graph nodes) go through different call sites and are not captured here.
+ */
+public class TestPhaseTimer {
+
+    private static final ThreadLocal<long[]> SEND_REQ_NANOS = ThreadLocal.withInitial(() -> new long[1]);
+
+    /** Zero this thread's accumulator (call before the unit of work you want to measure). */
+    public static void reset() {
+        SEND_REQ_NANOS.get()[0] = 0L;
+    }
+
+    public static void addSendRequest(long nanos) {
+        if (nanos > 0) SEND_REQ_NANOS.get()[0] += nanos;
+    }
+
+    public static long sendReqNanos() {
+        return SEND_REQ_NANOS.get()[0];
+    }
+}

--- a/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java
@@ -34,6 +34,7 @@ import com.akto.dto.testing.info.SingleTestPayload;
 import com.akto.kafka.KafkaConfig;
 import com.akto.log.LoggerMaker;
 import com.akto.log.LoggerMaker.LogDb;
+import com.akto.test_editor.execution.TestPhaseTimer;
 import com.akto.testing.TestExecutor;
 import com.akto.testing.Utils;
 import com.akto.testing.kafka_utils.TestRunMetrics.Stage;
@@ -119,6 +120,7 @@ public class ConsumerUtil {
 
                 // RUN_TEST wall + CPU. Recorded in a finally so a test that times out / throws still
                 // gets its timing counted once it unwinds (else COST only ever sees fast completers).
+                TestPhaseTimer.reset();
                 long runCpuStart = CPU_TIME_SUPPORTED ? THREAD_MX.getCurrentThreadCpuTime() : -1L;
                 long runWallStart = System.nanoTime();
                 TestingRunResult runResult;
@@ -126,11 +128,14 @@ public class ConsumerUtil {
                     runResult = executor.runTestNew(apiInfoKey, singleTestPayload.getTestingRunId(), instance.getTestingUtil(), singleTestPayload.getTestingRunResultSummaryId(),testConfig , instance.getTestingRunConfig(), instance.isDebug(), singleTestPayload.getTestLogs(), sample);
                 } finally {
                     metrics.recordStage(Stage.RUN_TEST, System.nanoTime() - runWallStart);
+                    metrics.recordStage(Stage.SEND_REQUEST, TestPhaseTimer.sendReqNanos());
                     if (runCpuStart >= 0) metrics.recordRunTestCpu(THREAD_MX.getCurrentThreadCpuTime() - runCpuStart);
                 }
 
                 executor.persistTestLogsToDb(runResult != null ? runResult.getTestLogs() : null);
+                long insertStart = System.nanoTime();
                 executor.insertResultsAndMakeIssues(Collections.singletonList(runResult), singleTestPayload.getTestingRunResultSummaryId());
+                metrics.recordStage(Stage.INSERT_RESULTS, System.nanoTime() - insertStart);
 
                 if (runResult != null && runResult.isVulnerable()) {
                     metrics.markVulnerable();

--- a/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/TestRunMetrics.java
+++ b/apps/mini-testing/src/main/java/com/akto/testing/kafka_utils/TestRunMetrics.java
@@ -48,9 +48,10 @@ public class TestRunMetrics {
 
     /**
      * Pipeline stages timed per test. LOOKUP is config/sample resolution; RUN_TEST is the full
-     * {@code runTestNew} wall (the bulk of a test's cost).
+     * {@code runTestNew} wall; SEND_REQUEST is the slice of it spent hitting the API under test;
+     * INSERT_RESULTS is the ultron result-write round-trip.
      */
-    public enum Stage { LOOKUP, RUN_TEST }
+    public enum Stage { LOOKUP, RUN_TEST, SEND_REQUEST, INSERT_RESULTS }
 
     /** WARN-level progress + cost heartbeat cadence. */
     private static final long HEARTBEAT_INTERVAL_MS = 60_000L;
@@ -334,16 +335,22 @@ public class TestRunMetrics {
 
         long lookup   = stageNanos.get(Stage.LOOKUP).sum();
         long runTest  = stageNanos.get(Stage.RUN_TEST).sum();
+        long sendReq  = stageNanos.get(Stage.SEND_REQUEST).sum();
+        long insertRt = stageNanos.get(Stage.INSERT_RESULTS).sum();
         long runCpu   = runTestCpuNanos.sum();
-        long billed   = lookup + runTest;
+        long other    = Math.max(0, runTest - sendReq);   // RUN_TEST minus target-API send = compute/setup
+        long billed   = lookup + runTest + insertRt;
 
-        long avgWallMs = ms(runTest + lookup) / n;
+        long avgWallMs = ms(runTest + lookup + insertRt) / n;
         loggerMaker.warnAndAddToDb("TESTRUN COST summaryId=" + summaryId
                 + " n=" + n
                 + " avgPerTestMs=" + avgWallMs
                 + " cpuPerTestMs=" + msPer(runCpu, n)
                 + " | RUN_TEST=" + msPer(runTest, n) + "ms (" + pctOf(runTest, billed) + " of billed)"
-                + " LOOKUP=" + msPer(lookup, n) + "ms");
+                + " [SEND_REQUEST=" + msPer(sendReq, n) + "ms/" + pctOf(sendReq, runTest)
+                + " | OTHER=" + msPer(other, n) + "ms/" + pctOf(other, runTest) + "]"
+                + " LOOKUP=" + msPer(lookup, n) + "ms"
+                + " INSERT_RESULTS=" + msPer(insertRt, n) + "ms/" + pctOf(insertRt, billed) + " of billed");
     }
 
     private static long ms(long nanos) { return nanos / 1_000_000L; }

--- a/apps/mini-testing/test-run-pipeline.md
+++ b/apps/mini-testing/test-run-pipeline.md
@@ -1,0 +1,147 @@
+# Single-test execution pipeline: `runTestFromMessage`
+
+Traces what happens when the consumer processes **one Kafka message** = one
+`(api, test)` cell. Scope is deliberately limited to two files:
+[`ConsumerUtil.runTestFromMessage`](src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java)
+and [`TestExecutor`](src/main/java/com/akto/testing/TestExecutor.java). Everything
+they call into (`YamlTestTemplate`, `Executor`, `VariableResolver`, `DataActor`,
+`TestingIssuesHandler`, …) is treated as a black box.
+
+`DataActor.*` calls are the persistence/lookup boundary (abstractor/Mongo I/O);
+they're flagged **[I/O]** below since they dominate per-test wall time.
+
+> **Running with `BLOCK_LOGS=true`?** Then the *logging* I/O is suppressed but
+> the *result* I/O is not. `LoggerMaker.insert()` early-returns when
+> `BLOCK_LOGS=true` ([LoggerMaker.java:305](../../libs/utils/src/main/java/com/akto/log/LoggerMaker.java#L305)),
+> so every `infoAndAddToDb` / `errorAndAddToDb` / `warnAndAddToDb` becomes a
+> local console log with **no DB write**. Flags below are marked **[I/O log]**
+> (skipped under `BLOCK_LOGS`) vs **[I/O result]** (always writes). Note the one
+> exception: `insertImportantTestingLog` does **not** go through `insert()`
+> ([LoggerMaker.java:268](../../libs/utils/src/main/java/com/akto/log/LoggerMaker.java#L268)),
+> so it still writes one testing-log per call (rate-limited to 1000/min), even
+> with `BLOCK_LOGS=true`.
+
+---
+
+## Top-level flow
+
+```
+ConsumerUtil.runTestFromMessage(message)
+  1. parse message               → SingleTestPayload
+  2. set account + activity ctx
+  3. lookup TestConfig (subcategory) + sample messages (apiInfoKey)
+  4. no samples?  → markSkipped, return
+  5. TestExecutor.runTestNew(...)            ← RUN THE TEST
+  6. TestExecutor.persistTestLogsToDb(...)   ← write logs        [I/O]
+  7. TestExecutor.insertResultsAndMakeIssues ← write result+issues [I/O]
+  8. mark pass/vuln, record lastTested
+  finally: clear activity context
+```
+
+---
+
+## 1. `ConsumerUtil.runTestFromMessage(String message)`
+([ConsumerUtil.java:74](src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java#L74))
+
+| Step | What | Ref |
+|---|---|---|
+| 1 | `parseTestMessage(message)` → `SingleTestPayload` (testingRunId, summaryId, apiInfoKey, subcategory, accountId, testLogs) | [:63](src/main/java/com/akto/testing/kafka_utils/ConsumerUtil.java#L63) |
+| 2 | `Context.accountId.set(...)`; `TestExecutor.setTestRunActivityContext(summaryId)` | :76-78 |
+| 3 | `new TestExecutor()`; read singletons: `TestingConfigurations.getInstance()` | :80-82 |
+| 4 | `testConfig = instance.getTestConfigMap().get(subcategory)` (the YAML template for this test) | :84 |
+| 5 | `messagesList = instance.getTestingUtil().getSampleMessages().get(apiInfoKey)` | :87 |
+| 6 | **skip branch:** if no sample messages → `metrics.markSkipped()`, return | :89-91 |
+| 7 | else pick the **last** sample: `sample = messagesList.get(size-1)` | :93 |
+| 8 | **`runResult = executor.runTestNew(apiInfoKey, testingRunId, testingUtil, summaryId, testConfig, testingRunConfig, isDebug, testLogs, sample)`** | :95 |
+| 9 | `executor.persistTestLogsToDb(runResult.getTestLogs())` — **[I/O log]**, skipped under `BLOCK_LOGS` | :96 |
+| 10 | `executor.insertResultsAndMakeIssues([runResult], summaryId)` — **[I/O result]** | :97 |
+| 11 | count outcome (`markVulnerable`/`markPassed`), `testedApisMap.put(apiInfoKey, now)`, `insertImportantTestingLog` "Test completed … in Ns" — **[I/O]** (writes even under `BLOCK_LOGS`) | :99-107 |
+| — | `finally`: `TestExecutor.clearActivityContext()` | :110 |
+
+---
+
+## 2. `TestExecutor.runTestNew(...)` — setup overload
+([TestExecutor.java:1226](src/main/java/com/akto/testing/TestExecutor.java#L1226))
+
+Resolves the `RawApi` and attacker auth, then delegates to the core overload.
+
+| Step | What | Ref |
+|---|---|---|
+| 2.1 | `RawApi` from `TestingConfigurations.getRawApiMap()` cache; else `RawApi.buildFromMessage(message)` and cache it | :1228-1232 |
+| 2.2 | `Executor.fetchOrFindAttackerRole()` → attacker `TestRole` → `findMatchingAuthMechanism(rawApi)` (the attacker token) | :1234-1240 |
+| 2.3 | delegate to core `runTestNew(apiInfoKey, testRunId, sampleMessageStore, attackerAuthMechanism, customAuthTypes, summaryId, testConfig, testingRunConfig, debug, testLogs, rawApi)` | :1241 |
+
+---
+
+## 3. `TestExecutor.runTestNew(...)` — core
+([TestExecutor.java:1244](src/main/java/com/akto/testing/TestExecutor.java#L1244))
+
+| Step | What | Ref |
+|---|---|---|
+| 3.1 | Pull `testSuperType`, `testSubType`, `agenticTestingAllowed`, `onlySmartTestingAllowed` from `testConfig.getInfo()` | :1246-1249 |
+| 3.2 | Resolve `ApiCollection` (from `testingUtil` map, else `dataActor.fetchApiCollectionMeta` **[I/O]**) | :1253-1259 |
+| 3.3 | **skip branches** → `generateFailedRunResultForMessage(...)`: Copilot-bot internal endpoint; out-of-testing-scope collection | :1260-1273 |
+| 3.4 | *(optional)* `shouldCallClientLayerForSampleData` → `clientLayer.fetchLatestSample(apiInfoKey)` **[I/O]**, decrypt if packed, rebuild `rawApi`; record `setSampleDataFetchLatency` | :1275-1300 |
+| 3.5 | `startTime = Context.now()`; `filterGraphQlPayload(rawApi, apiInfoKey)` | :1301-1308 |
+| 3.6 | Build nodes from `testConfig`: `filterNode` (apiSelectionFilters), `validatorNode` (validation), `executorNode` (execute), `auth`, `wordListsMap` | :1310-1317 |
+| 3.7 | Build `varMap`: seed `wordList_*` from `testConfig.getWordlists()`; `VariableResolver.resolveWordList(varMap, sampleDataMap, apiInfoKey)`; add testRunId, dashboardContext, summaryId, accountId, apiInfoKey, testSubType, agentic/onlySmart flags, yaml content | :1318-1353 |
+| 3.8 | Merge collection-description context into `wordList_data_context` / `wordList_every_prompt` | :1355-1395 |
+| 3.9 | `testExecutionLogId = UUID`; log "triggering test run …"; stamp `summaryId` on `testingRunConfig` | :1397-1404 |
+| 3.10 | `new Executor()`; `executor.overrideTestUrl(rawApi, testingRunConfig)` | :1406-1407 |
+| 3.11 | **`new YamlTestTemplate(...).run(debug, testLogs)` → `YamlTestResult`** — this is the actual test: builds attack requests, **sends HTTP to the target**, runs validators. Fallback `SOMETHING_WENT_WRONG` result if empty. | :1408-1415 |
+| 3.12 | `endTime`; compute `vulnerable` across results; set `Confidence`/severity (unless automated-pentest) | :1416-1439 |
+| 3.13 | Build **`TestingRunResult`** (ids, api, super/sub type, results, vulnerable, startTime, endTime, summaryId, workflowTest, testLogs); set `aiSummaryTraces`, `callbackUuids` / `callbackCheckPending` | :1441-1459 |
+| 3.14 | *(optional)* `testingRunConfig.getCleanUp()` → `cleanUpTestArtifacts(...)` | :1461-1468 |
+| 3.15 | return `TestingRunResult` | :1470 |
+
+---
+
+## 4. `TestExecutor.persistTestLogsToDb(List<TestLog>)`
+([TestExecutor.java:1191](src/main/java/com/akto/testing/TestExecutor.java#L1191))
+
+Iterates the test's logs; writes each via `loggerMaker.errorAndAddToDb` /
+`infoAndAddToDb` **[I/O log per line]** (no-op if `testLogs` is null/empty).
+
+Both route through `LoggerMaker.insert()`, so **with `BLOCK_LOGS=true` this whole
+method does zero DB I/O** — it only emits to the local console logger
+(`logger.error`/`logger.info`). This is the per-test logging tail that `BLOCK_LOGS`
+removes.
+
+---
+
+## 5. `TestExecutor.insertResultsAndMakeIssues(List<TestingRunResult>, summaryId)`
+([TestExecutor.java:1017](src/main/java/com/akto/testing/TestExecutor.java#L1017))
+
+| Step | What | Ref |
+|---|---|---|
+| 5.1 | `trim(...)`; **rerun case:** if a prior result exists → `dataActor.deleteTestingRunResults(...)` **[I/O]** | :1021-1032 |
+| 5.2 | Normalize `getTestResults()` into `singleTestResults` (TestResult) or `multiExecTestResults`; `recordTestExecutionMetrics(...)` | :1033-1050 |
+| 5.3 | Null out `testResults`/`testLogs` on the doc (slim it before write) | :1051-1052 |
+| 5.4 | **`dataActor.insertTestingRunResults(trr)`** — persist the result **[I/O]** | :1053 |
+| 5.5 | **`dataActor.updateTestResultsCountInTestSummary(summaryId, resultSize)`** **[I/O]** | :1055 |
+| 5.6 | **`new TestingIssuesHandler().handleIssuesCreationFromTestingRunResults(...)`** — create/update issues from the result (internally fetches + writes issues) **[I/O]** | :1058-1064 |
+
+---
+
+## Per-test I/O touchpoints (within these two files)
+
+Each processed message can trigger, in order (✅ = still happens under
+`BLOCK_LOGS=true`, ❌ = suppressed):
+
+| # | Call | Kind | `BLOCK_LOGS=true` |
+|---|---|---|---|
+| 1 | `fetchApiCollectionMeta` (only if not cached) — step 3.2 | result/lookup | ✅ |
+| 2 | `fetchLatestSample` (only if `shouldCallClientLayerForSampleData`) — step 3.4 | result/lookup | ✅ |
+| 3 | **target HTTP request(s)** inside `YamlTestTemplate.run` — step 3.11 | target | ✅ |
+| 4 | scattered `infoAndAddToDb` (e.g. "triggering test run", "Inserted results") | log | ❌ suppressed |
+| 5 | `persistTestLogsToDb` — one write per log line — step 4 | log | ❌ suppressed |
+| 6 | `insertImportantTestingLog` "Test completed …" — step 1.11 | log (special) | ✅ (bypasses `insert()`; rate-limited) |
+| 7 | `insertTestingRunResults` — step 5.4 | result | ✅ |
+| 8 | `updateTestResultsCountInTestSummary` — step 5.5 | result | ✅ |
+| 9 | issue create/update via `TestingIssuesHandler` — step 5.6 | result | ✅ |
+
+Steps 7–9 are the result-persistence tail that runs for every test after the
+target call (3). **`BLOCK_LOGS=true` removes the logging writes (4, 5) but leaves
+the target call, the result-persistence tail (7–9), and the `insertImportantTestingLog`
+write (6) intact** — so it trims per-test I/O but doesn't eliminate the
+result-write cost the flamegraph attributed to `insertResultsAndMakeIssues`.

--- a/apps/mini-testing/testing-setup.md
+++ b/apps/mini-testing/testing-setup.md
@@ -1,0 +1,175 @@
+# mini-testing perf investigation — setup & operational notes
+
+Operational companion that keeps getting rebuilt after every `/compact`. Read this first.
+It covers ONLY: how to run, where output lands, how to read it, and how to prove a claim.
+**No findings / no RCA live here** — those go in the dated investigation reports
+(`21-aug-investigation.md`, `24aug-*`). Code architecture lives in `CLAUDE.md`.
+
+---
+
+## 1. How to run a benchmark
+
+```
+local-bench/run-bench.sh <git-ref> <label> [max-minutes]
+# e.g. local-bench/run-bench.sh fix/testing-stops-running 24aug-subcategory-api-stall-1 60
+```
+
+Prereqs (all external, must be up before the run):
+- Kafka up; abstractor (ultron) reachable — no 403/422 on token exchange.
+- A test run **TRIGGERED** in the UI for `MINI_TESTING_NAME` with the same scope, BEFORE
+  invoking. Producer fans out M×N messages to `akto.test.messages`; consumer drains.
+- `local-bench/bench.env` exists (from `bench.env.template`). Holds
+  `DATABASE_ABSTRACTOR_SERVICE_TOKEN` (JWT) — **never commit**. `local-bench/` is self-gitignored.
+
+What the script does: checks out the ref, picks JDK from `apps/mini-testing/pom.xml`
+(`<source>8</source>` → Zulu 8, else 17 — build JDK MUST == run JDK), `mvn -am -pl
+apps/mini-testing clean package`, runs the fat jar with `NEW_TESTING_ENABLED=true`,
+`AKTO_LOG_LEVEL=WARN`, `RUNTIME_MODE=hybrid`, `-Xmx6g`. Auto-stops on `TESTRUN END` or
+`max-minutes`. Also launches `diagnose.sh` alongside.
+
+Env knobs: `XMX`/`XMS` (heap), `DIAG_INTERVAL` (diag sampling seconds, default 20).
+
+Build-only sanity check (fast, no run):
+`mvn -pl apps/mini-testing compile -DskipTests=true`
+
+---
+
+## 2. Where output lands (and the #1 gotcha)
+
+Per run, timestamped `local-bench/{run,diag}-<label>-<YYYYMMDD-HHMMSS>.log`:
+- `run-*.log`  — full JVM stdout+stderr. Contains the `TESTRUN *` metric lines.
+- `diag-*.log` — the `diagnose.sh` sampler table (see §4).
+- `hang-<ts>.txt` — auto-captured jstack bundle when diag detects a stall (see §4).
+
+### ⚠️ GOTCHA: run logs contain embedded NUL bytes → grep sees them as binary
+Some test payloads log raw `0x00` (e.g. `Unexpected char 0x00 in x-request-id`). That puts
+NUL bytes in `run-*.log`, so `file` reports "AKT archive data" and **plain `grep` silently
+matches nothing** (prints "0", exits 1). ALWAYS use `grep -a` on `run-*.log`:
+
+```
+grep -a "TESTRUN COST"            run-*.log
+grep -a "TESTRUN STALL-BY-SUBCAT" run-*.log
+```
+
+Do not trust a bare `grep` returning empty on `run-*.log`.
+
+---
+
+## 3. The metric lines (TestRunMetrics → warnAndAddToDb → both stdout AND ultron DB)
+
+`TestRunMetrics.java` `tick()` runs once per drain-loop iteration (`ConsumerUtil.java:445`)
+and emits on cadence:
+
+- `TESTRUN START / CONSUMER-UP / PROGRESS / RESTART / END` — lifecycle + throughput.
+- `TESTRUN COST` — per-test wall-time breakdown ("what is taking so long"). Fields:
+  `n` (completed tests), `avgPerTestMs`, `requestsPerTest`, `cpuPerTestMs`, then `RUN_TEST=…ms`
+  split into `RESOLVE_EXPR / SEND_REQUEST / VALIDATE / OTHER`, plus
+  `LOOKUP / PERSIST_LOGS / INSERT_RESULTS / ULTRON_TOTAL`.
+  - Sub-phase timing = `TestPhaseTimer` (thread-local, written at call sites in
+    `ExecutorAlgorithm` (resolveExpr) and `Executor` (sendRequest/validate)). Recorded in a
+    `try/finally` around `runTestNew` (ConsumerUtil ~162-167).
+  - **KNOWN LIMIT:** the finally records only when `runTestNew` RETURNS. A test stuck the full
+    300s hasn't returned, so it is NOT in `n` / the COST average ⇒ COST reflects *completers
+    only*. Cross-check against STALL/diag for the in-flight (stuck) population.
+- `TESTRUN STALL` — fires when `progress_frozen` OR `slots_clogged` (≥half the 200-slot pool
+  held by tasks older than `STUCK_AGE_MS`). Includes `oldestTasks=[…]` (top-15 oldest in-flight,
+  each `{age, subcategory, api, thread}`), plus:
+  - `TESTRUN STALL-BY-SUBCAT bySubcat=[SUBCAT=count, …]` — currently-stuck slots by subcategory.
+  - `TESTRUN STALL-BY-API   byApi=[apiKey path method=count, …]` — currently-stuck slots by API.
+  These are a **snapshot** of the in-flight registry (not a cumulative counter).
+
+Handy extractions (always `-a`):
+```
+grep -a "TESTRUN COST" run-*.log | sed -E 's/.*TESTRUN COST/COST/'
+# dominant stuck API per snapshot over time:
+grep -a "TESTRUN STALL-BY-API" run-*.log | sed -E 's/^([0-9-]+ [0-9:]+).*byApi=\[[^ ]+ ([^ ]+ [A-Z]+)=([0-9]+).*/\1  top=\2  count=\3/'
+```
+
+---
+
+## 4. diagnose.sh — the live bottleneck sampler
+
+Every `DIAG_INTERVAL`s it jstacks the JVM and prints one table row:
+```
+time cpu% | rate done avgMs stuck tmout err | workers io/cl/cpu/pk/ot | states R/W/T/B | kafkaLag
+```
+- `workers io/cl/cpu/pk/ot` = **`mini-test-worker-*`** threads bucketed by TOP FRAME:
+  - `io`  = `Net.poll|socketRead|NioSocketImpl|SSLSocketImpl.*read`
+  - `cl`  = `callAcquirePooledConnection|RealConnectionPool` (waiting for HTTP conn)
+  - `cpu` = `resolveWordListVar|java.util.regex|StringLatin1|Pattern` (word-list cartesian)
+  - `pk`  = `Unsafe.park`
+  - `ot`  = everything else
+- `states R/W/T/B` = RUNNABLE/WAITING/TIMED_WAITING/BLOCKED histogram for worker+pc pools.
+- On a sustained stall it writes `hang-<ts>.txt`: 3 jstacks 4s apart + state histogram +
+  "top frame dump 1 vs 3 (identical ⇒ genuinely stuck)" + hottest lock contention.
+
+### Known classifier bugs (flagged, NOT fixed)
+- `SSLSocketImpl.decode` counted `other`, should be `io` (regex only catches `SSLSocketImpl.*read`).
+- `Arrays.copyOfRange` counted `other`, should be `cpu`.
+⇒ the `cpu`/`io` buckets are floors (understated); `other` is inflated. Treat the buckets as a
+lead, then PROVE via §6 before claiming anything.
+
+---
+
+## 5. Thread architecture (critical for reading STALL vs diag correctly)
+
+Two pools, both sized `maxConcurrentRequest` (=200 here), 1:1 coupled:
+
+1. **`pc-pool-*`** — Confluent parallel-consumer callback threads. Each: parses the record,
+   calls `metrics.onSubmit(recordId, subcat, api, threadName)` **with its OWN (pc-pool) name**,
+   `executor.submit(runTestFromMessage)`, then **blocks in `future.get(300s)`**
+   (ConsumerUtil ~355-377).
+2. **`mini-test-worker-*`** — `Executors.newFixedThreadPool(200)`; actually runs `runTestNew`.
+   Executor/ApiExecutor ERROR logs and diagnose.sh's worker buckets are THIS pool.
+
+Consequences for reading data:
+- `TESTRUN STALL oldestTasks[].thread = pc-pool-*` is the **waiter** blocked in `future.get`,
+  NOT where work happens. Do not jstack-interpret pc-pool frames as the bottleneck.
+- diagnose.sh `workers io/cl/cpu` = **mini-test-worker** = the real execution signal.
+- One stuck test burns BOTH a pc-pool slot and a worker slot (pools equal-sized ⇒ no decoupling).
+- Test timeout = `maxRunTimeForTests` (300s). On timeout: `markTimedOut()`, `future.cancel(true)`,
+  `createTimedOutResultFromMessage` writes a `TEST_TIMED_OUT` terminal result to DB.
+
+---
+
+## 6. RULE: every bottleneck claim MUST be proven by correlating a metric line with jstack or JFR
+
+Metric lines (§3) and diag buckets (§4) are **leads, never proof**. `COST` sees only completers;
+diag buckets key on a single top frame and have known misclassifications. Before asserting *where*
+time goes, correlate against a real thread-level artifact. Do not spin an RCA from the metric lines
+alone.
+
+### Correlating with jstack (the fast path)
+1. From a `TESTRUN STALL` line, take a concrete stuck cell — a `{subcategory, api}` from
+   `oldestTasks` — and note its `age` (should be near 300s).
+2. Grab ≥3 jstacks of the **live** JVM ~4s apart (or use the auto `hang-<ts>.txt`):
+   `JSTACK=$("$(/usr/libexec/java_home -v 17)"/bin/jstack); for k in 1 2 3; do "$JSTACK" <pid> > /tmp/j.$k.txt; sleep 4; done`
+3. Look at the **`mini-test-worker-*`** threads (NOT `pc-pool-*` — those are just parked in
+   `future.get`; see §5). For a genuine CPU grind the top frame must be IDENTICAL across dumps 1
+   and 3 AND state `RUNNABLE` (a `RUNNABLE` socket read is I/O, not CPU — check the frame, not just
+   the state). For a block, expect `WAITING`/`TIMED_WAITING`/socket-read frames.
+4. Tie the thread back to the cell: the worker running a given record can be matched via the
+   `Thread [...] picked up record recordId=...` / `finished processing recordId=...` info logs, or
+   by matching the frame's test-template class to the stuck subcategory.
+5. A claim is proven only when the STALL cell, its ~300s age, and the repeated worker-thread frame
+   all point at the same code path. State which dumps/lines you used.
+
+### Correlating with JFR (when you need CPU time & allocation, not just a snapshot)
+- Enable on the run (add to the `java` line in `run-bench.sh`, or set once):
+  `-XX:StartFlightRecording=duration=0,filename=local-bench/rec-<label>.jfr,settings=profile`
+- After the run: `jfr print --events jdk.ExecutionSample rec-*.jfr` (hot methods by CPU),
+  `jfr print --events jdk.ObjectAllocationSample rec-*.jfr` (allocation hot spots),
+  `jfr view hot-methods rec-*.jfr`, `jfr view thread-cpu-load rec-*.jfr`.
+- Correlate the same way: the JFR hot method / allocating stack must match the code path implied
+  by the STALL cell and the diag `cpu`/`io` bucket. JFR settles CPU-vs-blocked definitively
+  (`ExecutionSample` counts on-CPU samples; blocked threads don't accrue them), which jstack alone
+  can't — a socket read shows `RUNNABLE` in jstack but produces no CPU samples in JFR.
+
+Report the artifact (dump filenames / jfr file + event) alongside any bottleneck claim.
+
+---
+
+## 7. Hard constraints
+- Never commit/push unless explicitly asked. `DATABASE_ABSTRACTOR_SERVICE_TOKEN` must never be
+  committed. Working branch: `fix/testing-stops-running`. MongoDB queries: one query per line.
+- Profiling rule: every claimed bottleneck must be backed by a tool measurement (§6) — no spun RCA.

--- a/local-bench/.gitignore
+++ b/local-bench/.gitignore
@@ -1,0 +1,9 @@
+# Env (contains local/secret config)
+bench.env
+
+# Logs & hang/stall thread-dump captures
+*.log
+hang-*.txt
+
+# Kafka test message dumps
+*.jsonl

--- a/local-bench/README.md
+++ b/local-bench/README.md
@@ -1,0 +1,47 @@
+# mini-testing branch benchmark
+
+End-to-end A/B benchmark of two mini-testing branches, compared from their
+`TESTRUN` log streams (both branches emit the identical format).
+
+## One-time setup
+```bash
+cp local-bench/bench.env.template local-bench/bench.env
+# edit local-bench/bench.env: paste abstractor token, set broker/mongo/name
+```
+
+## Run each branch (same workload, same env)
+Trigger a test run for your MINI_TESTING_NAME with the SAME scope before each,
+then:
+```bash
+# NOTE: use the metrics-ported BRANCH for 1.70.6, not the raw tag
+# (the tag has no TestRunMetrics -> no TESTRUN logs to compare).
+local-bench/run-bench.sh investigate/mini-testing-1.70.6-fast-run fast 60
+# re-trigger the same run, then:
+local-bench/run-bench.sh fix/testing-stops-running slow 60
+```
+Each builds with the right JDK (1.70.6 → Java 8, current → Java 17), runs against
+your real Kafka/abstractor/targets, tees to `local-bench/run-<label>-<ts>.log`,
+and auto-stops on `TESTRUN END` (or the max-minutes arg).
+
+## Compare
+```bash
+local-bench/compare-bench.py run-fast-*.log run-slow-*.log \
+    --label-a fast_1.70.6 --label-b slow_current
+```
+Headline = **wall-clock to process the first N tests** (N = largest count both
+runs reached) — an equal-work number robust to the slow branch not finishing.
+Also reports steady throughput, per-test latency, timeouts, peak stuckSlots, and
+a verdict.
+
+## Fairness notes
+- Same scope, same targets, same machine, same `XMX`/`XMS` for both runs.
+- Run back-to-back (or interleave 2–3x each and take medians) so target-side
+  drift doesn't dominate. A ~10x gap is far above that noise.
+- `time to N` includes the producer cold-start (that's branch code too, so it's
+  fair to include); `steady tests/s` excludes it (pure consumer throughput).
+
+## Files
+- `run-bench.sh` — build+run+capture one branch
+- `compare-bench.py` — parse two logs → metrics table + verdict
+- `bench.env` — your secrets/config (gitignored)
+- `kafka-test-messages.jsonl` — 226,740-msg dump of `akto.test.messages` (insurance)

--- a/local-bench/bench.env.template
+++ b/local-bench/bench.env.template
@@ -1,0 +1,18 @@
+# Copy to local-bench/bench.env and fill in. bench.env is gitignored (local-bench/* is).
+# Shared runtime env for both branch runs so the comparison is apples-to-apples.
+
+export KAFKA_BROKER_URL=localhost:9092
+export AKTO_MONGO_CONN="mongodb://localhost:27017"     # only used if a branch needs it
+export MINI_TESTING_NAME=local-mann-mac
+export DATABASE_ABSTRACTOR_SERVICE_TOKEN="PASTE_TOKEN_HERE"
+
+# resource caps applied to BOTH runs (keep identical for a fair test)
+export XMX=6g
+export XMS=2g
+
+# --- perf tunables (new-code ConsumerUtil reads these) ---
+# Cap worker concurrency (executor pool + parallel-consumer). ~2x cores for CPU-bound work.
+# 0 / unset = use the run's configured maxConcurrentRequest (e.g. 200).
+export MINI_TESTING_MAX_CONCURRENCY=20
+# Per-test timeout in seconds (was hard-coded 300). Cut CPU-starved tests fast.
+export MINI_TESTING_TASK_TIMEOUT_SECONDS=30

--- a/local-bench/compare-bench.py
+++ b/local-bench/compare-bench.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Compare two mini-testing runs from their TESTRUN log streams.
+
+Both branches emit identical `TESTRUN PROGRESS`/`TESTRUN END` lines, so the
+comparison is deterministic and reproducible from the logs alone.
+
+Headline metric: wall-clock time to process the first N tests, where N is the
+largest test count BOTH runs reached (equal-work comparison, robust to the fact
+that the slow branch may never finish the full matrix).
+
+Usage:
+  local-bench/compare-bench.py run-fast-*.log run-slow-*.log [--n N] [--label-a fast --label-b slow]
+"""
+import argparse, re, sys
+
+PROG = re.compile(r'TESTRUN PROGRESS\b')
+END  = re.compile(r'TESTRUN END\b')
+
+def num(pattern, line, cast=int, default=None):
+    m = re.search(pattern, line)
+    return cast(m.group(1)) if m else default
+
+def parse(path):
+    samples = []   # (elapsed_s, done, timeout, avg_ms, max_ms, stuck)
+    end = {}
+    with open(path, errors='replace') as f:
+        for line in f:
+            if PROG.search(line):
+                elapsed = num(r'elapsed=(\d+)s', line)
+                done    = num(r'done=(\d+)/', line)
+                if elapsed is None or done is None:
+                    continue
+                samples.append({
+                    'elapsed': elapsed,
+                    'done':    done,
+                    'timeout': num(r'\btimeout=(\d+)', line, default=0),
+                    'avg':     num(r'avgTestMs=(-?\d+)', line, default=-1),
+                    'max':     num(r'maxTestMs=(\d+)', line, default=0),
+                    'stuck':   num(r'stuckSlots=(\d+)', line, default=0),
+                })
+            elif END.search(line):
+                end = {
+                    'reason':   (re.search(r'reason=(\S+)', line) or [None, '?'])[1],
+                    'duration': num(r'durationSec=(\d+)', line, default=0),
+                    'done':     num(r'done=(\d+)/', line, default=0),
+                    'timeout':  num(r'\btimeout=(\d+)', line, default=0),
+                    'accounted':num(r'accountedFor=(\d+)', line, default=0),
+                }
+    return samples, end
+
+def time_to_n(samples, n):
+    """Linear-interpolate elapsed seconds at which done crosses n."""
+    prev = None
+    for s in samples:
+        if s['done'] >= n:
+            if prev is None or s['done'] == prev['done']:
+                return s['elapsed']
+            frac = (n - prev['done']) / (s['done'] - prev['done'])
+            return prev['elapsed'] + frac * (s['elapsed'] - prev['elapsed'])
+        prev = s
+    return None
+
+def steady_throughput(samples):
+    """tests/sec over the span from first non-zero progress to last sample."""
+    nz = [s for s in samples if s['done'] > 0]
+    if len(nz) < 2:
+        return None
+    a, b = nz[0], nz[-1]
+    dt = b['elapsed'] - a['elapsed']
+    return (b['done'] - a['done']) / dt if dt > 0 else None
+
+def final_avg(samples):
+    nz = [s for s in samples if s['avg'] >= 0]
+    return nz[-1]['avg'] if nz else None
+
+def summarize(path):
+    s, e = parse(path)
+    return {
+        'path': path, 'samples': s, 'end': e,
+        'final_done': (s[-1]['done'] if s else e.get('done', 0)),
+        'peak_stuck': max((x['stuck'] for x in s), default=0),
+        'final_avg': final_avg(s),
+        'final_max': max((x['max'] for x in s), default=0),
+        'final_timeout': (s[-1]['timeout'] if s else e.get('timeout', 0)),
+        'steady': steady_throughput(s),
+        'duration': e.get('duration'),
+        'reason': e.get('reason', '(no END)'),
+    }
+
+def fmt(v, unit='', nd=1):
+    if v is None: return 'n/a'
+    return f'{v:.{nd}f}{unit}' if isinstance(v, float) else f'{v}{unit}'
+
+def ratio(a, b):
+    if not a or not b: return 'n/a'
+    return f'{a / b:.2f}x' if b else 'n/a'
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('log_a'); ap.add_argument('log_b')
+    ap.add_argument('--n', type=int, default=None, help='equal-work test count (default: min of both finals)')
+    ap.add_argument('--label-a', default='A'); ap.add_argument('--label-b', default='B')
+    args = ap.parse_args()
+
+    A = summarize(args.log_a); B = summarize(args.log_b)
+    la, lb = args.label_a, args.label_b
+
+    n = args.n or (min(A['final_done'], B['final_done']) // 5000) * 5000
+    if n < 1000:
+        n = min(A['final_done'], B['final_done'])
+    ttn_a, ttn_b = time_to_n(A['samples'], n), time_to_n(B['samples'], n)
+    thr_a = (n / ttn_a) if ttn_a else None      # tests/s including cold start, over equal work
+    thr_b = (n / ttn_b) if ttn_b else None
+
+    rows = [
+        ('run reason',            A['reason'],               B['reason'],            ''),
+        ('final done',            A['final_done'],           B['final_done'],        ''),
+        (f'time to {n} tests (s)', fmt(ttn_a), fmt(ttn_b),   ratio(ttn_b, ttn_a) + ' (A faster if >1)'),
+        (f'throughput to N (tests/s)', fmt(thr_a), fmt(thr_b), ratio(thr_a, thr_b) + ' (A/B)'),
+        ('steady tests/s',        fmt(A['steady']),          fmt(B['steady']),       ratio(A['steady'], B['steady']) + ' (A/B)'),
+        ('steady tests/min',      fmt((A['steady'] or 0)*60), fmt((B['steady'] or 0)*60), ''),
+        ('final avgTestMs',       fmt(A['final_avg']),       fmt(B['final_avg']),    ratio(B['final_avg'], A['final_avg']) + ' (B slower if >1)'),
+        ('final maxTestMs',       fmt(A['final_max']),       fmt(B['final_max']),    ''),
+        ('final timeouts',        A['final_timeout'],        B['final_timeout'],     ''),
+        ('peak stuckSlots',       A['peak_stuck'],           B['peak_stuck'],        ''),
+    ]
+
+    w = 26
+    print(f'\n{"metric":<{w}} {la:>16} {lb:>16}   comparison')
+    print('-' * (w + 16 + 16 + 20))
+    for name, a, b, cmp in rows:
+        print(f'{name:<{w}} {str(a):>16} {str(b):>16}   {cmp}')
+    print()
+
+    if thr_a and thr_b:
+        r = thr_a / thr_b
+        faster, slower = (la, lb) if r >= 1 else (lb, la)
+        print(f'VERDICT: {faster} processed {n} tests {max(r,1/r):.1f}x faster than {slower} '
+              f'(equal-work wall-clock). ', end='')
+        # crude driver hint
+        if (B['final_timeout'] or 0) > 10 * (A['final_timeout'] or 0) + 10:
+            print(f'{lb} timeouts ({B["final_timeout"]}) vs {la} ({A["final_timeout"]}) — stuck/hung tests are a major factor.')
+        elif A['final_avg'] and B['final_avg'] and B['final_avg'] > 1.5 * A['final_avg']:
+            print(f'per-test latency {B["final_avg"]}ms vs {A["final_avg"]}ms — {lb} is slower per test, not just fewer slots.')
+        else:
+            print('check the per-test latency + stuckSlots columns for the driver.')
+    print()
+
+if __name__ == '__main__':
+    main()

--- a/local-bench/diagnose.sh
+++ b/local-bench/diagnose.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Live bottleneck sampler for a running mini-testing JVM — replaces the manual
+# jstack + grep + kafka-consumer-groups dance. Every INTERVAL seconds it prints one line:
+#   time | cpu% | rate done% avgMs stuck tmout err | worker buckets | states | kafkaLag
+#
+# Worker buckets classify each mini-test-worker by its top frame:
+#   io       = network wait (Net.poll / socketRead / NioSocketImpl / SSL read)
+#   connLock = okhttp connection-pool contention (callAcquirePooledConnection / RealConnectionPool)
+#   cpu      = resolveWordListVar / regex / String hashing
+#   park     = idle (Unsafe.park)
+#   other    = anything else
+# states = thread-state histogram for worker+pc pools: RUNNABLE/WAITING/TIMED/BLOCKED (R/W/T/B).
+# kafkaLag = committed-offset lag on the test topic (how many produced records are not yet committed).
+#
+# AUTO HANG-CAPTURE: if `done` doesn't advance for STALL_TICKS intervals while the run is still
+# active, it writes a hang-<ts>.txt bundle (3 stack dumps 4s apart + thread-state histogram +
+# BLOCKED lock-owner chain + kafka offsets) — the reproducible RCA artifact for the 40% stall.
+#
+# Usage: local-bench/diagnose.sh [interval_sec]   (default 20; runs until the JVM exits)
+set -uo pipefail
+INTERVAL="${1:-20}"
+REPO=/Users/mann/workspace/akto
+cd "$REPO"
+JSTACK="$(/usr/libexec/java_home -v 17 2>/dev/null)/bin/jstack"
+JAR_NAME="mini-testing-1.0-SNAPSHOT-jar"
+KAFKA_CTR="${KAFKA_CTR:-kafka-internal}"
+KAFKA_GROUP="${KAFKA_GROUP:-testing-group}"
+# done must be flat for this many consecutive intervals (while active) before we grab a hang bundle.
+STALL_TICKS="${STALL_TICKS:-3}"
+
+hdr() { printf "%-8s %6s | %6s %5s %7s %5s %5s %6s | %-22s | %-13s | %s\n" \
+  time cpu% rate done avgMs stuck tmout err "workers io/cl/cpu/pk/ot" "states R/W/T/B" kafkaLag; }
+
+# committed-offset lag on the topic the consumer group is draining (sum over partitions)
+kafka_lag() {
+  docker exec "$KAFKA_CTR" kafka-consumer-groups --bootstrap-server localhost:9092 \
+      --describe --group "$KAFKA_GROUP" 2>/dev/null \
+    | awk 'NR>1 && $6 ~ /^[0-9-]+$/ {cur+=$4; end+=$5; lag+=$6}
+           END{ if(end>0) printf "cur=%d/end=%d lag=%d", cur, end, lag; else printf "n/a"; }'
+}
+
+# error-bucket breakdown of the current run log (cumulative counts by type)
+err_breakdown() {
+  local log="$1"; [ -f "$log" ] || return
+  awk '
+    /ERROR|Exception/ {
+      if      ($0 ~ /Unexpected char .* in x-request-id/)                   h++
+      else if ($0 ~ /cannot loop on the given parameter|unable to resolve/) rp++
+      else if ($0 ~ /fetchTestScript/)                                      ts++
+      else if ($0 ~ /findStiByParam|Cannot construct instance/)             sti++
+      else if ($0 ~ /ultron\.akto\.io.*(timeout|SocketTimeout)|SocketTimeoutException/) ab++
+      else if ($0 ~ /Illegal character in path|URISyntaxException/)         uri++
+      else if ($0 ~ /Invalid method name/)                                  im++
+      else if ($0 ~ /Index [0-9]+ out of bounds/)                           oob++
+      else if ($0 ~ /ERROR/)                                                oth++
+    }
+    END{printf "  errors: headerChar=%d resolveParam=%d scriptNpe=%d stiDeser=%d abstractorTimeout=%d uriSyntax=%d invalidMethod=%d indexOOB=%d otherERROR=%d\n",
+        h+0, rp+0, ts+0, sti+0, ab+0, uri+0, im+0, oob+0, oth+0}' "$log"
+}
+
+# Full RCA bundle grabbed once when the run stalls: 3 dumps to see if threads are genuinely
+# stuck (same frame across all 3) vs merely slow, plus who owns the monitor everyone waits on.
+hang_capture() {
+  local pid="$1"; local out; out="local-bench/hang-$(date +%Y%m%d-%H%M%S).txt"
+  echo ">> STALL detected — capturing hang bundle to $out" | tee -a "$out"
+  {
+    echo "=== HANG CAPTURE pid=$pid $(date) ==="
+    echo "=== kafka: $(kafka_lag) (group=$KAFKA_GROUP) ==="
+    for k in 1 2 3; do
+      "$JSTACK" "$pid" 2>/dev/null > "/tmp/hang.$$.$k.txt"
+      echo; echo "--- dump $k: worker+pc thread-state histogram ---"
+      awk '/^"(mini-test-worker|pc-)/{getline s; if (s ~ /State:/){sub(/.*State: /,"",s); split(s,a," "); c[a[1]]++}} END{for(k in c) printf "  %-14s %d\n", k, c[k]}' "/tmp/hang.$$.$k.txt"
+      [ "$k" -lt 3 ] && perl -e 'select(undef,undef,undef,4)'
+    done
+
+    echo; echo "--- top frame of mini-test-worker threads, dump 1 vs 3 (identical => genuinely stuck) ---"
+    for k in 1 3; do
+      echo "  [dump $k]"
+      awk '/^"mini-test-worker/{f=1;name=$1;next} f&&/^\t*at /{sub(/^\t*at /,""); print "    "$0; f=0}' "/tmp/hang.$$.$k.txt" \
+        | sed -E 's/[@0-9a-fx]+//g; s/\(.*\)//' | sort | uniq -c | sort -rn | head -8
+    done
+
+    echo; echo "--- BLOCKED lock-owner chain (the monitor everyone is waiting on, and who holds it) ---"
+    awk '
+      /waiting to lock <0x/ { match($0,/<0x[0-9a-f]+>/); a=substr($0,RSTART,RLENGTH); waits[a]++ }
+      END{ mx=0; for(k in waits) if(waits[k]>mx){mx=waits[k]; hot=k}
+           if(hot!="") print "  most-contended monitor "hot" — "mx" threads waiting"; else print "  (no BLOCKED-on-monitor threads)" }
+    ' "/tmp/hang.$$.1.txt"
+    HOT=$(awk '/waiting to lock <0x/{match($0,/<0x[0-9a-f]+>/);a=substr($0,RSTART,RLENGTH);w[a]++} END{mx=0;for(k in w)if(w[k]>mx){mx=w[k];h=k};print h}' "/tmp/hang.$$.1.txt")
+    if [ -n "$HOT" ]; then
+      echo "  --- owner stanza (thread holding $HOT) ---"
+      awk -v hot="$HOT" 'BEGIN{RS=""} $0 ~ ("locked "hot) && $0 !~ ("waiting to lock "hot){print; exit}' "/tmp/hang.$$.1.txt" | sed 's/^/    /' | head -25
+    fi
+    echo; echo "=== end hang capture ==="
+  } >> "$out" 2>&1
+  rm -f /tmp/hang.$$.1.txt /tmp/hang.$$.2.txt /tmp/hang.$$.3.txt
+  echo ">> hang bundle written: $out"
+}
+
+hdr
+i=0; prev_done=""; flat=0; captured=0
+while true; do
+  PID=$(pgrep -f "$JAR_NAME" | head -1)
+  [ -z "$PID" ] && { echo ">> no running mini-testing JVM — done"; break; }
+  CPU=$(ps -o %cpu= -p "$PID" 2>/dev/null | tr -d ' ')
+  LOG=$(ls -t local-bench/run-*.log 2>/dev/null | head -1)
+  P=$(grep -a 'TESTRUN PROGRESS' "$LOG" 2>/dev/null | tail -1)
+  rate=$(echo "$P"  | grep -oE 'rate=[0-9.]+'        | cut -d= -f2)
+  donep=$(echo "$P" | grep -oE '\([0-9]+%\)'         | tr -d '()' | head -1)
+  donecnt=$(echo "$P" | grep -oE 'done=[0-9]+'       | head -1 | cut -d= -f2)
+  avg=$(echo "$P"   | grep -oE 'avgTestMs=[0-9]+'    | cut -d= -f2)
+  stuck=$(echo "$P" | grep -oE 'stuckSlots=[0-9]+'   | cut -d= -f2)
+  tmout=$(echo "$P" | grep -oE ' timeout=[0-9]+'     | grep -oE '[0-9]+')
+  err=$(echo "$P"   | grep -oE ' err=[0-9]+'         | grep -oE '[0-9]+')
+
+  "$JSTACK" "$PID" 2>/dev/null > /tmp/diag.$$.txt
+  buckets=$(awk '
+    /^"mini-test-worker/{p=1;next}
+    p && /^\t*at /{
+      if      ($0 ~ /Net\.poll|socketRead|NioSocketImpl|SSLSocketImpl.*read/)          io++
+      else if ($0 ~ /callAcquirePooledConnection|RealConnectionPool/)                   cl++
+      else if ($0 ~ /resolveWordListVar|java\.util\.regex|StringLatin1|Pattern/)        cpu++
+      else if ($0 ~ /Unsafe\.park/)                                                     pk++
+      else                                                                             ot++
+      p=0
+    }
+    END{printf "%d/%d/%d/%d/%d", io+0, cl+0, cpu+0, pk+0, ot+0}' /tmp/diag.$$.txt)
+  # thread-state histogram for worker+pc pools (RUNNABLE/WAITING/TIMED_WAITING/BLOCKED)
+  states=$(awk '
+    /^"(mini-test-worker|pc-)/{getline s; if (s ~ /State:/){sub(/.*State: /,"",s); split(s,a," ");
+      st=a[1]; if(st=="RUNNABLE")r++; else if(st=="WAITING")w++; else if(st=="TIMED_WAITING")t++; else if(st=="BLOCKED")b++}}
+    END{printf "%d/%d/%d/%d", r+0, w+0, t+0, b+0}' /tmp/diag.$$.txt)
+  rm -f /tmp/diag.$$.txt
+  lag=$(kafka_lag)
+
+  printf "%-8s %6s | %6s %5s %7s %5s %5s %6s | %-22s | %-13s | %s\n" \
+    "$(date +%H:%M:%S)" "${CPU:-?}" "${rate:-?}" "${donep:-?}" "${avg:-?}" "${stuck:-?}" "${tmout:-?}" "${err:-?}" \
+    "$buckets" "$states" "$lag"
+
+  # ---- stall detection: done flat for STALL_TICKS while the run is still active ----
+  if [ -n "${donecnt:-}" ]; then
+    if [ "$donecnt" = "$prev_done" ]; then flat=$((flat+1)); else flat=0; captured=0; fi
+    prev_done="$donecnt"
+    if [ "$flat" -ge "$STALL_TICKS" ] && [ "$captured" -eq 0 ]; then
+      hang_capture "$PID"; captured=1
+    fi
+  fi
+
+  i=$((i+1))
+  if [ $((i % 10)) -eq 0 ]; then err_breakdown "$LOG"; hdr; fi
+  perl -e "select(undef,undef,undef,$INTERVAL)"
+done

--- a/local-bench/run-bench-single.sh
+++ b/local-bench/run-bench-single.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Exp A — isolated single-threaded per-cell cost (no Kafka, no pool, no contention).
+# Runs com.akto.testing.BenchSingleTest against REAL apis+templates built via the producer's own
+# init mechanism (TestExecutor.init with doInitOnly=true). Answers: intrinsic cost vs contention.
+#
+# Usage:  local-bench/run-bench-single.sh <summaryId> [numApis] [capSec] [csvSubcats|ALL] [jfr]
+#   e.g.  local-bench/run-bench-single.sh 6a8c141599d091d3e61d48e1 3 400
+#         local-bench/run-bench-single.sh 6a8c141599d091d3e61d48e1 3 400 FUZZ_USER_ID jfr
+set -euo pipefail
+
+SUMMARY="${1:?usage: run-bench-single.sh <summaryId> [numApis] [capSec] [csvSubcats|ALL] [jfr]}"
+NUM_APIS="${2:-3}"
+CAP_SEC="${3:-400}"
+SUBCATS="${4:-}"
+JFR="${5:-}"
+
+REPO=/Users/mann/workspace/akto
+cd "$REPO"
+
+[[ -f local-bench/bench.env ]] || { echo "!! create local-bench/bench.env first"; exit 1; }
+# shellcheck disable=SC1091
+source local-bench/bench.env
+
+# Java 17 (current branch target); build == run JDK.
+if grep -q '<source>8</source>' apps/mini-testing/pom.xml 2>/dev/null; then
+  export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home
+else
+  unset JAVA_HOME || true
+fi
+JAVA_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+echo ">> mvn package (fat jar)"
+MAVEN_OPTS="" mvn -am -pl apps/mini-testing clean package -DskipTests=true -q
+JAR=apps/mini-testing/target/mini-testing-1.0-SNAPSHOT-jar-with-dependencies.jar
+[[ -f "$JAR" ]] || { echo "!! jar not found: $JAR"; exit 1; }
+
+export NEW_TESTING_ENABLED=true
+export AKTO_LOG_LEVEL=WARN
+export RUNTIME_MODE=hybrid
+
+TS=$(date +%Y%m%d-%H%M%S)
+LOG="local-bench/single-${SUMMARY}-${TS}.log"
+JFR_ARGS=()
+if [[ "$JFR" == "jfr" ]]; then
+  JFR_ARGS=(-XX:StartFlightRecording=duration=0,filename="local-bench/single-${SUMMARY}-${TS}.jfr",settings=profile)
+  echo ">> JFR on -> local-bench/single-${SUMMARY}-${TS}.jfr"
+fi
+
+echo ">> RUN: $("$JAVA_BIN" -version 2>&1 | head -1)"
+echo ">> args: summary=$SUMMARY numApis=$NUM_APIS capSec=$CAP_SEC subcats=[${SUBCATS:-<default 17>}]"
+echo ">> log -> $LOG"
+"$JAVA_BIN" -Xmx"${XMX:-6g}" -Xms"${XMS:-2g}" ${JFR_ARGS[@]+"${JFR_ARGS[@]}"} \
+  -cp "$JAR" com.akto.testing.BenchSingleTest "$SUMMARY" "$NUM_APIS" "$CAP_SEC" "$SUBCATS" 2>&1 | tee "$LOG"
+echo ">> done. log: $LOG"

--- a/local-bench/run-bench.sh
+++ b/local-bench/run-bench.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# End-to-end benchmark run of one mini-testing branch/tag.
+# Builds the fat jar with the JDK that branch needs, runs it against your real
+# Kafka/abstractor/targets, tees the TESTRUN log stream to local-bench/, and
+# auto-stops when the run finishes (TESTRUN END) or a max wall-clock is hit.
+#
+# Usage:  local-bench/run-bench.sh <git-ref> <label> [max-minutes]
+#   e.g.  local-bench/run-bench.sh vmini-testing-1.70.6            fast   60
+#         local-bench/run-bench.sh fix/testing-stops-running       slow   60
+#
+# Prereqs: Kafka up, abstractor reachable (no 403s), and a test run TRIGGERED
+# for MINI_TESTING_NAME with the SAME scope before each invocation.
+set -euo pipefail
+
+REF="${1:?usage: run-bench.sh <git-ref> <label> [max-minutes]}"
+LABEL="${2:?label required (e.g. fast|slow)}"
+MAX_MIN="${3:-60}"
+
+REPO=/Users/mann/workspace/akto
+cd "$REPO"
+
+JAR_NAME="mini-testing-1.0-SNAPSHOT-jar-with-dependencies.jar"
+
+# TERM, then (after a grace period) KILL any mini-testing JVM matching the jar.
+# The app catches SIGTERM (shutdown hook) and can linger, so we escalate to -9.
+kill_jvms() {
+  local pids; pids=$(pgrep -f "$JAR_NAME" 2>/dev/null || true)
+  [[ -z "$pids" ]] && return 0
+  echo ">> stopping mini-testing JVM(s): $pids"
+  kill $pids 2>/dev/null || true
+  for _ in $(seq 1 12); do pgrep -f "$JAR_NAME" >/dev/null 2>&1 || return 0; sleep 1; done
+  pids=$(pgrep -f "$JAR_NAME" 2>/dev/null || true)
+  [[ -n "$pids" ]] && { echo ">> forcing SIGKILL: $pids"; kill -9 $pids 2>/dev/null || true; }
+  return 0
+}
+# Never leave an orphaned JVM behind (covers Ctrl-C, errors, and normal exit).
+trap kill_jvms EXIT INT TERM
+
+echo ">> killing any stray mini-testing instances before starting"
+kill_jvms
+
+if [[ ! -f local-bench/bench.env ]]; then
+  echo "!! create local-bench/bench.env from bench.env.template first"; exit 1
+fi
+# shellcheck disable=SC1091
+source local-bench/bench.env
+
+echo ">> checkout $REF"
+#git switch --detach "$REF" 2>/dev/null || git switch "$REF"
+git checkout $REF
+echo ">> HEAD: $(git rev-parse --short HEAD)  ($(git describe --tags --always 2>/dev/null || true))"
+
+# Pick JDK from the module's compiler target (1.70.6 => Java 8, current => Java 17).
+# CRITICAL: build AND run with that same major. 70.6 needs Java 8's built-in Nashorn;
+# running its jar on Java 17 makes getEngineByName("nashorn") null (auth scripts break).
+if grep -q '<source>8</source>' apps/mini-testing/pom.xml 2>/dev/null; then
+  BUILD_TARGET=8
+  export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home
+else
+  BUILD_TARGET=17
+  unset JAVA_HOME || true
+fi
+# Run binary comes from JAVA_HOME (not PATH), so build JDK == run JDK.
+JAVA_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+# --- hard guard: abort if the run JVM major != build target (never silently run on the wrong JDK) ---
+RUN_VER_LINE="$("$JAVA_BIN" -version 2>&1 | head -1 || true)"
+if echo "$RUN_VER_LINE" | grep -q '"1\.8'; then RUN_MAJOR=8
+else RUN_MAJOR="$(echo "$RUN_VER_LINE" | grep -oE '"[0-9]+' | tr -d '"' | head -1)"; fi
+echo ">> build target = Java $BUILD_TARGET ; JAVA_BIN=$JAVA_BIN ; version: $RUN_VER_LINE"
+if [[ "$RUN_MAJOR" != "$BUILD_TARGET" ]]; then
+  echo "!! ABORT: run JVM is Java '$RUN_MAJOR' but build target is Java $BUILD_TARGET."
+  echo "!! (check that $JAVA_HOME exists / zulu-8 is installed). Not running."
+  exit 1
+fi
+echo ">> verified: building AND running on Java $RUN_MAJOR"
+
+echo ">> mvn package (this can take a few minutes)"
+MAVEN_OPTS="" mvn -am -pl apps/mini-testing clean package -DskipTests=true -q
+
+JAR=apps/mini-testing/target/mini-testing-1.0-SNAPSHOT-jar-with-dependencies.jar
+[[ -f "$JAR" ]] || { echo "!! jar not found: $JAR"; exit 1; }
+
+TS=$(date +%Y%m%d-%H%M%S)
+LOG="local-bench/run-${LABEL}-${TS}.log"
+
+export NEW_TESTING_ENABLED=true
+export AKTO_LOG_LEVEL=WARN
+export RUNTIME_MODE=hybrid
+
+echo ">> RUN jvm: $("$JAVA_BIN" -version 2>&1 | head -1)"
+echo ">> running -> $LOG   (auto-stop on TESTRUN END or ${MAX_MIN}m)"
+"$JAVA_BIN" -Xmx"${XMX:-6g}" -Xms"${XMS:-2g}" -jar "$JAR" > "$LOG" 2>&1 &
+PID=$!
+
+# auto-start the live bottleneck sampler; stream it to the console AND a file (self-exits when JVM dies)
+DIAG_LOG="local-bench/diag-${LABEL}-${TS}.log"
+echo ">> live diagnostics (also saved to $DIAG_LOG):"
+( local-bench/diagnose.sh "${DIAG_INTERVAL:-20}" 2>&1 | tee "$DIAG_LOG" ) &
+DIAG_PID=$!
+
+deadline=$(( $(date +%s) + MAX_MIN * 60 ))
+saw_start=0
+while kill -0 "$PID" 2>/dev/null; do
+  grep -q "TESTRUN START" "$LOG" 2>/dev/null && saw_start=1
+  if [[ $saw_start -eq 1 ]] && grep -q "TESTRUN END" "$LOG" 2>/dev/null; then
+    echo ">> TESTRUN END seen — stopping"; break
+  fi
+  if [[ "$(date +%s)" -ge "$deadline" ]]; then echo ">> max ${MAX_MIN}m reached — stopping"; break; fi
+  sleep 5
+done
+
+kill_jvms
+kill "${DIAG_PID:-}" 2>/dev/null || true
+pkill -f 'local-bench/diagnose.sh' 2>/dev/null || true
+
+echo ">> finished. log: $LOG"
+echo ">> TESTRUN lines:"; grep "TESTRUN" "$LOG" | tail -3
+echo ">> diagnostics summary (bucket table): $DIAG_LOG"
+tail -8 "$DIAG_LOG" 2>/dev/null
+echo "$LOG"


### PR DESCRIPTION
For testing issues we need to only look at these logs.

```
2026-09-01 06:00:04 [main] WARN com.akto.testing.kafka_utils.TestRunMetrics - acc: 1662680463, TESTRUN PROGRESS summaryId=6a9669ac4bede96740804e74 elapsed=57s rate=0.0/s done=0/131004 (0%) pass=0 vuln=0 skip=0 timeout=0 rejected=0 err=0 polled=0 workRemaining=0 inflight=0 stuckSlots=0 oldestInflightMs=0 avgTestMs=-1 maxTestMs=0 executor[active=0/0 queued=0 completed=0]
2026-09-01 06:01:04 [main] WARN com.akto.testing.kafka_utils.TestRunMetrics - acc: 1662680463, TESTRUN PROGRESS summaryId=6a9669ac4bede96740804e74 elapsed=117s rate=44.8/s eta~2804s done=5247/131004 (4%) pass=5199 vuln=55 skip=0 timeout=0 rejected=0 err=0 polled=5454 workRemaining=7539 inflight=200 stuckSlots=0 oldestInflightMs=15426 avgTestMs=2100 maxTestMs=26974 executor[active=200/200 queued=0 completed=5254]
2026-09-01 06:01:04 [main] WARN com.akto.testing.kafka_utils.TestRunMetrics - acc: 1662680463, TESTRUN COST summaryId=6a9669ac4bede96740804e74 n=5383 avgPerTestMs=1942 cpuPerTestMs=6 | RUN_TEST=534ms (27% of billed) [SEND_REQUEST=22ms/4% | OTHER=512ms/95%] LOOKUP=0ms INSERT_RESULTS=1408ms/72% of billed
2026-09-01 06:02:04 [main] WARN com.akto.testing.kafka_utils.TestRunMetrics - acc: 1662680463, TESTRUN PROGRESS summaryId=6a9669ac4bede96740804e74 elapsed=177s rate=62.3/s eta~1926s done=11026/131004 (8%) pass=10911 vuln=115 skip=0 timeout=0 rejected=0 err=0 polled=11226 workRemaining=1759 inflight=200 stuckSlots=0 oldestInflightMs=20505 avgTestMs=2044 maxTestMs=26974 executor[active=200/200 queued=0 completed=11026]

```