### PR TITLE
add: fetch multiple agents (batched context graph)

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
@@ -627,7 +627,12 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             }
             if ("agent".equals(rowType) && !isConnectorIngested(envType)) {
                 String serviceName = extractServiceNameForGrouping(hostName);
-                if (serviceName != null && !serviceName.equalsIgnoreCase(groupKey)) {
+                // groupKey is the canonical registry key (e.g. "claude2"), but serviceName is the raw
+                // hostname segment (e.g. "claudecli"/"claude-cli-project") — comparing them directly
+                // never matches for any agent whose raw tag value differs from its canonical key, so
+                // the agent's own identity collection was being added as if it were one of its own
+                // linked MCP servers. Canonicalize serviceName the same way groupKey was derived.
+                if (serviceName != null && !McpClientRegistry.resolveClientKey(serviceName).equalsIgnoreCase(groupKey)) {
                     serviceNames.add(serviceName);
                     serviceCollectionIds.computeIfAbsent(serviceName, k -> new HashSet<>()).add(c.getId());
                 }
@@ -2338,6 +2343,7 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
 
     @Setter private String groupKey;
     @Setter private String rowType;
+    @Setter private List<String> groupKeys;
 
     @Getter private List<String> assetHostNames;
     @Getter private List<Integer> assetCollectionIds;
@@ -2612,6 +2618,76 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
         } catch (Exception e) {
             loggerMaker.errorAndAddToDb("Error fetching agentic asset detail: " + e.getMessage());
             addActionError("Error fetching agentic asset detail: " + e.getMessage());
+            return ERROR.toUpperCase();
+        }
+    }
+
+    /**
+     * Batch form of fetchAgenticAssetDetail, scoped to just the fields the device flyout's
+     * context graph needs per agent (mcpServers/mcpServerCollectionIds/skillCount/pluginNames) —
+     * a device can show 10+ AI Agents, and firing fetchAgenticAssetDetail once per agent means
+     * that many concurrent requests just to draw one graph. getOrBuildClassification is called
+     * once for the whole batch (not once per groupKey); every other rowType-specific branch in
+     * fetchAgenticAssetDetail (plugin reverse-lookup, device sampling, inline topology) is left
+     * out here since the device flyout graph doesn't use them.
+     */
+    public String fetchAgenticAssetDetailsBatch() {
+        response = new BasicDBObject();
+        Map<String, BasicDBObject> byGroupKey = new HashMap<>();
+        try {
+            if (groupKeys == null || groupKeys.isEmpty() || StringUtils.isBlank(rowType)) {
+                response.put("detailsByGroupKey", byGroupKey);
+                return SUCCESS.toUpperCase();
+            }
+
+            Map<String, Integer> traffic = trafficMap != null ? trafficMap : Collections.emptyMap();
+            Map<String, Double> risk = riskScoreMap != null ? riskScoreMap : Collections.emptyMap();
+            ClassificationCacheEntry cached = getOrBuildClassification(traffic, risk, Collections.emptyMap());
+            Map<Integer, ApiCollection> byId = new HashMap<>();
+            for (ApiCollection c : cached.collections) byId.put(c.getId(), c);
+
+            for (String key : groupKeys) {
+                GroupSummary g = cached.groups.get(rowType + "|" + key);
+                BasicDBObject item = new BasicDBObject();
+                if (g == null) {
+                    item.put("mcpServers", Collections.emptyList());
+                    item.put("mcpServerCollectionIds", Collections.emptyMap());
+                    item.put("llmServers", Collections.emptyList());
+                    item.put("skillCount", 0);
+                    item.put("pluginNames", Collections.emptyList());
+                } else {
+                    item.put("mcpServers", new ArrayList<>(g.serviceNames));
+                    Map<String, List<Integer>> serviceCollectionIdsOut = new HashMap<>();
+                    // serviceNames is one flat set of everything linked to this agent, so callers
+                    // can't tell an LLM from an MCP server on their own — split out the LLMs using
+                    // the same classifier every other surface uses (buildDeviceChildren's row
+                    // types, the flyout's own stat counts). Deliberately NOT a raw tag check: a
+                    // gen-ai tag means AI Agent, not LLM, and an mcp-server tag outranks both.
+                    List<String> llmServers = new ArrayList<>();
+                    for (Map.Entry<String, Set<Integer>> e : g.serviceCollectionIds.entrySet()) {
+                        serviceCollectionIdsOut.put(e.getKey(), new ArrayList<>(e.getValue()));
+                        for (Integer id : e.getValue()) {
+                            ApiCollection c = byId.get(id);
+                            if (c == null) continue;
+                            if (AgenticObserveUtil.CLIENT_TYPE_LLM.equals(AgenticObserveUtil.getTypeFromCollection(c))) {
+                                llmServers.add(e.getKey());
+                                break;
+                            }
+                        }
+                    }
+                    item.put("mcpServerCollectionIds", serviceCollectionIdsOut);
+                    item.put("llmServers", llmServers);
+                    item.put("skillCount", g.skillNames.size());
+                    item.put("pluginNames", new ArrayList<>(g.pluginNames));
+                }
+                byGroupKey.put(key, item);
+            }
+
+            response.put("detailsByGroupKey", byGroupKey);
+            return SUCCESS.toUpperCase();
+        } catch (Exception e) {
+            loggerMaker.errorAndAddToDb("Error fetching agentic asset details batch: " + e.getMessage());
+            addActionError("Error fetching agentic asset details batch: " + e.getMessage());
             return ERROR.toUpperCase();
         }
     }
@@ -3285,7 +3361,33 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             int skillCount = c.getSkills() != null ? c.getSkills().size() : 0;
 
             final String fServiceName = serviceName;
-            String childType = AgenticObserveUtil.getTypeFromCollection(c);
+            // getTypeFromCollection alone isn't enough here: it classifies purely off which type tags
+            // are present, and a known client like claude-cli/cursor commonly carries mcp-client (not
+            // ai-agent) plus its own mcp-server tag — which getTypeFromCollection resolves to MCP
+            // Server. classifyAllGroups avoids this by checking the asset-owner tag through
+            // McpClientRegistry FIRST for its "agent" rows; mirror that same precedence here so a
+            // known client is classified as AI Agent (or SaaS Agent) rather than falling through to
+            // the raw tag-based MCP Server default.
+            boolean isPlugin = AgenticObserveUtil.isPluginCollection(c);
+            CollectionTags assetTag = isPlugin ? null : AgenticObserveUtil.findAssetTag(c);
+            boolean ownedByAgent = assetTag != null && StringUtils.isNotBlank(assetTag.getValue())
+                    && !Constants.AKTO_BROWSER_LLM_AGENT_TAG.equals(assetTag.getKeyName());
+            String childType;
+            if (isPlugin) {
+                childType = AgenticObserveUtil.CLIENT_TYPE_PLUGIN;
+            } else if (ownedByAgent) {
+                String key = McpClientRegistry.resolveClientKey(assetTag.getValue());
+                childType = AgenticObserveUtil.hasSaasAgentTag(c)
+                        ? AgenticObserveUtil.CLIENT_TYPE_SAAS_AGENT
+                        : McpClientRegistry.getAgentTypeFromValue(key);
+            } else {
+                childType = AgenticObserveUtil.getTypeFromCollection(c);
+            }
+            // Same key classifyAllGroups uses for "agent" GroupSummary rows (McpClientRegistry.
+            // resolveClientKey off the asset tag, not this row's own rawServiceName/hostname
+            // parsing) — lets the frontend look this agent up via fetchAgenticAssetDetailsBatch.
+            final CollectionTags fAssetTag = AgenticObserveUtil.CLIENT_TYPE_AI_AGENT.equals(childType)
+                    ? assetTag : null;
             BasicDBObject child = children.computeIfAbsent(pathKey, k -> {
                 BasicDBObject row = new BasicDBObject();
                 row.put("path", Arrays.asList(deviceId, k));
@@ -3293,6 +3395,10 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
                 row.put("endpoint", McpClientRegistry.formatDisplayName(fServiceName));
                 row.put("rawServiceName", fServiceName);
                 row.put("type", childType);
+                if (fAssetTag != null && StringUtils.isNotBlank(fAssetTag.getValue())) {
+                    row.put("groupKey", McpClientRegistry.resolveClientKey(fAssetTag.getValue()));
+                    row.put("rowType", "agent");
+                }
                 return row;
             });
             double[] rt = childRisk.computeIfAbsent(pathKey, k -> new double[2]);

--- a/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
@@ -3334,6 +3334,9 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
         Map<String, double[]> childRisk = new HashMap<>(); // pathKey -> {riskScore, lastTraffic}
         Map<String, int[]> childViolations = new HashMap<>();
         Map<String, Integer> childSkillCount = new HashMap<>();
+        // Only ever read for a direct (non-agent) MCP Server row's own tools — an agent's linked
+        // MCP servers get their collection ids from fetchAgenticAssetDetailsBatch instead.
+        Map<String, Set<Integer>> childCollectionIds = new HashMap<>();
         // Plugins live in their own child row (own collection), not embedded in the agent's — so
         // "how many plugins does this agent have" is answered by matching sibling plugin children
         // under the same device to this agent's own owner tag (mcp-client/ai-agent value).
@@ -3405,6 +3408,7 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             if (collRisk > rt[0]) rt[0] = collRisk;
             if (collTraffic > rt[1]) rt[1] = collTraffic;
             childSkillCount.merge(pathKey, skillCount, Math::max);
+            childCollectionIds.computeIfAbsent(pathKey, k -> new HashSet<>()).add(c.getId());
             if (AgenticObserveUtil.CLIENT_TYPE_AI_AGENT.equals(childType)) {
                 CollectionTags ownerTag = AgenticObserveUtil.findAssetTag(c);
                 if (ownerTag != null) ownerTagByPathKey.put(pathKey, ownerTag.getValue());
@@ -3431,6 +3435,10 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
             row.put("lastTrafficEpoch", (int) rt[1]);
             int skillCount = childSkillCount.getOrDefault(pathKey, 0);
             if (skillCount > 0) row.put("skillCount", skillCount);
+            if ("MCP Server".equals(row.getString("type"))) {
+                Set<Integer> ids = childCollectionIds.get(pathKey);
+                if (ids != null && !ids.isEmpty()) row.put("collectionIds", new ArrayList<>(ids));
+            }
             String ownerTagValue = ownerTagByPathKey.get(pathKey);
             int pluginCount = ownerTagValue != null ? pluginCountByOwnerTag.getOrDefault(ownerTagValue, 0) : 0;
             if (pluginCount > 0) row.put("pluginCount", pluginCount);

--- a/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/AgenticObserveAction.java
@@ -3365,16 +3365,22 @@ public class AgenticObserveAction extends AbstractThreatDetectionAction {
 
             final String fServiceName = serviceName;
             // getTypeFromCollection alone isn't enough here: it classifies purely off which type tags
-            // are present, and a known client like claude-cli/cursor commonly carries mcp-client (not
-            // ai-agent) plus its own mcp-server tag — which getTypeFromCollection resolves to MCP
-            // Server. classifyAllGroups avoids this by checking the asset-owner tag through
-            // McpClientRegistry FIRST for its "agent" rows; mirror that same precedence here so a
-            // known client is classified as AI Agent (or SaaS Agent) rather than falling through to
-            // the raw tag-based MCP Server default.
+            // are present, and a known client like claude-cli/cursor commonly carries ONLY an
+            // mcp-client tag (no ai-agent/mcp-server/gen-ai tag of its own) — which getTypeFromCollection
+            // falls through to its raw MCP Server default. Mirror classifyAllGroups' precedent of
+            // checking the asset-owner tag through McpClientRegistry so a known client still resolves
+            // to AI Agent (or SaaS Agent) instead.
+            // But when the collection DOES carry its own definitive type tag (mcp-server/gen-ai/
+            // browser-llm) — e.g. an Atlassian-hosted MCP server tagged mcp-client=kiroide to record
+            // who it belongs to, or a client's own locally-hosted MCP sub-server (mcp-client=
+            // claude-desktop + mcp-server=MCP Server) — that own tag wins instead, same as
+            // findTypeTag's "mcp-server wins regardless of tag insertion order" rule. Otherwise this
+            // row would show up mislabeled with the SERVER's name but the OWNER's agent type.
             boolean isPlugin = AgenticObserveUtil.isPluginCollection(c);
             CollectionTags assetTag = isPlugin ? null : AgenticObserveUtil.findAssetTag(c);
             boolean ownedByAgent = assetTag != null && StringUtils.isNotBlank(assetTag.getValue())
-                    && !Constants.AKTO_BROWSER_LLM_AGENT_TAG.equals(assetTag.getKeyName());
+                    && !Constants.AKTO_BROWSER_LLM_AGENT_TAG.equals(assetTag.getKeyName())
+                    && AgenticObserveUtil.findTypeTag(c) == null;
             String childType;
             if (isPlugin) {
                 childType = AgenticObserveUtil.CLIENT_TYPE_PLUGIN;

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -13619,6 +13619,28 @@
             </result>
         </action>
 
+        <action name="api/fetchAgenticAssetDetailsBatch" class="com.akto.action.AgenticObserveAction" method="fetchAgenticAssetDetailsBatch">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <interceptor-ref name="roleAccessInterceptor">
+                <param name="featureLabel">API_COLLECTIONS</param>
+                <param name="accessType">READ</param>
+            </interceptor-ref>
+            <result name="SUCCESS" type="json">
+                <param name="root">response</param>
+            </result>
+            <result name="FORBIDDEN" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/attributeViolationCountsToCollections" class="com.akto.action.AgenticObserveAction" method="attributeViolationCountsToCollections">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/AgGridTable.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/AgGridTable.jsx
@@ -356,32 +356,34 @@ export default function AgGridTable({
     ) : null;
 
     // ── Grid node ───────────────────────────────────────────────────────────
-    // Same reasoning as effectiveSideBar above: also closes off the right-click context menu's
-    // "Group by"/"Pivot"/"Aggregate" options, which key off these column flags independently of
-    // whatever the side panel shows.
+    // Row Group / Values / Pivot Mode never make sense in this app's tables (asset/entity lists,
+    // not analytics grids) — unconditionally off, not just on a server-paginated table where they'd
+    // also be misleading (operating on whatever page happens to be loaded client-side).
     const effectiveDefaultColDef = React.useMemo(() => ({
-        enableRowGroup: !isServerMode,
-        enablePivot: !isServerMode,
-        enableValue: !isServerMode,
+        enableRowGroup: false,
+        enablePivot: false,
+        enableValue: false,
         ...defaultColDef,
-    }), [defaultColDef, isServerMode]);
+    }), [defaultColDef]);
 
-    // Row Group / Values / Pivot Mode in the Columns tool panel only ever operate on whatever
-    // page happens to be loaded in the grid right now — meaningless (and misleading) on a
-    // server-paginated table, which never holds the full dataset client-side. Column show/hide
-    // and the Filters panel are unaffected; those already work correctly against the real query.
+    // Mirrors effectiveDefaultColDef above: also closes the Columns tool panel's own Row
+    // Group/Values/Pivot Mode UI, and the right-click context menu's "Group by"/"Pivot"/
+    // "Aggregate" options (which key off the columnDef flags above independently of this panel).
+    // Column show/hide and the Filters panel are unaffected. `sideBar` shorthand `true` (AG Grid's
+    // own default) is expanded to the same panel set first so it gets the same treatment.
     const effectiveSideBar = useMemo(() => {
-        if (!isServerMode || !sideBar || sideBar === true) return sideBar;
-        const toolPanels = (sideBar.toolPanels || []).map((panel) => {
+        if (!sideBar) return sideBar;
+        const base = sideBar === true ? { toolPanels: ["columns", "filters"] } : sideBar;
+        const toolPanels = (base.toolPanels || []).map((panel) => {
             const isColumnsPanel = panel === "columns" || panel?.toolPanel === "agColumnsToolPanel";
             if (!isColumnsPanel) return panel;
-            const base = panel === "columns"
+            const basePanel = panel === "columns"
                 ? { id: "columns", labelDefault: "Columns", labelKey: "columns", iconKey: "columns", toolPanel: "agColumnsToolPanel" }
                 : panel;
             return {
-                ...base,
+                ...basePanel,
                 toolPanelParams: {
-                    ...base.toolPanelParams,
+                    ...basePanel.toolPanelParams,
                     suppressRowGroups: true,
                     suppressValues: true,
                     suppressPivots: true,
@@ -389,8 +391,8 @@ export default function AgGridTable({
                 },
             };
         });
-        return { ...sideBar, toolPanels };
-    }, [sideBar, isServerMode]);
+        return { ...base, toolPanels };
+    }, [sideBar]);
 
     const gridNode = (
         <AgGridReact

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AssetTopologyGraph.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/AssetTopologyGraph.jsx
@@ -1,17 +1,20 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import ReactFlow, { Handle, Position, Background, Controls } from "react-flow-renderer";
 import { Box, HorizontalStack, VerticalStack, Text, Card, Icon, Avatar, Tooltip } from "@shopify/polaris";
-import { AutomationMajor, MagicMajor, CustomersMinor } from "@shopify/polaris-icons";
+import { AutomationMajor, MagicMajor, CustomersMinor, ToolsMajor } from "@shopify/polaris-icons";
 import MCPIcon from "@/assets/MCP_Icon.svg";
 import PluginIcon from "@/assets/Plugin.svg";
-import { getAgentLinkedComponents, buildMcpComponentsFromStis } from "./agenticPageBuilders";
-import agenticObserveApi from "./agenticObserveApi";
+import { getAgentLinkedComponents } from "./agenticPageBuilders";
+import { capToolLabels, TOOL_EDGE_COLOR, useMcpTools, withToolRows } from "./topologyTools";
 
 export function topoColors(category) {
     switch (category) {
         case "external": return { borderColor: "#3b82f6", backgroundColor: "#eff6ff" };
         case "agent":    return { borderColor: "#f97316", backgroundColor: "#fff7ed" };
         case "mcp":      return { borderColor: "#4cbebb", backgroundColor: "#ecfdf5" };
+        // Tools hang off MCP nodes, so they deliberately don't reuse mcp's teal — amber keeps a
+        // tool readable as its own thing rather than looking like another MCP Server.
+        case "tool":     return { borderColor: TOOL_EDGE_COLOR, backgroundColor: "#FFFBEB" };
         case "ai-model": return { borderColor: "#ec4899", backgroundColor: "#fdf2f8" };
         case "skill":    return { borderColor: "#7C3AED", backgroundColor: "#F3E8FF" };
         case "plugin":   return { borderColor: "#4F46E5", backgroundColor: "#EEF2FF" };
@@ -24,6 +27,7 @@ export function topoIcon(category) {
         case "external": return CustomersMinor;
         case "agent":    return AutomationMajor;
         case "mcp":      return MCPIcon;
+        case "tool":     return ToolsMajor;
         case "ai-model": return MagicMajor;
         case "skill":    return AutomationMajor;
         case "plugin":   return PluginIcon;
@@ -72,8 +76,22 @@ export function TopoNode({ data }) {
 export const TOPO_NODE_TYPES = { topoNode: TopoNode };
 
 const NODE_H = 84;
-const TOOL_H = 40;
 const GRAPH_H = 300;
+const NODE_W = 176;    // rendered node box, for centering on the focus node
+const FOCUS_ZOOM = 1;
+
+// Opens centred on the asset the flyout is actually about (the device on Endpoints, the agent/MCP
+// on Agentic Assets) instead of a fitView that shrinks everything to fit the widest branch.
+function centerOnFocus(api, nodes, focusId) {
+    const target = nodes.find(n => n.id === focusId);
+    if (!target) { api.fitView({ padding: 0.2 }); return; }
+    // getNode returns the store's copy, which carries the *measured* box — the node's width comes
+    // from TopoNode's label widths, so hardcoding it here would drift the moment those change.
+    const measured = api.getNode?.(focusId);
+    const w = measured?.width || NODE_W;
+    const h = measured?.height || NODE_H;
+    api.setCenter(target.position.x + w / 2, target.position.y + h / 2, { zoom: FOCUS_ZOOM });
+}
 
 // Returns parent AI Agent flat rows for an MCP/Skill asset.
 export function findParentAgents(asset, agenticFlatData = []) {
@@ -107,14 +125,29 @@ function buildDeviceItems(devices, deviceCount) {
     return items;
 }
 
-export default function AssetTopologyGraph({ asset, assetDevices = {}, agenticTreeData = [], agenticFlatData = [], inlineComponents = [], nodes: externalNodes, edges: externalEdges }) {
-    const { nodes: baseNodes, edges: baseEdges, height } = useMemo(() => {
+export default function AssetTopologyGraph({ asset, assetDevices = {}, agenticTreeData = [], agenticFlatData = [], inlineComponents = [], nodes: externalNodes, edges: externalEdges, height: externalHeight, focusNodeId }) {
+    // Each MCP's own tools, keyed by collection id — the extra hop the Endpoints graph shows.
+    // Only for our own layout; a caller that supplies nodes reserves its own tool rows.
+    const mcpCollectionIds = useMemo(() => {
+        if (externalNodes) return [];
+        // An agent needs one id per linked MCP; an MCP asset opened on its own needs its own
+        // collections, since the tools it exposes are spread across them.
+        const ids = asset?.type === "AI Agent"
+            ? Object.values(asset.mcpServerCollectionIds || {}).map(a => a?.[0])
+            : asset?.type === "MCP Server" ? (asset.collectionIds || []) : [];
+        return [...new Set(ids.filter(Boolean))];
+    }, [asset, externalNodes]);
+
+    const mcpTools = useMcpTools(mcpCollectionIds);
+
+    const { nodes, edges, height, focusId } = useMemo(() => {
         if (externalNodes && externalEdges) {
-            return { nodes: externalNodes, edges: externalEdges, height: GRAPH_H };
+            // Callers that lay out their own nodes (DeviceFlyout.jsx) size the box to their content.
+            return { nodes: externalNodes, edges: externalEdges, height: externalHeight || GRAPH_H, focusId: focusNodeId };
         }
 
         const devices = buildDeviceItems(assetDevices[asset.id] || [], asset.deviceCount);
-        const COL1 = 40, COL2 = 230, COL3 = 420;
+        const COL1 = 40, COL2 = 230, COL3 = 420, COL4 = 610;
 
         if (asset.type === "AI Agent") {
             const children = getAgentLinkedComponents(asset, agenticTreeData, agenticFlatData);
@@ -138,28 +171,34 @@ export default function AssetTopologyGraph({ asset, assetDevices = {}, agenticTr
 
             // MCPs, LLMs, Skills, inline tools/LLM on agent host — same hierarchy level
             const col3Items = [
-                ...mcps.map((m, i) => ({ id: `mcp-${i}`, cat: "mcp",      type: "MCP Server", label: m.name, edgeColor: "#4cbebb", collectionId: m.collectionIds?.[0] })),
+                ...mcps.map((m, i) => ({ id: `mcp-${i}`, cat: "mcp",      type: "MCP Server", label: m.name, edgeColor: "#4cbebb", collectionId: asset.mcpServerCollectionIds?.[m.name]?.[0] })),
                 ...llms.map((l, i) => ({ id: `llm-${i}`, cat: "ai-model", type: "LLM",        label: l.name, edgeColor: "#ec4899" })),
                 ...skillItems,
                 ...pluginItems,
                 ...inlineItems,
             ];
 
-            const maxRows   = Math.max(devices.length, col3Items.length, 1);
+            const rows      = withToolRows(col3Items, mcpTools);
+            const maxRows   = Math.max(devices.length, rows.length, 1);
             const totalH    = maxRows * NODE_H;
             const agentY    = (totalH - 44) / 2;
-            const devOffset = Math.max(0, (col3Items.length - devices.length) * NODE_H / 2);
+            const devOffset = Math.max(0, (rows.length - devices.length) * NODE_H / 2);
 
             return {
                 height: GRAPH_H,
+                focusId: "agent",
                 nodes: [
                     { id: "agent", type: "topoNode", draggable: false, position: { x: COL2, y: agentY }, data: { component: { category: "agent", type: "AI Agent", label: asset.name } } },
                     ...devices.map((d, i) => ({ id: d.id, type: "topoNode", draggable: false, position: { x: COL1, y: devOffset + i * NODE_H }, data: { component: { category: "external", type: d.type, label: d.label } } })),
-                    ...col3Items.map((item, i) => ({ id: item.id, type: "topoNode", draggable: false, position: { x: COL3, y: i * NODE_H }, data: { component: { category: item.cat, type: item.type, label: item.label, collectionId: item.collectionId } } })),
+                    ...rows.map((row, i) => (row.tool
+                        ? { id: row.tool.id, type: "topoNode", draggable: false, position: { x: COL4, y: i * NODE_H }, data: { component: { category: "tool", type: "Tool", label: row.tool.label } } }
+                        : { id: row.item.id, type: "topoNode", draggable: false, position: { x: COL3, y: i * NODE_H }, data: { component: { category: row.item.cat, type: row.item.type, label: row.item.label } } })),
                 ],
                 edges: [
                     ...devices.map(d => ({ id: `e-${d.id}-a`,   source: d.id, target: "agent",   type: "smoothstep", style: { stroke: "#9CA3AF", strokeWidth: 1.5 } })),
-                    ...col3Items.map(item   => ({ id: `e-a-${item.id}`, source: "agent",    target: item.id,  type: "smoothstep", style: { stroke: item.edgeColor, strokeWidth: 1.5 } })),
+                    ...rows.map(row => (row.tool
+                        ? { id: `e-${row.tool.id}`, source: row.item.id, target: row.tool.id, type: "smoothstep", style: { stroke: TOOL_EDGE_COLOR, strokeWidth: 1.5 } }
+                        : { id: `e-a-${row.item.id}`, source: "agent", target: row.item.id, type: "smoothstep", style: { stroke: row.item.edgeColor, strokeWidth: 1.5 } })),
                 ],
             };
         }
@@ -174,8 +213,23 @@ export default function AssetTopologyGraph({ asset, assetDevices = {}, agenticTr
         const cat     = asset.type === "MCP Server" ? "mcp" : asset.type === "Skill" ? "skill" : asset.type === "Plugin" ? "plugin" : "ai-model";
         const edgeCol = asset.type === "MCP Server" ? "#4cbebb" : asset.type === "Skill" ? "#7C3AED" : asset.type === "Plugin" ? "#4F46E5" : "#ec4899";
 
+        // An MCP asset's own tools, hanging off it the same way they hang off an agent's MCPs.
+        // Unioned across the asset's collections, since one MCP group can span several.
+        const assetToolLabels = asset.type === "MCP Server"
+            ? capToolLabels([...new Set((asset.collectionIds || []).flatMap(id => mcpTools[id] || []))])
+            : [];
+        const toolNodesAt = (x) => assetToolLabels.map((label, i) => ({
+            id: `asset-tool-${i}`, type: "topoNode", draggable: false,
+            position: { x, y: i * NODE_H },
+            data: { component: { category: "tool", type: "Tool", label } },
+        }));
+        const toolEdges = assetToolLabels.map((_, i) => ({
+            id: `e-as-tool-${i}`, source: "asset", target: `asset-tool-${i}`,
+            type: "smoothstep", style: { stroke: TOOL_EDGE_COLOR, strokeWidth: 1.5 },
+        }));
+
         if (parentAgents.length > 0) {
-            const maxRows   = Math.max(devices.length, parentAgents.length, 1);
+            const maxRows   = Math.max(devices.length, parentAgents.length, assetToolLabels.length, 1);
             const totalH    = maxRows * NODE_H;
             const assetY    = (totalH - 44) / 2;
             const devOffset = Math.max(0, (parentAgents.length - devices.length) * NODE_H / 2);
@@ -183,69 +237,46 @@ export default function AssetTopologyGraph({ asset, assetDevices = {}, agenticTr
 
             return {
                 height: GRAPH_H,
+                focusId: "asset",
                 nodes: [
                     { id: "asset", type: "topoNode", draggable: false, position: { x: COL3, y: assetY }, data: { component: { category: cat, type: asset.type, label: asset.name } } },
                     ...parentAgents.map((a, i) => ({ id: `agt-${i}`, type: "topoNode", draggable: false, position: { x: COL2, y: agOffset + i * NODE_H }, data: { component: { category: "agent", type: "AI Agent", label: a.name } } })),
                     ...devices.map((d, i) => ({ id: d.id, type: "topoNode", draggable: false, position: { x: COL1, y: devOffset + i * NODE_H }, data: { component: { category: "external", type: d.type, label: d.label } } })),
+                    ...toolNodesAt(COL4),
                 ],
                 edges: [
                     ...devices.map(d => ({ id: `e-${d.id}-a0`, source: d.id, target: "agt-0", type: "smoothstep", style: { stroke: "#9CA3AF", strokeWidth: 1.5 } })),
                     ...parentAgents.map((_, i) => ({ id: `e-a${i}-as`, source: `agt-${i}`, target: "asset", type: "smoothstep", style: { stroke: edgeCol, strokeWidth: 1.5 } })),
+                    ...toolEdges,
                 ],
             };
         }
 
         // Fallback: Device → Asset
-        const maxRows = Math.max(devices.length, 1);
+        const maxRows = Math.max(devices.length, assetToolLabels.length, 1);
         const totalH  = maxRows * NODE_H;
         const assetY  = (totalH - 44) / 2;
         return {
             height: GRAPH_H,
+            focusId: "asset",
             nodes: [
                 { id: "asset", type: "topoNode", draggable: false, position: { x: COL2, y: assetY }, data: { component: { category: cat, type: asset.type, label: asset.name } } },
                 ...devices.map((d, i) => ({ id: d.id, type: "topoNode", draggable: false, position: { x: COL1, y: i * NODE_H }, data: { component: { category: "external", type: d.type, label: d.label } } })),
+                ...toolNodesAt(COL3),
             ],
-            edges: devices.map(d => ({ id: `e-${d.id}-a`, source: d.id, target: "asset", type: "smoothstep", style: { stroke: edgeCol, strokeWidth: 1.5 } })),
+            edges: [
+                ...devices.map(d => ({ id: `e-${d.id}-a`, source: d.id, target: "asset", type: "smoothstep", style: { stroke: edgeCol, strokeWidth: 1.5 } })),
+                ...toolEdges,
+            ],
         };
-    }, [asset, assetDevices, agenticTreeData, agenticFlatData, inlineComponents, externalNodes, externalEdges]);
+    }, [asset, assetDevices, agenticTreeData, agenticFlatData, inlineComponents, mcpTools, externalNodes, externalEdges, externalHeight, focusNodeId]);
 
-    // One extra hop: each MCP node's own tools, same data McpComponentsView shows.
-    const [mcpTools, setMcpTools] = useState({});
-    const fetchedIds = useRef(new Set());
+    // Re-centres on every graph change, not just init — the flyouts' detail and tool fetches land
+    // after the first render, and the view should still be on the focus node once they do.
+    const flow = useRef(null);
     useEffect(() => {
-        const mcpNodes = baseNodes.filter(n => n.data.component.category === "mcp" && n.data.component.collectionId && !fetchedIds.current.has(n.id));
-        if (!mcpNodes.length) return;
-        mcpNodes.forEach(n => fetchedIds.current.add(n.id));
-        let cancelled = false;
-        agenticObserveApi.fetchCollectionStiBundlesBatch(mcpNodes.map(n => n.data.component.collectionId)).then(bundles => {
-            if (cancelled) return;
-            const next = {};
-            mcpNodes.forEach(n => {
-                const b = bundles.get(n.data.component.collectionId);
-                if (!b) return;
-                const { tools } = buildMcpComponentsFromStis(b.stiEndpoints, b.apiInfoList, b.id, b.auditRows);
-                next[n.id] = (tools || []).map(t => t.name).filter(Boolean);
-            });
-            setMcpTools(prev => ({ ...prev, ...next }));
-        }).catch(() => {});
-        return () => { cancelled = true; };
-    }, [baseNodes]);
-
-    const { nodes, edges } = useMemo(() => {
-        const toolNodes = [], toolEdges = [];
-        baseNodes.forEach(n => {
-            const tools = mcpTools[n.id];
-            if (!tools?.length) return;
-            const shown = tools.slice(0, 4);
-            const labels = tools.length > shown.length ? [...shown, `+${tools.length - shown.length} more`] : shown;
-            labels.forEach((label, i) => {
-                const id = `${n.id}-tool-${i}`;
-                toolNodes.push({ id, type: "topoNode", draggable: false, position: { x: n.position.x + 190, y: n.position.y + i * TOOL_H }, data: { component: { category: "mcp", type: "Tool", label } } });
-                toolEdges.push({ id: `e-${id}`, source: n.id, target: id, type: "smoothstep", style: { stroke: "#4cbebb", strokeWidth: 1.5 } });
-            });
-        });
-        return { nodes: [...baseNodes, ...toolNodes], edges: [...baseEdges, ...toolEdges] };
-    }, [baseNodes, baseEdges, mcpTools]);
+        if (flow.current) centerOnFocus(flow.current, nodes, focusId);
+    }, [nodes, focusId]);
 
     return (
         <Box style={{ height, borderRadius: 8, border: "1px solid #E1E5E9", overflow: "hidden", background: "#F8FAFC" }}>
@@ -253,9 +284,7 @@ export default function AssetTopologyGraph({ asset, assetDevices = {}, agenticTr
                 nodes={nodes}
                 edges={edges}
                 nodeTypes={TOPO_NODE_TYPES}
-                fitView
-                fitViewOptions={{ padding: 0.2 }}
-                onInit={api => api.fitView({ padding: 0.2 })}
+                onInit={api => { flow.current = api; centerOnFocus(api, nodes, focusId); }}
                 minZoom={0.2}
                 maxZoom={4}
                 nodesDraggable={true}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceFlyout.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceFlyout.jsx
@@ -11,9 +11,10 @@ import AssetTopologyGraph from "./AssetTopologyGraph";
 import { RiskFactorRow } from "./RiskFactorRow";
 import DetailGrid from "./DetailGrid";
 import agenticObserveApi, { buildAgenticObserveChatMetadata, fetchAgenticViolationsPage, openViolationInThreatActivity, deviceServiceKey } from "./agenticObserveApi";
+import { buildAgentBuiltinToolsFromStis } from "./agenticPageBuilders";
+import { TOOL_EDGE_COLOR, useMcpTools, withToolRows } from "./topologyTools";
 import api from "../api";
-import { extractServiceName, extractEndpointId } from "./constants";
-import { getFriendlyLlmName } from "./mcpClientHelper";
+import { extractEndpointId } from "./constants";
 import func from "@/util/func";
 import settingsApi from "../../settings/api";
 import "../../../components/layouts/style.css";
@@ -158,48 +159,29 @@ const GRID_DEFAULT_COL = { sortable: true, resizable: true, filter: false };
 
 // ─── Topology graph ───────────────────────────────────────────────────────────
 
-// Build col3 items (MCPs, LLMs, Skills) linked to a given AI Agent using collections data.
-// The agent's collectionIds tell us which collections it owns; service names on those
-// collections (excluding the agent's own service segment) are its linked MCP/LLM servers.
-function buildAgentCol3Items(agent, collections, agentIdx, builtinTools = []) {
-    const agentIdSet = new Set((agent.collectionIds || []).map(Number));
-    const deviceId = agent.path?.[0];
-    const agentServiceKey = agent.rawServiceName?.toLowerCase();
-    const seen = new Set();
+// Build col3 items (MCPs, Skills, Plugins) linked to a given AI Agent — from the batch detail
+// fetch (mcpServers/skillCount/pluginNames, keyed by agent.groupKey), the same fields
+// AssetTopologyGraph.jsx's own asset-flyout graph uses. No detail (fetch still pending, or this
+// agent has no groupKey) means no col3Items — nothing rather than a wrong guess.
+function buildAgentCol3Items(detail, agentIdx, builtinTools = []) {
     const items = [];
-
-    collections.forEach((c) => {
-        if (!agentIdSet.has(Number(c.id))) return;
-        const hostName = c.hostName || c.displayName || c.name;
-        if (!hostName) return;
-        if (extractEndpointId(hostName) !== deviceId) return;
-        const svc = extractServiceName(hostName);
-        if (!svc || svc.toLowerCase() === agentServiceKey) return;
-        if (seen.has(svc)) return;
-        seen.add(svc);
-        const tags = c.envType || [];
-        const isLlm = tags.some(t => t.keyName === "gen-ai" || t.keyName === "llm");
-        const cat = isLlm ? "ai-model" : "mcp";
-        const type = isLlm ? "LLM" : "MCP Server";
-        const edgeColor = isLlm ? "#ec4899" : "#4cbebb";
-        items.push({ id: `c3-${agentIdx}-${seen.size}`, cat, type, label: svc, agentIdx, edgeColor, collectionId: isLlm ? undefined : c.id });
-    });
-
-    // Also add skills from the agent's skillNames
-    (agent.skillNames || []).forEach((name, si) => {
-        items.push({ id: `skl-${agentIdx}-${si}`, cat: "skill", type: "Skill", label: name, agentIdx, edgeColor: "#7C3AED" });
-    });
-
-    // Inline LLM on agent host (e.g. Cowork /v1/messages on *.ai-agent.* collection)
-    const hasAgentHostCollection = collections.some((c) => {
-        if (!agentIdSet.has(Number(c.id))) return false;
-        const hostName = c.hostName || c.displayName || c.name || "";
-        return hostName.includes(".ai-agent.") && extractEndpointId(hostName) === deviceId;
-    });
-    if (hasAgentHostCollection) {
-        const tag = agentServiceKey || "claude";
-        const label = tag.includes("claude") ? getFriendlyLlmName("claude.ai") : tag;
-        items.push({ id: `inline-llm-${agentIdx}`, cat: "ai-model", type: "LLM", label, agentIdx, edgeColor: "#ec4899" });
+    if (detail) {
+        const llmNames = new Set(detail.llmServers || []);
+        (detail.mcpServers || []).forEach((name, i) => {
+            const isLlm = llmNames.has(name);
+            const collectionId = detail.mcpServerCollectionIds?.[name]?.[0];
+            items.push(isLlm
+                ? { id: `c3-${agentIdx}-${i}`, cat: "ai-model", type: "LLM", label: name, agentIdx, edgeColor: "#ec4899" }
+                : { id: `c3-${agentIdx}-${i}`, cat: "mcp", type: "MCP Server", label: name, agentIdx, edgeColor: "#4cbebb", collectionId });
+        });
+        if (detail.skillCount > 0) {
+            items.push({ id: `skl-${agentIdx}`, cat: "skill", type: "Skill", label: detail.skillCount === 1 ? "1 Skill" : `${detail.skillCount} Skills`, agentIdx, edgeColor: "#7C3AED" });
+        }
+        // pluginNames are compound "pluginName|ownerKey" keys (see AgenticObserveAction's
+        // classifyAllGroups) — only the bare name in front of "|" is ever shown.
+        (detail.pluginNames || []).forEach((key, i) => {
+            items.push({ id: `plg-${agentIdx}-${i}`, cat: "plugin", type: "Plugin", label: key.split("|")[0], agentIdx, edgeColor: "#4F46E5" });
+        });
     }
 
     const seenTools = new Set();
@@ -207,59 +189,79 @@ function buildAgentCol3Items(agent, collections, agentIdx, builtinTools = []) {
         const name = tool?.name;
         if (!name || seenTools.has(name)) return;
         seenTools.add(name);
-        items.push({ id: `inline-tool-${agentIdx}-${ti}`, cat: "mcp", type: "Tool", label: name, agentIdx, edgeColor: "#4cbebb" });
+        items.push({ id: `inline-tool-${agentIdx}-${ti}`, cat: "tool", type: "Tool", label: name, agentIdx, edgeColor: TOOL_EDGE_COLOR });
     });
 
     return items;
 }
 
-function TopologyGraph({ device, agents, collections = [], agentTools = {} }) {
+const TOPO_ROW_H = 76;      // one component row
+const TOPO_BLOCK_GAP = 28;  // gap between two agents' blocks
+const TOPO_NODE_H = 64;     // rendered node height, for vertical centering
+
+function TopologyGraph({ device, agents, agentDetails = new Map(), agentTools = {}, mcpTools = {} }) {
     const { nodes, edges } = useMemo(() => {
         const aiAgents = agents.filter(a => a.type === "AI Agent");
         const hasAgents = aiAgents.length > 0;
 
-        const NODE_H = 84;
-        const COL1_X = 40, COL2_X = 230, COL3_X = 420;
+        const COL1_X = 40, COL2_X = 250, COL3_X = 470, COL4_X = 690;
+        const centerIn = (top, blockH) => top + (blockH - TOPO_NODE_H) / 2;
 
         const deviceLabel = device.username && device.username !== "-" ? device.username : device.endpoint;
         const ns = [];
         const es = [];
 
         if (hasAgents) {
-            // Build col3 items for all agents, tagged with agentIdx
-            const col3Items = aiAgents.flatMap((a, ai) => buildAgentCol3Items(a, collections, ai, agentTools[ai] || []));
-            const maxRows = Math.max(aiAgents.length, col3Items.length, 1);
-            const totalH  = maxRows * NODE_H;
-            const devY    = (totalH - 44) / 2;
-            const agentOffset = Math.max(0, (col3Items.length - aiAgents.length) * NODE_H / 2);
+            // Each agent owns a vertical block sized to its own components, so a component always
+            // sits directly across from the agent it belongs to. Laying every agent's components
+            // out as one flat list instead (the old approach) left them lined up against
+            // whichever agent happened to share that row.
+            let cursor = 0;
+            const blocks = aiAgents.map((a, i) => {
+                const items = buildAgentCol3Items(agentDetails.get(a.groupKey), i, agentTools[i] || []);
+                const rows = withToolRows(items, mcpTools);
+                const blockH = Math.max(1, rows.length) * TOPO_ROW_H;
+                const block = { idx: i, label: a.endpoint, rows, top: cursor, blockH };
+                cursor += blockH + TOPO_BLOCK_GAP;
+                return block;
+            });
+            const contentH = Math.max(cursor - TOPO_BLOCK_GAP, TOPO_ROW_H);
 
-            ns.push({ id: "device", type: "topoNode", draggable: false, position: { x: COL1_X, y: devY }, data: { component: { category: "external", type: "User", label: deviceLabel } } });
-            aiAgents.forEach((a, i) => {
-                ns.push({ id: `agent-${i}`, type: "topoNode", draggable: false, position: { x: COL2_X, y: agentOffset + i * NODE_H }, data: { component: { category: "agent", type: "AI Agent", label: a.endpoint } } });
-                es.push({ id: `e-d-a${i}`, source: "device", target: `agent-${i}`, type: "smoothstep", style: { stroke: "#9ca3af", strokeWidth: 1.5 } });
+            ns.push({ id: "device", type: "topoNode", draggable: false, position: { x: COL1_X, y: centerIn(0, contentH) }, data: { component: { category: "external", type: "User", label: deviceLabel } } });
+            blocks.forEach((b) => {
+                ns.push({ id: `agent-${b.idx}`, type: "topoNode", draggable: false, position: { x: COL2_X, y: centerIn(b.top, b.blockH) }, data: { component: { category: "agent", type: "AI Agent", label: b.label } } });
+                es.push({ id: `e-d-a${b.idx}`, source: "device", target: `agent-${b.idx}`, type: "smoothstep", style: { stroke: "#9ca3af", strokeWidth: 1.5 } });
+                b.rows.forEach((row, j) => {
+                    const y = b.top + j * TOPO_ROW_H;
+                    if (row.tool) {
+                        ns.push({ id: row.tool.id, type: "topoNode", draggable: false, position: { x: COL4_X, y }, data: { component: { category: "tool", type: "Tool", label: row.tool.label } } });
+                        es.push({ id: `e-${row.tool.id}`, source: row.item.id, target: row.tool.id, type: "smoothstep", style: { stroke: TOOL_EDGE_COLOR, strokeWidth: 1.5 } });
+                        return;
+                    }
+                    const item = row.item;
+                    ns.push({ id: item.id, type: "topoNode", draggable: false, position: { x: COL3_X, y }, data: { component: { category: item.cat, type: item.type, label: item.label, collectionId: item.collectionId } } });
+                    es.push({ id: `e-a${b.idx}-${item.id}`, source: `agent-${b.idx}`, target: item.id, type: "smoothstep", style: { stroke: item.edgeColor, strokeWidth: 1.5 } });
+                });
             });
-            col3Items.forEach((item, i) => {
-                ns.push({ id: item.id, type: "topoNode", draggable: false, position: { x: COL3_X, y: i * NODE_H }, data: { component: { category: item.cat, type: item.type, label: item.label, collectionId: item.collectionId } } });
-                es.push({ id: `e-a${item.agentIdx}-${item.id}`, source: `agent-${item.agentIdx}`, target: item.id, type: "smoothstep", style: { stroke: item.edgeColor, strokeWidth: 1.5 } });
-            });
-        } else {
-            // No AI Agents — show device → direct service children (MCP/LLM)
-            const direct = agents.filter(a => a.type === "MCP Server" || a.type === "LLM");
-            const maxRows = Math.max(direct.length, 1);
-            const devY = (maxRows * NODE_H - 44) / 2;
-            ns.push({ id: "device", type: "topoNode", draggable: false, position: { x: COL1_X, y: devY }, data: { component: { category: "external", type: "User", label: deviceLabel } } });
-            direct.forEach((a, i) => {
-                const cat = a.type === "LLM" ? "ai-model" : "mcp";
-                const color = a.type === "LLM" ? "#ec4899" : "#9ca3af";
-                ns.push({ id: `svc-${i}`, type: "topoNode", draggable: false, position: { x: COL2_X, y: i * NODE_H }, data: { component: { category: cat, type: a.type, label: a.endpoint, collectionId: cat === "mcp" ? a.collectionIds?.[0] : undefined } } });
-                es.push({ id: `e-d-s${i}`, source: "device", target: `svc-${i}`, type: "smoothstep", style: { stroke: color, strokeWidth: 1.5 } });
-            });
+            return { nodes: ns, edges: es };
         }
 
+        // No AI Agents — show device → direct service children (MCP/LLM)
+        const direct = agents.filter(a => a.type === "MCP Server" || a.type === "LLM");
+        const contentH = Math.max(direct.length, 1) * TOPO_ROW_H;
+        ns.push({ id: "device", type: "topoNode", draggable: false, position: { x: COL1_X, y: centerIn(0, contentH) }, data: { component: { category: "external", type: "User", label: deviceLabel } } });
+        direct.forEach((a, i) => {
+            const cat = a.type === "LLM" ? "ai-model" : "mcp";
+            const color = a.type === "LLM" ? "#ec4899" : "#9ca3af";
+            ns.push({ id: `svc-${i}`, type: "topoNode", draggable: false, position: { x: COL2_X, y: i * TOPO_ROW_H }, data: { component: { category: cat, type: a.type, label: a.endpoint, collectionId: cat === "mcp" ? a.collectionIds?.[0] : undefined } } });
+            es.push({ id: `e-d-s${i}`, source: "device", target: `svc-${i}`, type: "smoothstep", style: { stroke: color, strokeWidth: 1.5 } });
+        });
         return { nodes: ns, edges: es };
-    }, [agents, device.endpoint, device.username, collections, agentTools]);
+    }, [agents, device.endpoint, device.username, agentDetails, agentTools, mcpTools]);
 
-    return <AssetTopologyGraph nodes={nodes} edges={edges} />;
+    // No height passed — same fixed box the Agentic Assets page graph uses. focusNodeId opens the
+    // view on the device this flyout is about, rather than fitting every agent branch at once.
+    return <AssetTopologyGraph nodes={nodes} edges={edges} focusNodeId="device" />;
 }
 
 // ─── User analysis section ─────────────────────────────────────────────────────
@@ -345,35 +347,61 @@ function OverviewTab({ device, agents, collections, onTabChange, startTimestamp,
 
     useEffect(() => {
         if (!aiAgents.length) { setAgentTools({}); return; }
+        // One batch over every agent's collections (3 requests total) rather than
+        // fetchAgentBuiltinToolsData per collection per agent, which was 3 requests each — a
+        // device with 10 agents across 3 collections apiece fired 90.
+        const allIds = [...new Set(aiAgents.flatMap(a => a.collectionIds || []))];
+        if (!allIds.length) { setAgentTools({}); return; }
         let cancelled = false;
-        (async () => {
-            try {
-                // allSettled at both levels — one failing collection used to blank the tools list for
-                // every agent in the flyout, not just its own.
-                const settled = await Promise.allSettled(aiAgents.map(async (agent, idx) => {
-                    const ids = agent.collectionIds || [];
-                    if (!ids.length) return [idx, []];
-                    const bundles = await Promise.allSettled(ids.map(id => agenticObserveApi.fetchAgentBuiltinToolsData(id)));
+        agenticObserveApi.fetchCollectionStiBundlesBatch(allIds)
+            .then(bundles => {
+                if (cancelled) return;
+                const next = {};
+                aiAgents.forEach((agent, idx) => {
                     const seen = new Set();
                     const tools = [];
-                    bundles.forEach((b) => {
-                        if (b.status !== "fulfilled") return;
-                        (b.value || []).forEach((tool) => {
+                    (agent.collectionIds || []).forEach((id) => {
+                        const b = bundles.get(typeof id === "string" ? parseInt(id, 10) : id);
+                        if (!b) return;
+                        buildAgentBuiltinToolsFromStis(b.stiEndpoints, b.apiInfoList, b.id, b.auditRows).forEach((tool) => {
                             if (!tool?.name || seen.has(tool.name)) return;
                             seen.add(tool.name);
                             tools.push(tool);
                         });
                     });
-                    return [idx, tools];
-                }));
-                const entries = settled.filter((s) => s.status === "fulfilled").map((s) => s.value);
-                if (!cancelled) setAgentTools(Object.fromEntries(entries));
-            } catch {
-                if (!cancelled) setAgentTools({});
-            }
-        })();
+                    next[idx] = tools;
+                });
+                setAgentTools(next);
+            })
+            .catch(() => { if (!cancelled) setAgentTools({}); });
         return () => { cancelled = true; };
     }, [aiAgents]);
+
+    // One batch call for every AI Agent's mcpServers/skillCount/pluginNames (context graph's
+    // col3Items) instead of one fetchAgenticAssetDetail per agent — a device can show 10+ agents.
+    const [agentDetails, setAgentDetails] = useState(new Map());
+    useEffect(() => {
+        const groupKeys = [...new Set(aiAgents.map(a => a.groupKey).filter(Boolean))];
+        if (!groupKeys.length) { setAgentDetails(new Map()); return; }
+        let cancelled = false;
+        api.fetchAgenticAssetDetailsBatch({ groupKeys, rowType: "agent" })
+            .then(byGroupKey => { if (!cancelled) setAgentDetails(byGroupKey); })
+            .catch(() => { if (!cancelled) setAgentDetails(new Map()); });
+        return () => { cancelled = true; };
+    }, [aiAgents]);
+
+    // Each MCP server's own tools, keyed by collection id. Fetched here rather than inside
+    // AssetTopologyGraph because the graph rows are laid out here — tools need reserved rows or
+    // they land on top of the next MCP's row.
+    const mcpCollectionIds = useMemo(() => {
+        const ids = new Set();
+        agentDetails.forEach(d => Object.values(d?.mcpServerCollectionIds || {}).forEach(arr => {
+            if (arr?.[0]) ids.add(arr[0]);
+        }));
+        return [...ids];
+    }, [agentDetails]);
+
+    const mcpTools = useMcpTools(mcpCollectionIds);
 
     const inlineToolCount = useMemo(
         () => Object.values(agentTools).reduce((n, tools) => n + (tools?.length || 0), 0),
@@ -448,7 +476,7 @@ function OverviewTab({ device, agents, collections, onTabChange, startTimestamp,
 
                 <VerticalStack gap="2">
                     <Text variant="headingXs" color="subdued">Context graph</Text>
-                    <TopologyGraph device={device} agents={agents} collections={collections} agentTools={agentTools} />
+                    <TopologyGraph device={device} agents={agents} agentDetails={agentDetails} agentTools={agentTools} mcpTools={mcpTools} />
                 </VerticalStack>
 
                 <VerticalStack gap="2">

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceFlyout.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/DeviceFlyout.jsx
@@ -199,10 +199,26 @@ const TOPO_ROW_H = 76;      // one component row
 const TOPO_BLOCK_GAP = 28;  // gap between two agents' blocks
 const TOPO_NODE_H = 64;     // rendered node height, for vertical centering
 
+// A device-child row's own edgeColor/cat, for a "direct" node — one that hangs straight off the
+// device rather than behind an AI Agent. Only "MCP Server" carries a collectionId (buildDeviceChildren
+// — only agent rows get a groupKey instead, for the detail batch fetch), so it's the only direct
+// type with tools of its own; LLM/Skill/Plugin render as plain leaves.
+function directNodeStyle(type) {
+    switch (type) {
+        case "LLM":    return { cat: "ai-model", edgeColor: "#ec4899" };
+        case "Skill":  return { cat: "skill",    edgeColor: "#7C3AED" };
+        case "Plugin": return { cat: "plugin",   edgeColor: "#4F46E5" };
+        default:       return { cat: "mcp",      edgeColor: "#4cbebb" }; // MCP Server
+    }
+}
+
 function TopologyGraph({ device, agents, agentDetails = new Map(), agentTools = {}, mcpTools = {} }) {
     const { nodes, edges } = useMemo(() => {
         const aiAgents = agents.filter(a => a.type === "AI Agent");
-        const hasAgents = aiAgents.length > 0;
+        // Anything the device talks to directly, not behind a recognized AI Agent — its own
+        // sibling branch off the device, same as an agent's, instead of being dropped just because
+        // this device also happens to have agents.
+        const directChildren = agents.filter(a => ["MCP Server", "LLM", "Skill", "Plugin"].includes(a.type));
 
         const COL1_X = 40, COL2_X = 250, COL3_X = 470, COL4_X = 690;
         const centerIn = (top, blockH) => top + (blockH - TOPO_NODE_H) / 2;
@@ -211,51 +227,61 @@ function TopologyGraph({ device, agents, agentDetails = new Map(), agentTools = 
         const ns = [];
         const es = [];
 
-        if (hasAgents) {
-            // Each agent owns a vertical block sized to its own components, so a component always
-            // sits directly across from the agent it belongs to. Laying every agent's components
-            // out as one flat list instead (the old approach) left them lined up against
-            // whichever agent happened to share that row.
-            let cursor = 0;
-            const blocks = aiAgents.map((a, i) => {
-                const items = buildAgentCol3Items(agentDetails.get(a.groupKey), i, agentTools[i] || []);
-                const rows = withToolRows(items, mcpTools);
-                const blockH = Math.max(1, rows.length) * TOPO_ROW_H;
-                const block = { idx: i, label: a.endpoint, rows, top: cursor, blockH };
-                cursor += blockH + TOPO_BLOCK_GAP;
-                return block;
-            });
-            const contentH = Math.max(cursor - TOPO_BLOCK_GAP, TOPO_ROW_H);
-
-            ns.push({ id: "device", type: "topoNode", draggable: false, position: { x: COL1_X, y: centerIn(0, contentH) }, data: { component: { category: "external", type: "User", label: deviceLabel } } });
-            blocks.forEach((b) => {
-                ns.push({ id: `agent-${b.idx}`, type: "topoNode", draggable: false, position: { x: COL2_X, y: centerIn(b.top, b.blockH) }, data: { component: { category: "agent", type: "AI Agent", label: b.label } } });
-                es.push({ id: `e-d-a${b.idx}`, source: "device", target: `agent-${b.idx}`, type: "smoothstep", style: { stroke: "#9ca3af", strokeWidth: 1.5 } });
-                b.rows.forEach((row, j) => {
-                    const y = b.top + j * TOPO_ROW_H;
-                    if (row.tool) {
-                        ns.push({ id: row.tool.id, type: "topoNode", draggable: false, position: { x: COL4_X, y }, data: { component: { category: "tool", type: "Tool", label: row.tool.label } } });
-                        es.push({ id: `e-${row.tool.id}`, source: row.item.id, target: row.tool.id, type: "smoothstep", style: { stroke: TOOL_EDGE_COLOR, strokeWidth: 1.5 } });
-                        return;
-                    }
-                    const item = row.item;
-                    ns.push({ id: item.id, type: "topoNode", draggable: false, position: { x: COL3_X, y }, data: { component: { category: item.cat, type: item.type, label: item.label, collectionId: item.collectionId } } });
-                    es.push({ id: `e-a${b.idx}-${item.id}`, source: `agent-${b.idx}`, target: item.id, type: "smoothstep", style: { stroke: item.edgeColor, strokeWidth: 1.5 } });
-                });
-            });
-            return { nodes: ns, edges: es };
-        }
-
-        // No AI Agents — show device → direct service children (MCP/LLM)
-        const direct = agents.filter(a => a.type === "MCP Server" || a.type === "LLM");
-        const contentH = Math.max(direct.length, 1) * TOPO_ROW_H;
-        ns.push({ id: "device", type: "topoNode", draggable: false, position: { x: COL1_X, y: centerIn(0, contentH) }, data: { component: { category: "external", type: "User", label: deviceLabel } } });
-        direct.forEach((a, i) => {
-            const cat = a.type === "LLM" ? "ai-model" : "mcp";
-            const color = a.type === "LLM" ? "#ec4899" : "#9ca3af";
-            ns.push({ id: `svc-${i}`, type: "topoNode", draggable: false, position: { x: COL2_X, y: i * TOPO_ROW_H }, data: { component: { category: cat, type: a.type, label: a.endpoint, collectionId: cat === "mcp" ? a.collectionIds?.[0] : undefined } } });
-            es.push({ id: `e-d-s${i}`, source: "device", target: `svc-${i}`, type: "smoothstep", style: { stroke: color, strokeWidth: 1.5 } });
+        // Each agent (and each direct child) owns a vertical block sized to its own components, so
+        // a component always sits directly across from the thing it belongs to. Laying every
+        // agent's components out as one flat list instead (the old approach) left them lined up
+        // against whichever agent happened to share that row.
+        let cursor = 0;
+        const agentBlocks = aiAgents.map((a, i) => {
+            const items = buildAgentCol3Items(agentDetails.get(a.groupKey), i, agentTools[i] || []);
+            const rows = withToolRows(items, mcpTools);
+            const blockH = Math.max(1, rows.length) * TOPO_ROW_H;
+            const block = { idx: i, label: a.endpoint, rows, top: cursor, blockH };
+            cursor += blockH + TOPO_BLOCK_GAP;
+            return block;
         });
+        const directBlocks = directChildren.map((a, i) => {
+            const style = directNodeStyle(a.type);
+            const collectionId = a.type === "MCP Server" ? a.collectionIds?.[0] : undefined;
+            const item = { id: `direct-${i}`, type: a.type, label: a.endpoint, cat: style.cat, edgeColor: style.edgeColor, collectionId };
+            // Row 0 (the item itself) is reserved implicitly — only the tool rows behind it, if any,
+            // need laying out here.
+            const toolRows = withToolRows([item], mcpTools).slice(1);
+            const blockH = Math.max(1, toolRows.length + 1) * TOPO_ROW_H;
+            const block = { idx: i, item, toolRows, top: cursor, blockH };
+            cursor += blockH + TOPO_BLOCK_GAP;
+            return block;
+        });
+        const contentH = Math.max(cursor - TOPO_BLOCK_GAP, TOPO_ROW_H);
+
+        ns.push({ id: "device", type: "topoNode", draggable: false, position: { x: COL1_X, y: centerIn(0, contentH) }, data: { component: { category: "external", type: "User", label: deviceLabel } } });
+
+        agentBlocks.forEach((b) => {
+            ns.push({ id: `agent-${b.idx}`, type: "topoNode", draggable: false, position: { x: COL2_X, y: centerIn(b.top, b.blockH) }, data: { component: { category: "agent", type: "AI Agent", label: b.label } } });
+            es.push({ id: `e-d-a${b.idx}`, source: "device", target: `agent-${b.idx}`, type: "smoothstep", style: { stroke: "#9ca3af", strokeWidth: 1.5 } });
+            b.rows.forEach((row, j) => {
+                const y = b.top + j * TOPO_ROW_H;
+                if (row.tool) {
+                    ns.push({ id: row.tool.id, type: "topoNode", draggable: false, position: { x: COL4_X, y }, data: { component: { category: "tool", type: "Tool", label: row.tool.label } } });
+                    es.push({ id: `e-${row.tool.id}`, source: row.item.id, target: row.tool.id, type: "smoothstep", style: { stroke: TOOL_EDGE_COLOR, strokeWidth: 1.5 } });
+                    return;
+                }
+                const item = row.item;
+                ns.push({ id: item.id, type: "topoNode", draggable: false, position: { x: COL3_X, y }, data: { component: { category: item.cat, type: item.type, label: item.label, collectionId: item.collectionId } } });
+                es.push({ id: `e-a${b.idx}-${item.id}`, source: `agent-${b.idx}`, target: item.id, type: "smoothstep", style: { stroke: item.edgeColor, strokeWidth: 1.5 } });
+            });
+        });
+
+        directBlocks.forEach((b) => {
+            ns.push({ id: b.item.id, type: "topoNode", draggable: false, position: { x: COL2_X, y: centerIn(b.top, b.blockH) }, data: { component: { category: b.item.cat, type: b.item.type, label: b.item.label } } });
+            es.push({ id: `e-d-${b.item.id}`, source: "device", target: b.item.id, type: "smoothstep", style: { stroke: b.item.edgeColor, strokeWidth: 1.5 } });
+            b.toolRows.forEach((row, j) => {
+                const y = b.top + (j + 1) * TOPO_ROW_H; // row 0 is the item itself
+                ns.push({ id: row.tool.id, type: "topoNode", draggable: false, position: { x: COL3_X, y }, data: { component: { category: "tool", type: "Tool", label: row.tool.label } } });
+                es.push({ id: `e-${row.tool.id}`, source: b.item.id, target: row.tool.id, type: "smoothstep", style: { stroke: TOOL_EDGE_COLOR, strokeWidth: 1.5 } });
+            });
+        });
+
         return { nodes: ns, edges: es };
     }, [agents, device.endpoint, device.username, agentDetails, agentTools, mcpTools]);
 
@@ -392,14 +418,16 @@ function OverviewTab({ device, agents, collections, onTabChange, startTimestamp,
 
     // Each MCP server's own tools, keyed by collection id. Fetched here rather than inside
     // AssetTopologyGraph because the graph rows are laid out here — tools need reserved rows or
-    // they land on top of the next MCP's row.
+    // they land on top of the next MCP's row. Covers both an agent-linked MCP (via agentDetails)
+    // and a direct one hanging straight off the device (buildDeviceChildren's own collectionIds).
     const mcpCollectionIds = useMemo(() => {
         const ids = new Set();
         agentDetails.forEach(d => Object.values(d?.mcpServerCollectionIds || {}).forEach(arr => {
             if (arr?.[0]) ids.add(arr[0]);
         }));
+        agents.forEach(a => { if (a.type === "MCP Server" && a.collectionIds?.[0]) ids.add(a.collectionIds[0]); });
         return [...ids];
-    }, [agentDetails]);
+    }, [agentDetails, agents]);
 
     const mcpTools = useMcpTools(mcpCollectionIds);
 

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/topologyTools.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/agentic/topologyTools.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import agenticObserveApi from "./agenticObserveApi";
+import { buildMcpComponentsFromStis } from "./agenticPageBuilders";
+
+// Shared by both context graphs — the device flyout's (DeviceFlyout.jsx) and the asset flyout's
+// (AssetTopologyGraph.jsx). They lay their nodes out differently but hang tools off an MCP the
+// same way, and keeping two copies of that had already let them drift apart.
+
+export const TOOL_CAP = 4;          // tools shown per MCP before collapsing to "+N more"
+export const TOOL_EDGE_COLOR = "#D97706";
+
+// Tool names trimmed to TOOL_CAP, with the remainder collapsed into a trailing "+N more".
+export function capToolLabels(tools = []) {
+    const shown = tools.slice(0, TOOL_CAP);
+    return tools.length > shown.length ? [...shown, `+${tools.length - shown.length} more`] : shown;
+}
+
+// One row per component, plus a reserved row per tool hanging off an MCP. Both layouts place a
+// row at a fixed pitch, so a tool without its own row lands on top of the next component.
+export function withToolRows(items, mcpTools) {
+    const rows = [];
+    items.forEach((item) => {
+        rows.push({ item });
+        const tools = item.cat === "mcp" && item.collectionId ? (mcpTools[item.collectionId] || []) : [];
+        capToolLabels(tools).forEach((label, i) => rows.push({ item, tool: { id: `${item.id}-tool-${i}`, label } }));
+    });
+    return rows;
+}
+
+// Tool names per collection id, keyed for withToolRows. Batched — 3 requests for the whole set of
+// ids, not 3 per id. Callers derive the ids themselves (they hold different shapes) and must
+// memoize them, or this refetches on every render.
+export function useMcpTools(collectionIds) {
+    const [mcpTools, setMcpTools] = useState({});
+
+    useEffect(() => {
+        if (!collectionIds.length) { setMcpTools({}); return; }
+        let cancelled = false;
+        agenticObserveApi.fetchCollectionStiBundlesBatch(collectionIds)
+            .then(bundles => {
+                if (cancelled) return;
+                const next = {};
+                bundles.forEach((b, id) => {
+                    const { tools } = buildMcpComponentsFromStis(b.stiEndpoints, b.apiInfoList, b.id, b.auditRows);
+                    next[id] = (tools || []).map(t => t.name).filter(Boolean);
+                });
+                setMcpTools(next);
+            })
+            .catch(() => { if (!cancelled) setMcpTools({}); });
+        return () => { cancelled = true; };
+    }, [collectionIds]);
+
+    return mcpTools;
+}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/api.js
@@ -326,6 +326,33 @@ export default {
             mcpComponentCount: resp?.assetMcpComponentCount || 0,
         }
     },
+    // Batch form of fetchAgenticAssetDetail, scoped to just mcpServers/mcpServerCollectionIds/
+    // skillCount/pluginNames — the device flyout's context graph needs this for every AI Agent
+    // shown on a device (can be 10+), and firing fetchAgenticAssetDetail once per agent would mean
+    // that many concurrent requests just to draw one graph (see AgenticObserveAction.
+    // fetchAgenticAssetDetailsBatch's own comment). Returns a Map<groupKey, detail>.
+    async fetchAgenticAssetDetailsBatch({ groupKeys, rowType, trafficMap, riskScoreMap } = {}) {
+        if (!groupKeys?.length) return new Map();
+        const resp = await request({
+            url: '/api/fetchAgenticAssetDetailsBatch',
+            method: 'post',
+            data: { groupKeys, rowType, trafficMap, riskScoreMap },
+        })
+        const byGroupKey = resp?.detailsByGroupKey || {};
+        const out = new Map();
+        Object.entries(byGroupKey).forEach(([key, d]) => {
+            out.set(key, {
+                mcpServers: d?.mcpServers || [],
+                mcpServerCollectionIds: d?.mcpServerCollectionIds || {},
+                // Subset of mcpServers that are actually LLMs (gen-ai/browser-llm tagged), so the
+                // graph can label them "LLM" instead of lumping everything under "MCP Server".
+                llmServers: d?.llmServers || [],
+                skillCount: d?.skillCount || 0,
+                pluginNames: d?.pluginNames || [],
+            });
+        });
+        return out;
+    },
     // Server-side paginated device list for ONE asset's flyout Devices tab — scoped to just
     // that asset's own apiCollectionIds (cheap), not the whole account. usernameMap is the
     // same Endpoint Shield map already fetched once for the main grid (fetchEndpointShieldUserMetadata),


### PR DESCRIPTION
Reintroduces the batched agent-details fetch for the device flyout's context graph (previously #6343, reverted in #6351 due to a classification bug), with the bug fixed this time:

- Batch API in AgenticObserveAction.java to fetch mcpServers/llmServers/ skillCount/pluginNames for many agents in one call instead of one request per agent (was ~90 calls per device panel, now 3).
- Fixed a self-reference bug where an agent's own identity collection could be added as one of its own linked MCP servers (raw hostname segment vs canonical registry key were compared without canonicalizing both sides).
- Fixed classification of known clients (e.g. claude-cli, cursor) that carry both mcp-client and mcp-server tags, so they resolve to AI Agent / SaaS Agent instead of falling through to MCP Server.
- Frontend: DeviceFlyout.jsx and AssetTopologyGraph.jsx updated to use the batched API and render agents/tools distinctly; shared graph logic extracted into topologyTools.js.