### PR TITLE
Refactor user analysis data handling and enhance API functionality

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
@@ -2270,7 +2270,9 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                 // fixed (see fetchAgenticAssetDetail, the lazy per-asset endpoint the Overview tab's
                 // full device list — topology graph, etc. — now comes from instead).
                 List<BasicDBObject> devices = buildDevicesForGroup(g, byId, traffic, risk, userAnalysis);
-                if (!"skill".equals(g.rowType) && !"plugin".equals(g.rowType)) {
+                // Only "agent" rows have their own token identity — service/llm/skill/plugin rows
+                // would just redundantly echo whichever agent's tokens their hostname happens to embed.
+                if ("agent".equals(g.rowType)) {
                     int aiInteractionsTotal = 0;
                     for (BasicDBObject d : devices) {
                         Object v = d.get("aiInteractions");
@@ -2750,11 +2752,8 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             Map<String, Integer> userAnalysis = userAnalysisFlatMap != null ? userAnalysisFlatMap : Collections.emptyMap();
             List<BasicDBObject> topApps = new ArrayList<>();
             for (GroupSummary g : groups.values()) {
-                // Skill and Plugin rows deliberately excluded here — same reasoning as "Top Assets
-                // with Violations" above and the grid's per-row "aiInteractions" column (which already
-                // nulls this out for plugins below): UserAnalysisData is keyed only per agent-app-per-
-                // device.
-                if ("skill".equals(g.rowType) || "plugin".equals(g.rowType)) continue;
+                // Only "agent" rows get ranked here — same reasoning as the grid column above.
+                if (!"agent".equals(g.rowType)) continue;
                 int groupTotal = 0;
                 Set<String> seenKeys = new HashSet<>();
                 for (String hostName : g.hostNames) {
@@ -2775,6 +2774,8 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                     row.put("id", g.rowType + "-" + g.groupKey);
                     row.put("name", g.name);
                     row.put("type", g.clientType);
+                    // Frontend maps this to assetTagValue to resolve a per-app icon (see shapeRow).
+                    row.put("groupKey", g.groupKey);
                     row.put("aiInteractions", groupTotal);
                     topApps.add(row);
                 }

--- a/apps/dashboard/src/main/java/com/akto/action/monitoring/EndpointShieldAgentAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/monitoring/EndpointShieldAgentAction.java
@@ -12,6 +12,7 @@ import com.akto.log.LoggerMaker;
 import com.akto.log.LoggerMaker.LogDb;
 import com.akto.dto.Log;
 import com.akto.dao.context.Context;
+import com.akto.utils.search.SearchClientFactory;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Sorts;
@@ -49,11 +50,25 @@ public class EndpointShieldAgentAction extends UserAction {
     private List<UserAnalysisData> userAnalysisList = new ArrayList<>();
 
     public String fetchUserAnalysisList() {
-        userAnalysisList = UserAnalysisDataDao.instance.findAll(Filters.empty(),
-                Projections.include(UserAnalysisData.USER_NAME, UserAnalysisData.LAST_UPDATED_AT,
-                        UserAnalysisData.TOTAL_INPUT_TOKENS,
-                        UserAnalysisData.TOTAL_OUTPUT_TOKENS, UserAnalysisData.AI_SUMMARY,
-                        UserAnalysisData.HARMFUL_TOPICS));
+        // startTime > 0 means a real range was picked (endTime is always nonzero, even for "All
+        // time" — see AgenticAssetsPage.jsx), so branch on startTime alone to keep "All time" on
+        // the cheap lifetime-counter path below instead of an on-the-fly query.
+        if (startTime > 0) {
+            long startMs = startTime > 0 ? startTime * 1000L : 0L;
+            long endMs = endTime > 0 ? endTime * 1000L : System.currentTimeMillis();
+            long t0 = System.currentTimeMillis();
+            userAnalysisList = SearchClientFactory.instance()
+                    .fetchUserAnalysisTokenTotals(Context.accountId.get(), startMs, endMs);
+            loggerMaker.warnAndAddToDb("[fetchUserAnalysisList-timing] on-the-fly query TOTAL="
+                    + (System.currentTimeMillis() - t0) + "ms, rows=" + userAnalysisList.size()
+                    + ", rangeMs=" + (endMs - startMs));
+        } else {
+            userAnalysisList = UserAnalysisDataDao.instance.findAll(Filters.empty(),
+                    Projections.include(UserAnalysisData.USER_NAME, UserAnalysisData.LAST_UPDATED_AT,
+                            UserAnalysisData.TOTAL_INPUT_TOKENS,
+                            UserAnalysisData.TOTAL_OUTPUT_TOKENS, UserAnalysisData.AI_SUMMARY,
+                            UserAnalysisData.HARMFUL_TOPICS));
+        }
         return SUCCESS.toUpperCase();
     }
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AgenticAssetsPage.jsx
@@ -457,7 +457,7 @@ export default function AgenticAssetsPage() {
         Promise.allSettled([
           fetchAgenticViolationCountsByHost({ startTimestamp, endTimestamp }),
           fetchAgenticSkillViolationCounts({ startTimestamp, endTimestamp }),
-          agenticObserveApi.listUserAnalysis(),
+          agenticObserveApi.listUserAnalysis(startTimestamp, endTimestamp),
         ])
           .then(async ([hostCountsSettled, skillViolationsSettled, userAnalysisSettled]) => {
             if (!isMountedRef.current) return;
@@ -612,6 +612,7 @@ export default function AgenticAssetsPage() {
   const topAppsRows = useMemo(() =>
     (stats.topUsedApplications || []).map((row) => ({
       ...row,
+      assetTagValue: row.groupKey,
       onClick: (r) => openAssetByName(r.name, r.type),
       renderValue: (r) => (
         <HorizontalStack align="end" blockAlign="center" wrap={false} gap="0">

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/agenticObserveApi.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/agenticObserveApi.js
@@ -323,11 +323,11 @@ export function buildAgenticObserveChatMetadata(scope, data = {}) {
 }
 
 const agenticObserveApi = {
-    async listUserAnalysis() {
+    async listUserAnalysis(startTime, endTime) {
         const resp = await request({
             url: "/api/listUserAnalysis",
             method: "post",
-            data: {},
+            data: { startTime: startTime || 0, endTime: endTime || 0 },
         });
         if (Array.isArray(resp)) return resp;
         if (Array.isArray(resp?.userAnalysisList)) return resp.userAnalysisList;

--- a/libs/utils/src/main/java/com/akto/utils/elasticsearch/ElasticSearchClient.java
+++ b/libs/utils/src/main/java/com/akto/utils/elasticsearch/ElasticSearchClient.java
@@ -1,5 +1,7 @@
 package com.akto.utils.elasticsearch;
 
+import com.akto.dto.agentic_sessions.UserAnalysisData;
+import com.akto.dto.agentic_sessions.UserAnalysisData.UserAnalysisDataKey;
 import com.akto.log.LoggerMaker;
 import com.akto.log.LoggerMaker.LogDb;
 import com.akto.util.http_util.CoreHTTPClient;
@@ -71,6 +73,11 @@ public class ElasticSearchClient extends SearchClient {
     // Distinct policy names hit by any span in the session — flat, no hierarchy to preserve.
     private static final String AGG_GUARDRAIL_POLICIES  = "guardrailPoliciesAgg";
     private static final int    GUARDRAIL_POLICIES_BREADTH = 10;
+    // Nested agg: terms on serviceId.keyword → sub-agg terms on deviceId.keyword, with token sums.
+    private static final String AGG_USER_ANALYSIS_SERVICE  = "userAnalysisByService";
+    private static final String AGG_USER_ANALYSIS_DEVICE   = "userAnalysisByDevice";
+    private static final int    USER_ANALYSIS_SERVICE_SIZE = 200;
+    private static final int    USER_ANALYSIS_DEVICE_SIZE  = 2000;
 
     private static final ElasticSearchClient INSTANCE = new ElasticSearchClient();
     public static ElasticSearchClient instance() { return INSTANCE; }
@@ -543,6 +550,78 @@ public class ElasticSearchClient extends SearchClient {
         }
         return new ArgusStats(aggTotalSpans, aggInputTokens, aggOutputTokens,
             aggTopApps, aggAppBreakdown, aggTopTraces, aggTraceSpark, aggTokenSpark, aggTraceSparkTs);
+    }
+
+    // ── Time-ranged token totals per (serviceId, deviceId) ─────────────────────
+    // On-the-fly, date-range-scoped replacement for UserAnalysisDataDao's lifetime counter.
+    // Atlas-only (atlasTrafficFilter=true) — the lifetime counter itself has no such split, so
+    // "All time" vs. a real range can disagree until that counter/cron gets the same scoping.
+    @Override
+    public List<UserAnalysisData> fetchUserAnalysisTokenTotals(int accountId, long startMs, long endMs) {
+        List<UserAnalysisData> rows = new ArrayList<>();
+        if (!isConfigured()) return rows;
+        try {
+            JSONObject filteredQuery = buildQuery(accountId, startMs, endMs, null, null, Boolean.TRUE);
+
+            JSONObject aggs = new JSONObject()
+                .put(AGG_USER_ANALYSIS_SERVICE, new JSONObject()
+                    .put("terms", new JSONObject()
+                        .put("field", AgentQueryRecord.F_SERVICE_ID_KW)
+                        .put("size", USER_ANALYSIS_SERVICE_SIZE))
+                    .put("aggs", new JSONObject()
+                        .put(AGG_USER_ANALYSIS_DEVICE, new JSONObject()
+                            .put("terms", new JSONObject()
+                                .put("field", AgentQueryRecord.F_DEVICE_ID_KW)
+                                .put("size", USER_ANALYSIS_DEVICE_SIZE))
+                            .put("aggs", tokenSubAggs()))));
+
+            JSONObject aggsResult = aggregate(filteredQuery, aggs);
+            if (aggsResult == null) return rows;
+
+            JSONObject serviceAgg = aggsResult.optJSONObject(AGG_USER_ANALYSIS_SERVICE);
+            JSONArray serviceBuckets = serviceAgg != null ? serviceAgg.optJSONArray("buckets") : null;
+            if (serviceBuckets == null) return rows;
+            // Unlike this file's "top N" aggs, this method must be exhaustive — warn if the
+            // service/device size caps truncated real data.
+            long otherServices = serviceAgg.optLong("sum_other_doc_count", 0);
+            if (otherServices > 0) {
+                logger.error("fetchUserAnalysisTokenTotals: accountId=" + accountId + " truncated "
+                    + otherServices + " docs beyond top " + USER_ANALYSIS_SERVICE_SIZE + " serviceIds");
+            }
+
+            for (int i = 0; i < serviceBuckets.length(); i++) {
+                JSONObject serviceBucket = serviceBuckets.optJSONObject(i);
+                if (serviceBucket == null) continue;
+                String serviceId = serviceBucket.optString("key", "");
+
+                JSONObject deviceAgg = serviceBucket.optJSONObject(AGG_USER_ANALYSIS_DEVICE);
+                JSONArray deviceBuckets = deviceAgg != null ? deviceAgg.optJSONArray("buckets") : null;
+                if (deviceBuckets == null) continue;
+                long otherDevices = deviceAgg.optLong("sum_other_doc_count", 0);
+                if (otherDevices > 0) {
+                    logger.error("fetchUserAnalysisTokenTotals: accountId=" + accountId + " serviceId=" + serviceId
+                        + " truncated " + otherDevices + " docs beyond top " + USER_ANALYSIS_DEVICE_SIZE + " deviceIds");
+                }
+
+                for (int j = 0; j < deviceBuckets.length(); j++) {
+                    JSONObject deviceBucket = deviceBuckets.optJSONObject(j);
+                    if (deviceBucket == null) continue;
+                    String deviceId = deviceBucket.optString("key", "");
+                    long in  = subAggLong(deviceBucket, AGG_IN_TOKENS);
+                    long out = subAggLong(deviceBucket, AGG_OUT_TOKENS);
+                    if (in == 0 && out == 0) continue;
+
+                    UserAnalysisData row = new UserAnalysisData();
+                    row.setId(new UserAnalysisDataKey(serviceId, deviceId));
+                    row.setTotalInputTokens(in);
+                    row.setTotalOutputTokens(out);
+                    rows.add(row);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("fetchUserAnalysisTokenTotals error for accountId=" + accountId + ": " + e.getMessage());
+        }
+        return rows;
     }
 
     // ── Spans for a single message/trace ──────────────────────────────────────

--- a/libs/utils/src/main/java/com/akto/utils/search/AzureDataExplorerClient.java
+++ b/libs/utils/src/main/java/com/akto/utils/search/AzureDataExplorerClient.java
@@ -2,6 +2,7 @@ package com.akto.utils.search;
 
 import com.akto.dao.agentic_sessions.AgentQueryTopicMappingDao;
 import com.akto.dto.agentic_sessions.AgentQueryTopicMapping;
+import com.akto.dto.agentic_sessions.UserAnalysisData;
 import com.akto.log.LoggerMaker;
 import com.akto.log.LoggerMaker.LogDb;
 import com.akto.utils.elasticsearch.AgentQueryRecord;
@@ -525,6 +526,13 @@ public class AzureDataExplorerClient extends SearchClient {
         }
         return new ArgusStats(aggTotalSpans, aggInputTokens, aggOutputTokens,
             aggTopApps, aggAppBreakdown, aggTopTraces, aggTraceSpark, aggTokenSpark, aggTraceSparkTs);
+    }
+
+    // Skipped for now on this backend — see ElasticSearchClient.fetchUserAnalysisTokenTotals for
+    // the intended shape when this gets picked back up.
+    @Override
+    public List<UserAnalysisData> fetchUserAnalysisTokenTotals(int accountId, long startMs, long endMs) {
+        return new ArrayList<>();
     }
 
     private long[] queryDataRange(String where, long fallbackMs) {

--- a/libs/utils/src/main/java/com/akto/utils/search/SearchClient.java
+++ b/libs/utils/src/main/java/com/akto/utils/search/SearchClient.java
@@ -1,5 +1,6 @@
 package com.akto.utils.search;
 
+import com.akto.dto.agentic_sessions.UserAnalysisData;
 import com.akto.utils.elasticsearch.AgentQueryRecord;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -59,6 +60,14 @@ public abstract class SearchClient {
 
     public abstract ArgusStats fetchArgusStats(
         int accountId, long startMs, long endMs, Boolean atlasTrafficFilter);
+
+    /**
+     * Time-ranged replacement for UserAnalysisDataDao's lifetime-total read — sums input/output
+     * tokens per (serviceId, deviceId) within [startMs, endMs). Only id/totalInputTokens/
+     * totalOutputTokens are populated; topic/summary fields are cron-computed elsewhere.
+     */
+    public abstract List<UserAnalysisData> fetchUserAnalysisTokenTotals(
+        int accountId, long startMs, long endMs);
 
     public abstract List<Map<String, Object>> fetchTraceDetail(
         int accountId, String traceId, Boolean atlasTrafficFilter);


### PR DESCRIPTION
- Updated `AgenticObserveAction` to only process "agent" rows for user analysis.
- Modified `EndpointShieldAgentAction` to support time range filtering for user analysis data.
- Adjusted `AgenticAssetsPage` to pass start and end timestamps when fetching user analysis.
- Enhanced `agenticObserveApi` to accept time range parameters in `listUserAnalysis`.
- Implemented new methods in `ElasticSearchClient` and `AzureDataExplorerClient` for fetching user analysis token totals based on time ranges.