### PR TITLE
Add jetty-context.xml for internal service configuration and update Dockerfile

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -395,7 +395,7 @@ jobs:
           [ "$BUILD_DASHBOARD" = "true" ] && add_files apps/dashboard target/dashboard.war set_xmx.sh gzip.ini
           [ "$BUILD_TESTING" = "true" ] && add_files apps/testing target/testing-1.0-SNAPSHOT-jar-with-dependencies.jar start.sh
           [ "$BUILD_BILLING" = "true" ] && add_files apps/billing target/billing.war
-          [ "$BUILD_INTERNAL" = "true" ] && add_files apps/internal target/internal.war
+          [ "$BUILD_INTERNAL" = "true" ] && add_files apps/internal target/internal.war jetty-context.xml
           [ "$BUILD_THREAT" = "true" ] && add_files apps/threat-detection target/threat-detection-1.0-SNAPSHOT-jar-with-dependencies.jar start.sh
           [ "$BUILD_THREAT_BACKEND" = "true" ] && add_files apps/threat-detection-backend target/threat-detection-backend-1.0-SNAPSHOT-jar-with-dependencies.jar start.sh
           [ "$BUILD_ACCOUNT_EXECUTOR" = "true" ] && add_files apps/account-job-executor target/account-job-executor-1.0-SNAPSHOT-jar-with-dependencies.jar start.sh

--- a/apps/internal/Dockerfile
+++ b/apps/internal/Dockerfile
@@ -6,4 +6,5 @@ ADD ./target/internal.war /var/lib/jetty/webapps/root.war
 RUN echo "--module=http-forwarded" > /var/lib/jetty/start.d/http-forwarded.ini
 RUN echo "jetty.httpConfig.sendServerVersion=false" > /var/lib/jetty/start.d/server.ini
 RUN echo "org.slf4j.simpleLogger.log.org.eclipse.jetty.annotations.AnnotationParser=ERROR" >> /var/lib/jetty/start.d/server.ini
+COPY ./jetty-context.xml /var/lib/jetty/webapps/root.xml
 EXPOSE 8080

--- a/apps/internal/jetty-context.xml
+++ b/apps/internal/jetty-context.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="contextPath">/</Set>
+  <Set name="war"><Property name="jetty.webapps" default="/var/lib/jetty/webapps"/>/root.war</Set>
+
+  <Set name="tempDirectory">/var/lib/jetty/work/root</Set>
+  <Set name="persistTempDirectory">false</Set>
+
+  <Call name="setAttribute">
+    <Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
+    <Arg>^$</Arg>
+  </Call>
+</Configure>


### PR DESCRIPTION
## RCA + fix: `akto-internal` OOM crash-loop filling the dashboard VM disk

### Root cause

`akto-internal` was OOM-killed on nearly every boot (`RestartCount=23`, `OOMKilled=true`, kills ~10s apart in `dmesg`). Jetty only deletes its unpacked-WAR scratch directory on a **graceful** shutdown i.e. `SIGKILL` can't be trapped, so every crash orphaned a ~108MB directory under `/tmp` in the container's writable layer.

Why it OOM'd: the JVM sat at **195MB anon inside a 200MB cap** before serving a single request. A heap histogram showed the memory going to Jetty's startup annotation scan - **46,918 `JarFileResource` + 47,711 `URL` + 178,434 char arrays (38MB)** , from bytecode-scanning all 213 bundled jars for annotations this app doesn't use (everything is declared in `web.xml`).

Not a leak: memory was flat over time, and a Full GC moved tenured only 80,175K → 77,584K.

### The fix

One new file (`apps/internal/jetty-context.xml`), wired in with one `COPY`:

| Setting | Fixes |
|---|---|
| `tempDirectory` → fixed path | Jetty unpacks to one fixed folder instead of a new random `/tmp` folder per boot |
| `WebInfIncludeJarPattern=^$` | Skips annotation-scanning `WEB-INF/lib` (unused here; no classes are removed, loading stays lazy) |

### Benchmarks `mem_limit: 200m`

| Metric | Before | After | Change |
|---|---|---|---|
| anon memory (idle) | 195 MB (98% of cap) | **110 MB (55%)** | **−44%** |
| anon memory (20-concurrent × 3 burst) | OOM-killed | **142 MB (71%)** | 58 MB headroom |
| annotation scan | 1885 ms | **9 ms** | **210× faster** |
| startup | 3858 ms | **1152 ms** | **3.3× faster** |
| orphaned dirs after 2 OOM-kills | 2, unbounded growth | **0** | leak eliminated |
| restarts under load | crash loop (23+) | **0** | stable |