### PR TITLE
Update test run time limits and add new runtime options in UI

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/testing/StartTestAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/testing/StartTestAction.java
@@ -1539,7 +1539,7 @@ public class StartTestAction extends UserAction {
                     List<Bson> updates = new ArrayList<>();
 
                     if (editableTestingRunConfig.getTestRunTime() > 0
-                            && editableTestingRunConfig.getTestRunTime() <= 6 * 60 * 60
+                            && editableTestingRunConfig.getTestRunTime() <= 12 * 60 * 60
                             && editableTestingRunConfig.getTestRunTime() != existingTestingRun.getTestRunTime()) {
                         updates.add(Updates.set(TestingRun.TEST_RUNTIME, editableTestingRunConfig.getTestRunTime()));
                     }

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/RunTest.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api_collections/RunTest.jsx
@@ -526,6 +526,8 @@ function RunTest({ endpoints, filtered, apiCollectionId, apiCollectionIds, disab
         }
         return abc
     }, [])
+    runTimeHours.push({ label: "9 hours", value: `${9 * 60 * 60}` })
+    runTimeHours.push({ label: "12 hours", value: `${12 * 60 * 60}` })
 
     const testRunTimeOptions = [...runTimeMinutes, ...runTimeHours]
 


### PR DESCRIPTION
- Increased maximum test run time from 6 hours to 12 hours in StartTestAction.java.
- Added new runtime options for 9 hours and 12 hours in RunTest.jsx.