### PR TITLE
feat: bulk enable/disable system proxy for selected Endpoint Shield agents

### DIFF
--- a/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
+++ b/apps/dashboard/src/main/java/com/akto/action/settings/ModuleInfoAction.java
@@ -642,6 +642,31 @@ public class ModuleInfoAction extends UserAction {
         target.setDevices(new ArrayList<>(merged));
     }
 
+    // Shared by updateModuleEnvAndReboot (one module) and bulkUpdateModuleEnvAndReboot (many) —
+    // same allowed-key/secret-redaction rules and reboot flag either way, just a different filter.
+    private List<Bson> buildEnvUpdates(Map<String, String> envData) {
+        List<Bson> updates = new ArrayList<>();
+
+        // Write directly to additionalData.env — same field the Go module writes at startup.
+        // Go module only writes env vars once at startup (not on every heartbeat), so no race condition.
+        for (Map.Entry<String, String> entry : envData.entrySet()) {
+            boolean isAllowedKey = ModuleInfoConstants.ALLOWED_ENV_KEYS_BY_MODULE.values().stream()
+                .anyMatch(moduleEnvMap -> moduleEnvMap.containsKey(entry.getKey()));
+
+            if (isAllowedKey) {
+                // Skip secret fields if the user submitted the redacted placeholder unchanged
+                if (ModuleInfoConstants.SECRET_ENV_KEYS.contains(entry.getKey())
+                        && ModuleInfoConstants.REDACTED_PLACEHOLDER.equals(entry.getValue())) {
+                    continue;
+                }
+                updates.add(Updates.set(ModuleInfo.ADDITIONAL_DATA + ".env." + entry.getKey(), entry.getValue()));
+            }
+        }
+
+        updates.add(Updates.set(ModuleInfo._REBOOT, true));
+        return updates;
+    }
+
     public String updateModuleEnvAndReboot() {
         if (moduleId == null || moduleId.isEmpty()) {
             return ERROR.toUpperCase();
@@ -653,31 +678,30 @@ public class ModuleInfoAction extends UserAction {
 
         try {
             Bson moduleFilter = Filters.eq(ModuleInfoDao.ID, moduleId);
+            ModuleInfoDao.instance.updateMany(moduleFilter, Updates.combine(buildEnvUpdates(envData)));
+            return SUCCESS.toUpperCase();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ERROR.toUpperCase();
+        }
+    }
 
+    // Bulk counterpart of updateModuleEnvAndReboot, for the Endpoint Shield table's multi-select
+    // (e.g. enabling/disabling system proxy for several agents at once) — reuses the existing
+    // moduleIds field (already used by deleteModuleInfo/rebootModules) and envData, same allowed-
+    // key rules, one updateMany instead of looping per id.
+    public String bulkUpdateModuleEnvAndReboot() {
+        if (moduleIds == null || moduleIds.isEmpty()) {
+            return ERROR.toUpperCase();
+        }
 
-            List<Bson> updates = new ArrayList<>();
+        if (envData == null || envData.isEmpty()) {
+            return SUCCESS.toUpperCase();
+        }
 
-            // Write directly to additionalData.env — same field the Go module writes at startup.
-            // Go module only writes env vars once at startup (not on every heartbeat), so no race condition.
-            for (Map.Entry<String, String> entry : envData.entrySet()) {
-                boolean isAllowedKey = ModuleInfoConstants.ALLOWED_ENV_KEYS_BY_MODULE.values().stream()
-                    .anyMatch(moduleEnvMap -> moduleEnvMap.containsKey(entry.getKey()));
-
-                if (isAllowedKey) {
-                    // Skip secret fields if the user submitted the redacted placeholder unchanged
-                    if (ModuleInfoConstants.SECRET_ENV_KEYS.contains(entry.getKey())
-                            && ModuleInfoConstants.REDACTED_PLACEHOLDER.equals(entry.getValue())) {
-                        continue;
-                    }
-                    updates.add(Updates.set(ModuleInfo.ADDITIONAL_DATA + ".env." + entry.getKey(), entry.getValue()));
-                }
-            }
-
-            updates.add(Updates.set(ModuleInfo._REBOOT, true));
-
-
-            ModuleInfoDao.instance.updateMany(moduleFilter, Updates.combine(updates));
-
+        try {
+            Bson moduleFilter = Filters.in(ModuleInfoDao.ID, moduleIds);
+            ModuleInfoDao.instance.updateMany(moduleFilter, Updates.combine(buildEnvUpdates(envData)));
             return SUCCESS.toUpperCase();
         } catch (Exception e) {
             e.printStackTrace();

--- a/apps/dashboard/src/main/resources/struts.xml
+++ b/apps/dashboard/src/main/resources/struts.xml
@@ -764,6 +764,29 @@
             </result>
         </action>
 
+        <action name="api/bulkUpdateModuleEnvAndReboot" class="com.akto.action.settings.ModuleInfoAction" method="bulkUpdateModuleEnvAndReboot">
+            <interceptor-ref name="json"/>
+            <interceptor-ref name="defaultStack" />
+            <interceptor-ref name="roleAccessInterceptor">
+                <param name="featureLabel">ADMIN_ACTIONS</param>
+                <param name="accessType">READ_WRITE</param>
+                <param name="actionDescription">User bulk-updated module environment and initiated reboot</param>
+            </interceptor-ref>
+
+            <result name="FORBIDDEN" type="json">
+                <param name="statusCode">403</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+            <result name="SUCCESS" type="json"/>
+
+            <result name="ERROR" type="json">
+                <param name="statusCode">422</param>
+                <param name="ignoreHierarchy">false</param>
+                <param name="includeProperties">^actionErrors.*</param>
+            </result>
+        </action>
+
         <action name="api/fetchEndpointShieldSettings" class="com.akto.action.settings.EndpointShieldSettingsAction" method="fetchEndpointShieldSettings">
             <interceptor-ref name="json"/>
             <interceptor-ref name="defaultStack" />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/GithubServerTable.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/GithubServerTable.js
@@ -844,9 +844,6 @@ function GithubServerTable(props) {
                 onSelectionChange={customSelectionChange}
                 headings={processedHeadings}
                 promotedBulkActions={props.selectable ? props.promotedBulkActions && props.promotedBulkActions(bulkActionResources) : []}
-                // Overflow ("...") menu for bulk actions that shouldn't always sit alongside the
-                // promoted ones — Polaris recommends at most 2 promoted actions at once.
-                bulkActions={props.selectable ? props.bulkActions && props.bulkActions(bulkActionResources) : []}
                 hasZebraStriping={props.hasZebraStriping || false}
                 sortable={sortableColumns}
                 sortColumnIndex={activeColumnSort.columnIndex}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/GithubServerTable.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/components/tables/GithubServerTable.js
@@ -844,6 +844,9 @@ function GithubServerTable(props) {
                 onSelectionChange={customSelectionChange}
                 headings={processedHeadings}
                 promotedBulkActions={props.selectable ? props.promotedBulkActions && props.promotedBulkActions(bulkActionResources) : []}
+                // Overflow ("...") menu for bulk actions that shouldn't always sit alongside the
+                // promoted ones — Polaris recommends at most 2 promoted actions at once.
+                bulkActions={props.selectable ? props.bulkActions && props.bulkActions(bulkActionResources) : []}
                 hasZebraStriping={props.hasZebraStriping || false}
                 sortable={sortableColumns}
                 sortColumnIndex={activeColumnSort.columnIndex}

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
@@ -289,29 +289,66 @@ function EndpointShieldMetadata() {
         return { value: ret, total };
     }, [startTimestamp, endTimestamp]);
 
+    // Delete stays restricted to internal akto.io users (destructive — removes agent info entries
+    // outright). Enable/Disable System Proxy is reversible (just flips an env flag and reboots the
+    // agent, same as the single-device Configure tab's toggle) and available to anyone who can
+    // reach this page — the backend still enforces ADMIN_ACTIONS regardless.
     const allowBulkActions = window.USER_NAME && window.USER_NAME.endsWith("@akto.io");
 
     const promotedBulkActions = (selectedAgents) => {
         const actions = [];
-        if (allowBulkActions) {
-            actions.push({
-                content: `Delete ${selectedAgents.length} agent info entr${selectedAgents.length > 1 ? "ies" : "y"}`,
-                onAction: async () => {
-                    const msg = `Are you sure you want to delete ${selectedAgents.length} agent info entr${selectedAgents.length > 1 ? "ies" : "y"}?`;
-                    func.showConfirmationModal(msg, "Delete", async () => {
-                        try {
-                            await settingRequests.deleteModuleInfo(selectedAgents);
-                            func.setToast(true, false, `${selectedAgents.length} agent info entr${selectedAgents.length > 1 ? "ies" : "y"} deleted successfully`);
-                            window.location.reload();
-                        } catch (error) {
-                            console.error("Error deleting agent info:", error);
-                            func.setToast(true, true, "Failed to delete agent info");
-                        }
-                    });
-                },
+        const agentCount = selectedAgents.length;
+        const agentWord = `agent${agentCount > 1 ? "s" : ""}`;
+
+        const bulkToggleSystemProxy = (enable) => () => {
+            const verb = enable ? "enable" : "disable";
+            const msg = `Are you sure you want to ${verb} system proxy for ${agentCount} ${agentWord}? They will pick up the change on their next reboot.`;
+            func.showConfirmationModal(msg, enable ? "Enable" : "Disable", async () => {
+                try {
+                    await settingRequests.bulkUpdateModuleEnvAndReboot(selectedAgents, { ENABLE_SYSTEM_PROXY: enable ? "true" : "false" });
+                    func.setToast(true, false, `System proxy ${enable ? "enabled" : "disabled"} for ${agentCount} ${agentWord}. Agents will pick up changes shortly.`);
+                    setRefreshKey(k => k + 1);
+                } catch (error) {
+                    console.error("Error updating system proxy:", error);
+                    func.setToast(true, true, "Failed to update system proxy");
+                }
             });
-        }
+        };
+
+        actions.push({
+            content: `Enable system proxy for ${agentCount} ${agentWord}`,
+            onAction: bulkToggleSystemProxy(true),
+        });
+        actions.push({
+            content: `Disable system proxy for ${agentCount} ${agentWord}`,
+            onAction: bulkToggleSystemProxy(false),
+        });
+
         return actions;
+    };
+
+    // Delete lives in the overflow ("...") menu rather than alongside the promoted actions above —
+    // Polaris recommends at most 2 promoted actions at once, and Delete is the akto.io-only,
+    // destructive one, so it doesn't need the same prominence as Enable/Disable.
+    const bulkActions = (selectedAgents) => {
+        if (!allowBulkActions) return [];
+        const agentCount = selectedAgents.length;
+        return [{
+            content: `Delete ${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"}`,
+            onAction: async () => {
+                const msg = `Are you sure you want to delete ${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"}?`;
+                func.showConfirmationModal(msg, "Delete", async () => {
+                    try {
+                        await settingRequests.deleteModuleInfo(selectedAgents);
+                        func.setToast(true, false, `${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"} deleted successfully`);
+                        window.location.reload();
+                    } catch (error) {
+                        console.error("Error deleting agent info:", error);
+                        func.setToast(true, true, "Failed to delete agent info");
+                    }
+                });
+            },
+        }];
     };
 
     const handleRowClick = useCallback((agent) => {
@@ -363,8 +400,9 @@ function EndpointShieldMetadata() {
                         headings={headings}
                         onRowClick={handleRowClick}
                         rowClickable={true}
-                        selectable={allowBulkActions}
+                        selectable={true}
                         promotedBulkActions={promotedBulkActions}
+                        bulkActions={bulkActions}
                     />
                 ]}
             />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/observe/atlas/EndpointShieldMetadata.jsx
@@ -324,31 +324,25 @@ function EndpointShieldMetadata() {
             onAction: bulkToggleSystemProxy(false),
         });
 
+        if (allowBulkActions) {
+            actions.push({
+                content: `Delete ${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"}`,
+                onAction: async () => {
+                    const msg = `Are you sure you want to delete ${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"}?`;
+                    func.showConfirmationModal(msg, "Delete", async () => {
+                        try {
+                            await settingRequests.deleteModuleInfo(selectedAgents);
+                            func.setToast(true, false, `${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"} deleted successfully`);
+                            window.location.reload();
+                        } catch (error) {
+                            console.error("Error deleting agent info:", error);
+                            func.setToast(true, true, "Failed to delete agent info");
+                        }
+                    });
+                },
+            });
+        }
         return actions;
-    };
-
-    // Delete lives in the overflow ("...") menu rather than alongside the promoted actions above —
-    // Polaris recommends at most 2 promoted actions at once, and Delete is the akto.io-only,
-    // destructive one, so it doesn't need the same prominence as Enable/Disable.
-    const bulkActions = (selectedAgents) => {
-        if (!allowBulkActions) return [];
-        const agentCount = selectedAgents.length;
-        return [{
-            content: `Delete ${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"}`,
-            onAction: async () => {
-                const msg = `Are you sure you want to delete ${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"}?`;
-                func.showConfirmationModal(msg, "Delete", async () => {
-                    try {
-                        await settingRequests.deleteModuleInfo(selectedAgents);
-                        func.setToast(true, false, `${agentCount} agent info entr${agentCount > 1 ? "ies" : "y"} deleted successfully`);
-                        window.location.reload();
-                    } catch (error) {
-                        console.error("Error deleting agent info:", error);
-                        func.setToast(true, true, "Failed to delete agent info");
-                    }
-                });
-            },
-        }];
     };
 
     const handleRowClick = useCallback((agent) => {
@@ -402,7 +396,6 @@ function EndpointShieldMetadata() {
                         rowClickable={true}
                         selectable={true}
                         promotedBulkActions={promotedBulkActions}
-                        bulkActions={bulkActions}
                     />
                 ]}
             />

--- a/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
+++ b/apps/dashboard/web/polaris_web/web/src/apps/dashboard/pages/settings/api.js
@@ -1132,6 +1132,15 @@ const settingRequests = {
             data: {moduleId, moduleName, envData}
         })
     },
+    // Bulk counterpart for the Endpoint Shield table's multi-select (e.g. enabling/disabling
+    // system proxy for several agents at once) — same envData shape as updateModuleEnvAndReboot.
+    bulkUpdateModuleEnvAndReboot(moduleIds, envData) {
+        return request({
+            url: '/api/bulkUpdateModuleEnvAndReboot',
+            method: 'post',
+            data: {moduleIds, envData}
+        })
+    },
     fetchFilterYamlTemplate() {
         return request({
             url: '/api/fetchFilterYamlTemplate',


### PR DESCRIPTION
## Summary
- Adds multi-select bulk actions to the Endpoint Shield table so several agents can have system proxy enabled/disabled at once, instead of one at a time under each agent's Configure tab.
- Backend: extracted the existing `updateModuleEnvAndReboot`'s env-update logic into a shared `buildEnvUpdates()` helper, and added `bulkUpdateModuleEnvAndReboot()` — reuses the *existing* `moduleIds`/`envData` fields on `ModuleInfoAction` (already used by `deleteModuleInfo`/`rebootModules`) with a single `Filters.in(...)` + `updateMany` instead of looping per id. New struts.xml action, same `ADMIN_ACTIONS`/`READ_WRITE` gate as the single-item endpoint.
- Frontend: row-selection checkboxes on the Endpoint Shield table are no longer restricted to `@akto.io` users — toggling system proxy is reversible (unlike the existing Delete action), and the backend still enforces `ADMIN_ACTIONS` regardless of what the UI shows. Added "Enable/Disable system proxy for N agents" as promoted bulk actions with a confirmation modal, matching the existing Delete action's UX.

Kept intentionally minimal — only touches `ModuleInfoAction.java`, its struts.xml entry, the `settings/api.js` wrapper, and `EndpointShieldMetadata.jsx` itself. (An earlier version of this PR also modified the shared `GithubServerTable.js` to move Delete into an overflow menu, purely to silence a cosmetic Polaris dev-console warning about having 3 promoted bulk actions at once for `@akto.io` users — reverted since that's not worth widening a component used across most of the dashboard for a devtools-only warning with no functional impact.)

## Test plan
- [x] Backend compiles clean (`mvn compile`), frontend builds clean (webpack).
- [x] Verified live: selected an agent, clicked "Enable system proxy for 1 agent", confirmed the modal, confirmed the exact `{moduleIds: [...], envData: {ENABLE_SYSTEM_PROXY: "true"}}` request fired and returned 200.
- [x] Confirmed the DB write directly in Mongo: `additionalData.env.ENABLE_SYSTEM_PROXY` set to `"true"` and `reboot: true` on the selected agent's `module_info` document.
- [x] Confirmed non-`@akto.io` users see only the two system-proxy actions (Delete hidden entirely, same as before).
- [x] Confirmed `GithubServerTable.js` is untouched (verified via `git diff` against the base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)