### PR TITLE
fix: enforce product-scope NO_ACCESS check regardless of RBAC billing tier

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/interceptor/RoleAccessInterceptor.java
+++ b/apps/dashboard/src/main/java/com/akto/interceptor/RoleAccessInterceptor.java
@@ -109,10 +109,6 @@ public class RoleAccessInterceptor extends AbstractInterceptor {
                 return invocation.invoke();
             }
 
-            if(!(UsageMetricCalculator.isRbacFeatureAvailable(sessionAccId) || featureLabel.equalsIgnoreCase(RbacEnums.Feature.ADMIN_ACTIONS.toString()))){
-                logger.debug("Time by feature label check in: " + (Context.now() - timeNow));
-                return invocation.invoke();
-            }
             timeNow = Context.now();
             int userId = user.getId();
 
@@ -129,6 +125,16 @@ public class RoleAccessInterceptor extends AbstractInterceptor {
                 userRole = userRoleRecord.getName().toUpperCase();
             }
 
+            // Product-scope (NO_ACCESS) enforcement must run regardless of whether this account
+            // has paid for the RBAC feature — it's a distinct, more fundamental boundary ("does
+            // this user have any access to this product line at all") from the fine-grained,
+            // per-feature read/write check further below, which the RBAC-paid-feature gate
+            // legitimately relaxes to "full access" for accounts without the custom-roles add-on.
+            // The isRbacFeatureAvailable() skip used to sit BEFORE this block, so on any account
+            // without that add-on it skipped the NO_ACCESS denial too, for every endpoint except
+            // the hardcoded ADMIN_ACTIONS ones — silently leaking product-scoped data to users
+            // explicitly denied access to that product (e.g. a user with no Atlas access could
+            // still read Atlas data through any non-ADMIN_ACTIONS-labeled endpoint).
             if (!isOnboardingRequest && userRoleRecord.equals(Role.NO_ACCESS)) {
                 HttpServletResponse response = (HttpServletResponse) ServletActionContext.getResponse();
                 response.setHeader("X-No-Access-Error", "true");
@@ -168,6 +174,15 @@ public class RoleAccessInterceptor extends AbstractInterceptor {
                 return invocation.invoke();
             }
             // ===== END PRODUCT SCOPE VALIDATION =====
+
+            // Fine-grained, per-feature read/write check — relaxed to "full access" for accounts
+            // that haven't paid for the RBAC feature (custom roles). ADMIN_ACTIONS is exempt from
+            // this relaxation: it gates a genuinely dangerous capability and is always enforced
+            // regardless of billing tier.
+            if(!(UsageMetricCalculator.isRbacFeatureAvailable(sessionAccId) || featureLabel.equalsIgnoreCase(RbacEnums.Feature.ADMIN_ACTIONS.toString()))){
+                logger.debug("Time by feature label check in: " + (Context.now() - timeNow));
+                return invocation.invoke();
+            }
 
             Feature featureType = Feature.valueOf(this.featureLabel.toUpperCase());
 


### PR DESCRIPTION
## Summary

Reported symptom: a user without RBAC access to Atlas (Endpoint Security) sees a red "You do not have access to this product. Please ask Admin to grant access or navigate to accessible product" banner and `fetchAgenticUsers` correctly returns 403 — but `fetchAgenticAssetsSummary` on the same page, for the same user, returns real data.

## Root cause

`RoleAccessInterceptor.intercept()` had two genuinely independent checks collapsed behind one early-return:

1. **Billing gate** — `UsageMetricCalculator.isRbacFeatureAvailable(accountId)`: has this account paid for the RBAC/custom-roles add-on? If not, the fine-grained per-feature read/write check should relax to "full access" (there's no custom-role concept to enforce without the add-on).
2. **Product-scope gate** — `Role.NO_ACCESS`: does this *specific user* have any access to this product line (API / AGENTIC / ENDPOINT / MCP / DAST) at all? This is a fundamental per-user boundary, unrelated to the account's billing tier.

The old code checked (1) *before* (2), with an exemption only for the `ADMIN_ACTIONS` featureLabel:

```java
if(!(UsageMetricCalculator.isRbacFeatureAvailable(sessionAccId) || featureLabel.equalsIgnoreCase(Feature.ADMIN_ACTIONS.toString()))){
    return invocation.invoke();   // <-- skips check (2) entirely
}
... // NO_ACCESS check happens after this, so it's skipped along with it
```

So for any account without the RBAC add-on, **every endpoint except the hardcoded `ADMIN_ACTIONS`-labeled ones skipped the NO_ACCESS denial too** — silently leaking product-scoped data to users explicitly denied access to that product.

## Why fetchAgenticUsers/fetchMcpRegistries were fine but fetchAgenticAssetsSummary wasn't

Both `fetchAgenticUsers` (`ModuleInfoAction`) and `fetchMcpRegistries` (`McpAllowlistAction`) are gated by `ADMIN_ACTIONS` — the one hardcoded exemption, always enforced regardless of billing tier. `fetchAgenticAssetsSummary`, like nearly every other endpoint in the codebase, is gated by `API_COLLECTIONS`, which is subject to the bypass.

## This is not a scale-test-PR regression — it's a pre-existing, dormant bug

Confirmed via `git log`:
- `RoleAccessInterceptor.java` was last touched years ago (`add threat access toggle in role`, a string of `product scope changes` commits) — completely untouched by the ATLAS scale-out work. This commit is its first change since.
- `fetchAgenticUsers` and `fetchMcpRegistries`'s struts.xml entries similarly predate the scale-test PR by years.
- `fetchAgenticAssetsSummary` is a *new* endpoint, added by `937bfa384a` ("Rebuild ATLAS agentic pages onto server-side pagination"). Its predecessor — the old Agentic Assets page — fetched its data from `api/getAllCollectionsBasic`, whose struts.xml entry (`API_COLLECTIONS`-gated, confirmed via `git log -S`, last touched in an unrelated 2024-era commit) is *also* untouched by the rebuild.
- Checked whether a separate DAO-level filter (`AccountsContextDaoWithRbac`, applied automatically to every `ApiCollectionsDao.findAll` call) might have been compensating on the old page. It scopes queries by `UsersCollectionsList.getCollectionsIdForUser`/`getContextCollectionsForUser` — a "which collections belong to this product/role-group" filter, not a "does this user have any right to query this product at all" check. It applies identically to old and new code, so it wouldn't have caught this on either.

**Conclusion**: the old page's primary data source (`getAllCollectionsBasic`) had this exact same gap the whole time. The rebuild didn't introduce the vulnerability — it introduced a new endpoint that happened to inherit the same already-broken gate every non-`ADMIN_ACTIONS` endpoint has always had. This most likely surfaced now because this specific test scenario (a NO_ACCESS-scoped test user, checked directly against this page's data) hadn't been run against either version of the page before.

## Fix

Reordered so the NO_ACCESS product-scope check runs unconditionally whenever `DashboardMode.isMetered()` — independent of the RBAC billing gate. The billing gate now only relaxes the fine-grained per-feature check that follows it, which is what it was actually meant to do. Pure reorder, no new logic, no message/behavior changes for either check individually.

## Test plan
- [x] Compiles clean; dashboard restarts cleanly with no new errors.
- [x] **Confirmed live by the reporter**: fix resolves the reported leak.
- [x] Confirmed via code trace this is a no-op for any account with the RBAC add-on already granted (the common path) — no regression risk there.
- [x] Confirmed via git history this is a long-standing gap, not something introduced by the ATLAS scale-out PR (see RCA above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)