### PR TITLE
Implement advanced traffic filter strategy for URL merging

### DIFF
--- a/apps/api-runtime/src/main/java/com/akto/parsers/HttpCallParser.java
+++ b/apps/api-runtime/src/main/java/com/akto/parsers/HttpCallParser.java
@@ -266,7 +266,11 @@ public class HttpCallParser {
                     }else{
                         filterType = FILTER_TYPE.ALLOWED;
                     }
-                    
+
+                    if (apiFilter.getStrategy() != null && Boolean.TRUE.equals(apiFilter.getStrategy().getDemerge())) {
+                        APICatalogSync.markUrlAsMerged(apiCollectionId, responseParam.getRequestParams().getURL(),
+                                responseParam.getRequestParams().getMethod());
+                    }
                 }
             } catch (Exception e) {
                 loggerMaker.errorAndAddToDb(e, String.format("Error in httpCallFilter %s", e.toString()));

--- a/apps/api-runtime/src/main/java/com/akto/runtime/APICatalogSync.java
+++ b/apps/api-runtime/src/main/java/com/akto/runtime/APICatalogSync.java
@@ -776,6 +776,10 @@ public class APICatalogSync {
             return null; // Don't merge GraphQL endpoints
         }
 
+        if (isUrlMerged(newUrl.getUrl(), newUrl.getMethod().name())) {
+            return null; // URL was flagged demerge:true by an advanced traffic filter
+        }
+
         for(int i = start; i < tokens.length; i ++) {
             String tempToken = tokens[i];
             if(DictionaryFilter.isEnglishWord(tempToken)) continue;
@@ -836,6 +840,10 @@ public class APICatalogSync {
 
         if(HttpResponseParams.isGraphQLEndpoint(dbUrl.getUrl()) || HttpResponseParams.isGraphQLEndpoint(newUrl.getUrl())) {
             return null; // Don't merge GraphQL endpoints
+        }
+
+        if (isUrlMerged(dbUrl.getUrl(), dbUrl.getMethod().name()) || isUrlMerged(newUrl.getUrl(), newUrl.getMethod().name())) {
+            return null; // One of the URLs was flagged demerge:true by an advanced traffic filter
         }
 
         for(int i = 0; i < newTokens.length; i ++) {
@@ -902,6 +910,35 @@ public class APICatalogSync {
         }
 
         return urlTemplate;
+    }
+
+    public static boolean isUrlMerged(String url, String method) {
+        for (MergedUrls entry : mergedUrls) {
+            if (entry.getUrl().equals(url) && entry.getMethod().equals(method)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void markUrlAsMerged(int apiCollectionId, String url, String method) {
+        if (isUrlMerged(url, method)) {
+            return;
+        }
+        try {
+            MergedUrlsDao.instance.updateOne(Filters.and(
+                    Filters.eq(MergedUrls.URL, url),
+                    Filters.eq(MergedUrls.METHOD, method),
+                    Filters.eq(MergedUrls.API_COLLECTION_ID, apiCollectionId)
+            ), Updates.combine(
+                    Updates.set(MergedUrls.URL, url),
+                    Updates.set(MergedUrls.METHOD, method),
+                    Updates.set(MergedUrls.API_COLLECTION_ID, apiCollectionId)
+            ));
+            mergedUrls.add(new MergedUrls(url, method, apiCollectionId));
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("Error while saving demerged url in DB: " + e.getMessage(), LogDb.RUNTIME);
+        }
     }
 
     public static void mergeUrlsAndSave(int apiCollectionId, Boolean urlRegexMatchingEnabled, boolean mergeUrlsBasic, BloomFilter<CharSequence> existingAPIsInDb,boolean ignoreCaseInsensitiveApis, boolean mergeUrlsOnVersions, boolean skipMergingOnKnownStaticURLsForVersionedApis) {

--- a/apps/api-runtime/src/main/java/com/akto/runtime/APICatalogSync.java
+++ b/apps/api-runtime/src/main/java/com/akto/runtime/APICatalogSync.java
@@ -79,6 +79,9 @@ public class APICatalogSync {
     public static final Pattern VERSION_PATTERN = Pattern.compile("\\bv([1-9][0-9]?|100)\\b");
 
     public static Set<MergedUrls> mergedUrls;
+    // Same merged_urls collection as mergedUrls, filtered to only the demerge:true rows
+    // (see MergedUrls#isDemerge for why this needs to stay a distinct in-memory view).
+    public static Set<MergedUrls> demergedUrls;
 
     public Map<String, FilterConfig> advancedFilterMap =  new HashMap<>();
 
@@ -100,6 +103,7 @@ public class APICatalogSync {
         this.sensitiveParamInfoBooleanMap = new HashMap<>();
         this.aktoPolicyNew = new AktoPolicyNew();
         mergedUrls = new HashSet<>();
+        demergedUrls = new HashSet<>();
         if (buildFromDb) {
             buildFromDB(false, fetchAllSTI);
             AccountSettings accountSettings = AccountSettingsDao.instance.findOne(AccountSettingsDao.generateFilter());
@@ -913,7 +917,7 @@ public class APICatalogSync {
     }
 
     public static boolean isUrlMerged(String url, String method) {
-        for (MergedUrls entry : mergedUrls) {
+        for (MergedUrls entry : demergedUrls) {
             if (entry.getUrl().equals(url) && entry.getMethod().equals(method)) {
                 return true;
             }
@@ -926,6 +930,9 @@ public class APICatalogSync {
             return;
         }
         try {
+            // Same merged_urls collection as genuine template merges, but flagged demerge:true
+            // so MergedUrlsDao#getMergedUrls (used by convertToMap to exclude already-merged
+            // urls from SingleTypeInfo writes) skips these rows instead of wrongly excluding them.
             MergedUrlsDao.instance.updateOne(Filters.and(
                     Filters.eq(MergedUrls.URL, url),
                     Filters.eq(MergedUrls.METHOD, method),
@@ -933,9 +940,10 @@ public class APICatalogSync {
             ), Updates.combine(
                     Updates.set(MergedUrls.URL, url),
                     Updates.set(MergedUrls.METHOD, method),
-                    Updates.set(MergedUrls.API_COLLECTION_ID, apiCollectionId)
+                    Updates.set(MergedUrls.API_COLLECTION_ID, apiCollectionId),
+                    Updates.set(MergedUrls.DEMERGE, true)
             ));
-            mergedUrls.add(new MergedUrls(url, method, apiCollectionId));
+            demergedUrls.add(new MergedUrls(url, method, apiCollectionId));
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb("Error while saving demerged url in DB: " + e.getMessage(), LogDb.RUNTIME);
         }
@@ -1734,6 +1742,7 @@ public class APICatalogSync {
         }
 
         mergedUrls = MergedUrlsDao.instance.getMergedUrls();
+        demergedUrls = MergedUrlsDao.instance.getDemergedUrls();
 
         loggerMaker.infoAndAddToDb("Building from db completed", LogDb.RUNTIME);
         aktoPolicyNew.buildFromDb(fetchAllSTI);

--- a/libs/dao/src/main/java/com/akto/dao/filter/MergedUrlsDao.java
+++ b/libs/dao/src/main/java/com/akto/dao/filter/MergedUrlsDao.java
@@ -3,6 +3,7 @@ package com.akto.dao.filter;
 import com.akto.dao.AccountsContextDao;
 import com.akto.dto.filter.MergedUrls;
 import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Filters;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -16,19 +17,30 @@ public class MergedUrlsDao extends AccountsContextDao<MergedUrls> {
         return "merged_urls";
     }
 
-    public Set<MergedUrls> getMergedUrls() {
-        MongoCursor<MergedUrls> cursor = instance.getMCollection().find().cursor();
+    private Set<MergedUrls> fetch(org.bson.conversions.Bson filter) {
+        MongoCursor<MergedUrls> cursor = instance.getMCollection().find(filter).cursor();
 
-        Set<MergedUrls> mergedUrls = new HashSet<>();
+        Set<MergedUrls> ret = new HashSet<>();
 
         while(cursor.hasNext()) {
-            MergedUrls mergedUrlsObj = cursor.next();
-            mergedUrls.add(mergedUrlsObj);
+            ret.add(cursor.next());
         }
 
         cursor.close();
 
-        return mergedUrls;
+        return ret;
+    }
+
+    // Urls genuinely absorbed into a template - excludes rows an advanced traffic
+    // filter's demerge:true strategy flagged (those must keep their own standalone
+    // SingleTypeInfo entries, see APICatalogSync#convertToMap).
+    public Set<MergedUrls> getMergedUrls() {
+        return fetch(Filters.ne(MergedUrls.DEMERGE, true));
+    }
+
+    // Urls flagged demerge:true - must never be folded into a template.
+    public Set<MergedUrls> getDemergedUrls() {
+        return fetch(Filters.eq(MergedUrls.DEMERGE, true));
     }
 
     @Override

--- a/libs/dao/src/main/java/com/akto/dao/monitoring/FilterConfigYamlParser.java
+++ b/libs/dao/src/main/java/com/akto/dao/monitoring/FilterConfigYamlParser.java
@@ -7,11 +7,13 @@ import java.util.Map;
 import com.akto.dao.api_protection_parse_layer.AggregationLayerParser;
 import com.akto.dao.test_editor.filter.ConfigParser;
 import com.akto.dao.test_editor.info.InfoParser;
+import com.akto.dao.test_editor.strategy.StrategyParser;
 import com.akto.dto.api_protection_parse_layer.AggregationRules;
 import com.akto.dto.monitoring.FilterConfig;
 import com.akto.dto.test_editor.ConfigParserResult;
 import com.akto.dto.test_editor.ExecutorConfigParserResult;
 import com.akto.dto.test_editor.Info;
+import com.akto.dto.test_editor.Strategy;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -124,6 +126,13 @@ public class FilterConfigYamlParser {
                     filterConfig.setFailureFilter(failureResult);
                 }
             }
+        }
+
+        // Parse strategy (e.g. demerge) if present
+        if (filterConfig != null && config.containsKey(FilterConfig.STRATEGY)) {
+            StrategyParser strategyParser = new StrategyParser();
+            Strategy strategy = strategyParser.parse(config.get(FilterConfig.STRATEGY));
+            filterConfig.setStrategy(strategy);
         }
 
         return filterConfig;

--- a/libs/dao/src/main/java/com/akto/dao/test_editor/strategy/StrategyParser.java
+++ b/libs/dao/src/main/java/com/akto/dao/test_editor/strategy/StrategyParser.java
@@ -24,6 +24,11 @@ public class StrategyParser {
             strategy.setInsertVulnApi((boolean) insertVulnApi);
         }
 
+        Object demerge = metadataMap.get("demerge");
+        if (demerge != null) {
+            strategy.setDemerge((Boolean) demerge);
+        }
+
         return strategy;
     }
 

--- a/libs/dao/src/main/java/com/akto/dto/filter/MergedUrls.java
+++ b/libs/dao/src/main/java/com/akto/dto/filter/MergedUrls.java
@@ -16,6 +16,17 @@ public class MergedUrls {
     public static final String API_COLLECTION_ID = "apiCollectionId";
     private int apiCollectionId;
 
+    /*
+     * True for a url an advanced traffic filter's demerge:true strategy flagged as
+     * "never merge into a template" - false/absent for a url that was genuinely
+     * absorbed into a template. Kept out of equals()/hashCode() on purpose so lookups
+     * by (url, method, apiCollectionId) are unaffected; callers that care about the
+     * distinction query by this field instead (see MergedUrlsDao#getMergedUrls vs
+     * #getDemergedUrls).
+     */
+    public static final String DEMERGE = "demerge";
+    private boolean demerge;
+
     public MergedUrls() {}
 
     public MergedUrls(String url, String method, int apiCollectionId) {
@@ -67,5 +78,13 @@ public class MergedUrls {
 
     public void setApiCollectionId(int apiCollectionId) {
         this.apiCollectionId = apiCollectionId;
+    }
+
+    public boolean isDemerge() {
+        return demerge;
+    }
+
+    public void setDemerge(boolean demerge) {
+        this.demerge = demerge;
     }
 }

--- a/libs/dao/src/main/java/com/akto/dto/monitoring/FilterConfig.java
+++ b/libs/dao/src/main/java/com/akto/dto/monitoring/FilterConfig.java
@@ -8,6 +8,7 @@ import com.akto.dto.api_protection_parse_layer.AggregationRules;
 import com.akto.dto.test_editor.ConfigParserResult;
 import com.akto.dto.test_editor.ExecutorConfigParserResult;
 import com.akto.dto.test_editor.Info;
+import com.akto.dto.test_editor.Strategy;
 
 public class FilterConfig {
     private String id;
@@ -29,6 +30,8 @@ public class FilterConfig {
     private AggregationRules aggregationRules;
     public static final String _INFO = "info";
     private Info info;
+    public static final String STRATEGY = "strategy";
+    private Strategy strategy;
     public static final String DEFAULT_ALLOW_FILTER = "DEFAULT_ALLOW_FILTER";
     public static final String DEFAULT_BLOCK_FILTER = "DEFAULT_BLOCK_FILTER";
 
@@ -164,6 +167,14 @@ public class FilterConfig {
 
     public void setFailureFilter(ConfigParserResult failureFilter) {
         this.failureFilter = failureFilter;
+    }
+
+    public Strategy getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(Strategy strategy) {
+        this.strategy = strategy;
     }
 
 }

--- a/libs/dao/src/main/java/com/akto/dto/test_editor/Strategy.java
+++ b/libs/dao/src/main/java/com/akto/dto/test_editor/Strategy.java
@@ -4,6 +4,7 @@ public class Strategy {
     
     private String runOnce;
     private boolean insertVulnApi;
+    private Boolean demerge;
 
     public Strategy(String runOnce, boolean insertVulnApi) {
         this.runOnce = runOnce;
@@ -28,5 +29,13 @@ public class Strategy {
     public void setInsertVulnApi(boolean insertVulnApi) {
         this.insertVulnApi = insertVulnApi;
     }
-    
+
+    public Boolean getDemerge() {
+        return demerge;
+    }
+
+    public void setDemerge(Boolean demerge) {
+        this.demerge = demerge;
+    }
+
 }


### PR DESCRIPTION
- Added support for a new strategy in the FilterConfig to handle demerge functionality.
- Enhanced HttpCallParser to mark URLs as merged based on the demerge strategy.
- Introduced methods in APICatalogSync to check and mark URLs as merged, preventing merging of flagged URLs.
- Updated FilterConfigYamlParser to parse the new strategy configuration from YAML files.