### PR TITLE
fix: return full ValidationResult verdict from /validate/file

### DIFF
--- a/apps/guardrails-service/container/README.md
+++ b/apps/guardrails-service/container/README.md
@@ -128,7 +128,15 @@ curl -X POST http://localhost:8080/api/validate/file \
   -F "contextSource=AGENTIC"
 ```
 
-Response includes `allowed` and, when blocked, `reason`.
+The response uses the same `ValidationResult` shape as `/validate/request` and `/validate/response`: `allowed`, and on a block the `reason` and `behaviour` that stopped the upload (the verdict from the failing chunk). `modifiedPayload` is always empty — this endpoint enforces by blocking and never returns rewritten file content.
+
+```json
+{
+  "allowed": false,
+  "reason": "file contains sensitive content redacted by guardrail policy (mask)",
+  "behaviour": "mask"
+}
+```
 
 This endpoint never rejects a request: it always answers `200` with a verdict, and `allowed: false` only ever comes from a guardrail policy (including redaction, when `FILE_VALIDATE_BLOCK_ON_REDACTION` is on). Everything that stops content from being inspected fails open and is logged with a `skipReason`:
 

--- a/apps/guardrails-service/container/src/handlers/file_validation.go
+++ b/apps/guardrails-service/container/src/handlers/file_validation.go
@@ -56,18 +56,18 @@ func (h *ValidationHandler) ValidateFile(c *gin.Context) {
 		if p := recover(); p != nil {
 			h.logger.Error("File validation panicked; allowing file", zap.Any("panic", p))
 			if !c.Writer.Written() {
-				c.JSON(http.StatusOK, gin.H{"allowed": true})
+				allowFile(c)
 			}
 		}
 	}()
 	if h.cfg == nil {
 		h.logger.Error("File validation config is nil; allowing file")
-		c.JSON(http.StatusOK, gin.H{"allowed": true})
+		allowFile(c)
 		return
 	}
 
 	if !h.cfg.File.Enabled {
-		c.JSON(http.StatusOK, gin.H{"allowed": true})
+		allowFile(c)
 		return
 	}
 
@@ -81,7 +81,7 @@ func (h *ValidationHandler) ValidateFile(c *gin.Context) {
 	if formErr != nil {
 		h.logger.Warn("Failed to parse file inputs; allowing request",
 			zap.String("skipReason", "multipart-parse-failed"), zap.Error(formErr))
-		c.JSON(http.StatusOK, gin.H{"allowed": true})
+		allowFile(c)
 		return
 	}
 
@@ -103,7 +103,7 @@ func (h *ValidationHandler) ValidateFile(c *gin.Context) {
 			h.logger.Info("ValidateFile - no applicable policies; allowing without inspection",
 				zap.String("contextSource", contextSource),
 				zap.String("sessionID", sessionID))
-			c.JSON(http.StatusOK, gin.H{"allowed": true})
+			allowFile(c)
 			return
 		}
 	}
@@ -113,7 +113,7 @@ func (h *ValidationHandler) ValidateFile(c *gin.Context) {
 	if len(inputs) == 0 {
 		h.logger.Warn("No file inputs to inspect; allowing request",
 			zap.String("skipReason", "no-inputs"), zap.String("sessionID", sessionID))
-		c.JSON(http.StatusOK, gin.H{"allowed": true})
+		allowFile(c)
 		return
 	}
 
@@ -544,25 +544,35 @@ func (h *ValidationHandler) validateWithRetry(ctx context.Context, payload strin
 }
 
 func (h *ValidationHandler) writeMultiFileResponse(c *gin.Context, results []*fileResult) {
-	overallAllowed := true
-	var overallReason string
+	c.JSON(http.StatusOK, fileVerdict(results))
+}
 
+// fileVerdict collapses the per-file results into a single mcp.ValidationResult so the
+// file endpoint answers in the same shape as /validate/request and /validate/response:
+// `Allowed` plus, on a block, the `Reason` and `behaviour` that stopped the upload. The
+// first blocked file wins (evaluation already stops at it). ModifiedPayload is always
+// left empty — this endpoint enforces by blocking and never returns rewritten file
+// content (see chunkStopsFile).
+func fileVerdict(results []*fileResult) *mcp.ValidationResult {
 	for _, fr := range results {
-		if !fr.Allowed {
-			overallAllowed = false
-			overallReason = fr.Reason
-			break
+		if fr.Allowed {
+			continue
 		}
+		verdict := &mcp.ValidationResult{Allowed: false, Reason: fr.Reason}
+		if fr.FailedResult != nil {
+			verdict.Behaviour = fr.FailedResult.Behaviour
+			verdict.Modified = fr.FailedResult.Modified
+			verdict.Metadata = fr.FailedResult.Metadata
+		}
+		return verdict
 	}
+	return &mcp.ValidationResult{Allowed: true}
+}
 
-	resp := gin.H{
-		"allowed": overallAllowed,
-	}
-	if !overallAllowed {
-		resp["reason"] = overallReason
-	}
-
-	c.JSON(http.StatusOK, resp)
+// allowFile writes the fail-open verdict shared by every path that cannot (or need not)
+// inspect content, in the same mcp.ValidationResult shape as a validated allow.
+func allowFile(c *gin.Context) {
+	c.JSON(http.StatusOK, &mcp.ValidationResult{Allowed: true})
 }
 
 func marshalPromptPayload(content string) string {

--- a/apps/guardrails-service/container/src/handlers/file_validation_test.go
+++ b/apps/guardrails-service/container/src/handlers/file_validation_test.go
@@ -112,6 +112,57 @@ func TestValidateFileInspectionFailures(t *testing.T) {
 	})
 }
 
+// The blocked-file response must match the /validate/request shape: Allowed=false plus the
+// Reason (and behaviour) that stopped the upload, so a caller sees why the file was rejected.
+func TestWriteMultiFileResponseVerdict(t *testing.T) {
+	h := &ValidationHandler{logger: zap.NewNop()}
+
+	t.Run("allow carries no reason or behaviour", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		h.writeMultiFileResponse(c, []*fileResult{{Filename: "a.txt", Allowed: true}})
+
+		var resp mcp.ValidationResult
+		if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		if !resp.Allowed || resp.Reason != "" || resp.Behaviour != "" {
+			t.Fatalf("unexpected allow verdict: %s", recorder.Body.String())
+		}
+	})
+
+	t.Run("block carries reason and behaviour from the failing chunk", func(t *testing.T) {
+		blocked := &fileResult{
+			Filename:     "b.txt",
+			Allowed:      false,
+			Reason:       "file contains sensitive content redacted by guardrail policy (mask)",
+			FailedResult: &mcp.ValidationResult{Allowed: true, Modified: true, Behaviour: "mask", ModifiedPayload: "secret"},
+		}
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		// The first blocked file wins even when an allowed file precedes it.
+		h.writeMultiFileResponse(c, []*fileResult{{Allowed: true}, blocked})
+
+		var resp mcp.ValidationResult
+		if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		if resp.Allowed {
+			t.Fatalf("blocked file must not be allowed: %s", recorder.Body.String())
+		}
+		if resp.Reason != blocked.Reason {
+			t.Fatalf("reason = %q, want %q", resp.Reason, blocked.Reason)
+		}
+		if resp.Behaviour != "mask" {
+			t.Fatalf("behaviour = %q, want mask", resp.Behaviour)
+		}
+		// The endpoint enforces by blocking and must never leak the rewritten content.
+		if resp.ModifiedPayload != "" {
+			t.Fatalf("modifiedPayload must be empty, got %q", resp.ModifiedPayload)
+		}
+	})
+}
+
 func TestFileChunkFailuresDoNotHidePolicyBlocks(t *testing.T) {
 	for _, tc := range []struct {
 		name       string


### PR DESCRIPTION
Align the file validation response with /validate/request and /validate/response: emit an mcp.ValidationResult carrying allowed plus, on a block, the reason and behaviour from the failing chunk (modifiedPayload stays empty; the endpoint enforces by blocking and never returns rewritten content). Route all fail-open paths through a shared allowFile helper so the whole endpoint answers in one consistent shape.