### PR TITLE
Fix NPE in fetchTestScript when no script is configured

### DIFF
--- a/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
+++ b/libs/utils/src/main/java/com/akto/data_actor/ClientActor.java
@@ -4303,7 +4303,11 @@ public class ClientActor extends DataActor {
             try {
                 payloadObj = BasicDBObject.parse(responsePayload);
                 BasicDBObject testScriptObj = (BasicDBObject) payloadObj.get("testScript");
-                testScript = objectMapper.readValue(testScriptObj.toJson(), TestScript.class);
+                // No script configured for this type is a normal, common outcome (most accounts
+                // don't set one) — not an error. Avoid NPE-ing on toJson() and don't log it.
+                if (testScriptObj != null) {
+                    testScript = objectMapper.readValue(testScriptObj.toJson(), TestScript.class);
+                }
             } catch (Exception e) {
                 loggerMaker.errorAndAddToDb("error extracting response in fetchTestScript" + e, LoggerMaker.LogDb.RUNTIME);
             }


### PR DESCRIPTION
## Why
Customer log showed ~100 occurrences in a 16-minute window of:
\`error extracting response in fetchTestScript java.lang.NullPointerException: Cannot invoke "com.mongodb.BasicDBObject.toJson()" because "testScriptObj" is null\`

Root cause: \`TestScriptsDao.fetchTestScript()\` (server-side) legitimately returns \`null\` whenever the account has no \`TestScript\` configured for that type — the common case, not an error. The server serializes that as \`testScript: null\`, but \`ClientActor.fetchTestScript()\` unconditionally called \`.toJson()\` on it, NPEing on every such normal response. Caught by the outer try/catch and logged as ERROR each time — since scripts are cached with a 5-min TTL (\`ApiExecutorUtil.getCachedScript\`), this fires on essentially every cache refresh for any account/type without a configured script.

## What
Guard on \`testScriptObj == null\` and skip the parse — \`testScript\` stays \`null\`, which is already the correct/handled "no script" case downstream.

## Test plan
- [x] \`libs/dao\`, \`libs/utils\` compile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)